### PR TITLE
only upx on linux

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -121,7 +121,7 @@ jobs:
             TAG=$GITHUB_SHA
           fi
 
-          if [[ ! $OS =~ ^macos.*$ ]]; then
+          if [[ $OS =~ ^ubuntu.*$ ]]; then
             upx --lzma --best ./target/$TARGET/release/easytier-core"$SUFFIX"
             upx --lzma --best ./target/$TARGET/release/easytier-cli"$SUFFIX"
           fi


### PR DESCRIPTION
- **only upx on linux**

upx with --lzma or --best failed to run on win10 & win7
upx -9 on win 10 will be isolated by win defender
