### PR TITLE
minor fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "defguard_wireguard_rs"
@@ -1298,7 +1298,6 @@ dependencies = [
  "quinn",
  "rand 0.8.5",
  "rcgen",
- "regex",
  "reqwest",
  "ring 0.17.8",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
-members = ["easytier",  "easytier-gui/src-tauri"]
-default-members = [ "easytier" ]
+members = ["easytier", "easytier-gui/src-tauri"]
+default-members = ["easytier"]
 
 [profile.dev]
 panic = "unwind"

--- a/easytier/Cargo.toml
+++ b/easytier/Cargo.toml
@@ -58,8 +58,6 @@ async-trait = "0.1.74"
 dashmap = "5.5.3"
 timedmap = "=1.0.1"
 
-regex = "1"
-
 # for full-path zero-copy
 zerocopy = { version = "0.7.32", features = ["derive", "simd"] }
 bytes = "1.5.0"

--- a/easytier/src/common/config.rs
+++ b/easytier/src/common/config.rs
@@ -229,8 +229,11 @@ impl ConfigLoader for TomlConfigLoader {
         match hostname {
             Some(hostname) => {
                 if !hostname.is_empty() {
-                    let re = regex::Regex::new(r"[^\u4E00-\u9FA5a-zA-Z0-9\-]*").unwrap();
-                    let mut name = re.replace_all(&hostname, "").to_string();
+                    let mut name = hostname
+                        .chars()
+                        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+                        .take(32)
+                        .collect::<String>();
 
                     if name.len() > 32 {
                         name = name.chars().take(32).collect::<String>();

--- a/easytier/src/peer_center/instance.rs
+++ b/easytier/src/peer_center/instance.rs
@@ -196,6 +196,17 @@ impl PeerCenterInstance {
                 let mut rpc_ctx = tarpc::context::current();
                 rpc_ctx.deadline = SystemTime::now() + Duration::from_secs(3);
 
+                if ctx
+                    .job_ctx
+                    .global_peer_map_update_time
+                    .load()
+                    .elapsed()
+                    .as_secs()
+                    > 60
+                {
+                    ctx.job_ctx.global_peer_map_digest.store(Digest::default());
+                }
+
                 let ret = client
                     .get_global_peer_map(rpc_ctx, ctx.job_ctx.global_peer_map_digest.load())
                     .await?;

--- a/easytier/src/peers/peer_ospf_route.rs
+++ b/easytier/src/peers/peer_ospf_route.rs
@@ -537,6 +537,10 @@ impl RouteTable {
             self.peer_infos.insert(*peer_id, info.clone());
         }
 
+        if self.peer_infos.is_empty() {
+            return;
+        }
+
         // build next hop map
         self.next_hop_map.clear();
         self.next_hop_map.insert(my_peer_id, (my_peer_id, 0));

--- a/easytier/src/tunnel/packet_def.rs
+++ b/easytier/src/tunnel/packet_def.rs
@@ -60,6 +60,8 @@ bitflags::bitflags! {
     struct PeerManagerHeaderFlags: u8 {
         const ENCRYPTED = 0b0000_0001;
         const LATENCY_FIRST = 0b0000_0010;
+
+        const _ = !0;
     }
 }
 


### PR DESCRIPTION
  1. fix ospf route panic if no ipv4 assigned.
  2. should refetch global peer latency map every 60s
  3. remove regex dep because it's too large and unnecessary.