### PR TITLE
fix compile error due to rust version format

### DIFF
--- a/easytier/Cargo.toml
+++ b/easytier/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 authors = ["kkrainbow"]
 keywords = ["vpn", "p2p", "network", "easytier"]
 categories = ["network-programming", "command-line-utilities"]
-rust-version = "1.77"
+rust-version = "1.77.0"
 license-file = "LICENSE"
 readme = "README.md"
 


### PR DESCRIPTION

## rust install encounter error

command: 
```
cargo install --git https://github.com/EasyTier/EasyTier.git easytier
```

error: 
```
error: the `cargo::` syntax for build script output instructions was added in Rust 1.77.0, but the minimum supported Rust version of `easytier v1.2.3 (/Users/rui/.cargo/git/checkouts/easytier-54d55767af537c07/096ed39/easytier)` is 1.77.
```

## fix method

change `1.77` to `1.77.0` in `easytier/Cargo.toml`