### PR TITLE
support change tun interface name

### DIFF
--- a/easytier/src/common/config.rs
+++ b/easytier/src/common/config.rs
@@ -150,6 +150,8 @@ pub struct VpnPortalConfig {
 pub struct Flags {
     #[derivative(Default(value = "\"tcp\".to_string()"))]
     pub default_protocol: String,
+    #[derivative(Default(value = "\"tun\".to_string()"))]
+    pub dev_name: String,
     #[derivative(Default(value = "true"))]
     pub enable_encryption: bool,
     #[derivative(Default(value = "true"))]

--- a/easytier/src/easytier-core.rs
+++ b/easytier/src/easytier-core.rs
@@ -172,6 +172,9 @@ and the vpn client is in network of 10.14.14.0/24"
     #[arg(long, help = "do not use ipv6", default_value = "false")]
     disable_ipv6: bool,
 
+    #[arg(long, help = "interface name", default_value = "tun")]
+    dev_name: String,
+
     #[arg(
         long,
         help = "mtu of the TUN device, default is 1420 for non-encryption, 1400 for encryption"
@@ -424,6 +427,7 @@ impl From<Cli> for TomlConfigLoader {
         f.enable_encryption = !cli.disable_encryption;
         f.enable_ipv6 = !cli.disable_ipv6;
         f.latency_first = cli.latency_first;
+        f.dev_name = cli.dev_name;
         if let Some(mtu) = cli.mtu {
             f.mtu = mtu;
         }

--- a/easytier/src/instance/virtual_nic.rs
+++ b/easytier/src/instance/virtual_nic.rs
@@ -273,6 +273,8 @@ impl VirtualNic {
 
         #[cfg(target_os = "linux")]
         {
+            let dev_name = self.global_ctx.get_flags().dev_name;
+            config.name(format!("{}{}", dev_name, 0));
             config.platform(|config| {
                 // detect protocol by ourselves for cross platform
                 config.packet_information(false);


### PR DESCRIPTION

The "tun0" interface is too common, leading to potential conflicts.