### PR TITLE
fix punching task leak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1623,6 +1623,7 @@ dependencies = [
  "derivative",
  "encoding",
  "futures",
+ "futures-util",
  "gethostname 0.5.0",
  "globwalk",
  "http 1.1.0",

--- a/easytier-gui/src-tauri/src/lib.rs
+++ b/easytier-gui/src-tauri/src/lib.rs
@@ -136,7 +136,7 @@ impl NetworkConfig {
         }
 
         cfg.set_rpc_portal(
-            format!("127.0.0.1:{}", self.rpc_port)
+            format!("0.0.0.0:{}", self.rpc_port)
                 .parse()
                 .with_context(|| format!("failed to parse rpc portal port: {}", self.rpc_port))?,
         );

--- a/easytier/Cargo.toml
+++ b/easytier/Cargo.toml
@@ -203,6 +203,7 @@ zip = "0.6.6"
 [dev-dependencies]
 serial_test = "3.0.0"
 rstest = "0.18.2"
+futures-util = "0.3.30"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 defguard_wireguard_rs = "0.4.2"

--- a/easytier/src/common/mod.rs
+++ b/easytier/src/common/mod.rs
@@ -14,6 +14,7 @@ pub mod global_ctx;
 pub mod ifcfg;
 pub mod netns;
 pub mod network;
+pub mod scoped_task;
 pub mod stun;
 pub mod stun_codec_ext;
 

--- a/easytier/src/common/scoped_task.rs
+++ b/easytier/src/common/scoped_task.rs
@@ -1,0 +1,134 @@
+//! This crate provides a wrapper type of Tokio's JoinHandle: `ScopedTask`, which aborts the task when it's dropped.
+//! `ScopedTask` can still be awaited to join the child-task, and abort-on-drop will still trigger while it is being awaited.
+//!
+//! For example, if task A spawned task B but is doing something else, and task B is waiting for task C to join,
+//! aborting A will also abort both B and C.
+
+use std::future::Future;
+use std::ops::Deref;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::task::JoinHandle;
+
+#[derive(Debug)]
+pub struct ScopedTask<T> {
+    inner: JoinHandle<T>,
+}
+
+impl<T> Drop for ScopedTask<T> {
+    fn drop(&mut self) {
+        self.inner.abort()
+    }
+}
+
+impl<T> Future for ScopedTask<T> {
+    type Output = <JoinHandle<T> as Future>::Output;
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.inner).poll(cx)
+    }
+}
+
+impl<T> From<JoinHandle<T>> for ScopedTask<T> {
+    fn from(inner: JoinHandle<T>) -> Self {
+        Self { inner }
+    }
+}
+
+impl<T> Deref for ScopedTask<T> {
+    type Target = JoinHandle<T>;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ScopedTask;
+    use futures_util::future::pending;
+    use std::sync::{Arc, RwLock};
+    use tokio::task::yield_now;
+
+    struct Sentry(Arc<RwLock<bool>>);
+    impl Drop for Sentry {
+        fn drop(&mut self) {
+            *self.0.write().unwrap() = true
+        }
+    }
+
+    #[tokio::test]
+    async fn drop_while_not_waiting_for_join() {
+        let dropped = Arc::new(RwLock::new(false));
+        let sentry = Sentry(dropped.clone());
+        let task = ScopedTask::from(tokio::spawn(async move {
+            let _sentry = sentry;
+            pending::<()>().await
+        }));
+        yield_now().await;
+        assert!(!*dropped.read().unwrap());
+        drop(task);
+        yield_now().await;
+        assert!(*dropped.read().unwrap());
+    }
+
+    #[tokio::test]
+    async fn drop_while_waiting_for_join() {
+        let dropped = Arc::new(RwLock::new(false));
+        let sentry = Sentry(dropped.clone());
+        let handle = tokio::spawn(async move {
+            ScopedTask::from(tokio::spawn(async move {
+                let _sentry = sentry;
+                pending::<()>().await
+            }))
+            .await
+            .unwrap()
+        });
+        yield_now().await;
+        assert!(!*dropped.read().unwrap());
+        handle.abort();
+        yield_now().await;
+        assert!(*dropped.read().unwrap());
+    }
+
+    #[tokio::test]
+    async fn no_drop_only_join() {
+        assert_eq!(
+            ScopedTask::from(tokio::spawn(async {
+                yield_now().await;
+                5
+            }))
+            .await
+            .unwrap(),
+            5
+        )
+    }
+
+    #[tokio::test]
+    async fn manually_abort_before_drop() {
+        let dropped = Arc::new(RwLock::new(false));
+        let sentry = Sentry(dropped.clone());
+        let task = ScopedTask::from(tokio::spawn(async move {
+            let _sentry = sentry;
+            pending::<()>().await
+        }));
+        yield_now().await;
+        assert!(!*dropped.read().unwrap());
+        task.abort();
+        yield_now().await;
+        assert!(*dropped.read().unwrap());
+    }
+
+    #[tokio::test]
+    async fn manually_abort_then_join() {
+        let dropped = Arc::new(RwLock::new(false));
+        let sentry = Sentry(dropped.clone());
+        let task = ScopedTask::from(tokio::spawn(async move {
+            let _sentry = sentry;
+            pending::<()>().await
+        }));
+        yield_now().await;
+        assert!(!*dropped.read().unwrap());
+        task.abort();
+        yield_now().await;
+        assert!(task.await.is_err());
+    }
+}

--- a/easytier/src/easytier-core.rs
+++ b/easytier/src/easytier-core.rs
@@ -340,7 +340,7 @@ impl Cli {
     }
 
     fn check_tcp_available(port: u16) -> Option<SocketAddr> {
-        let s = format!("127.0.0.1:{}", port).parse::<SocketAddr>().unwrap();
+        let s = format!("0.0.0.0:{}", port).parse::<SocketAddr>().unwrap();
         TcpSocket::new_v4().unwrap().bind(s).map(|_| s).ok()
     }
 
@@ -353,9 +353,9 @@ impl Cli {
                         return s;
                     }
                 }
-                return "127.0.0.1:0".parse().unwrap();
+                return "0.0.0.0:0".parse().unwrap();
             }
-            return format!("127.0.0.1:{}", port).parse().unwrap();
+            return format!("0.0.0.0:{}", port).parse().unwrap();
         }
 
         self.rpc_portal.parse().unwrap()

--- a/easytier/src/vpn_portal/wireguard.rs
+++ b/easytier/src/vpn_portal/wireguard.rs
@@ -24,7 +24,7 @@ use crate::{
         mpsc::{MpscTunnel, MpscTunnelSender},
         packet_def::{PacketType, ZCPacket, ZCPacketType},
         wireguard::{WgConfig, WgTunnelListener},
-        Tunnel, TunnelError, TunnelListener,
+        Tunnel, TunnelListener,
     },
 };
 

--- a/script/install.sh
+++ b/script/install.sh
@@ -188,7 +188,7 @@ listeners = [
 ]
 exit_nodes = []
 peer = []
-rpc_portal = "127.0.0.1:15888"
+rpc_portal = "0.0.0.0:15888"
 
 [network_identity]
 network_name = "default"


### PR DESCRIPTION
the punching task creator doesn't check if the task is already
running, and may create many punching task to same peer node.

this patch also improve hole punching by checking hole punch packet
even if punch rpc is failed.
