### PR TITLE
add the options to enable latency first or not

### DIFF
--- a/easytier-gui/locales/cn.yml
+++ b/easytier-gui/locales/cn.yml
@@ -50,6 +50,7 @@ on_text: 点击开启
 show_config: 显示配置
 close: 关闭
 
+use_latency_first: 延迟优先模式
 my_node_info: 当前节点信息
 peer_count: 已连接
 upload: 上传

--- a/easytier-gui/locales/en.yml
+++ b/easytier-gui/locales/en.yml
@@ -43,7 +43,7 @@ logging_copy_dir: Copy Log Path
 disable_auto_launch: Disable Launch on Reboot
 enable_auto_launch: Enable Launch on Reboot
 exit: Exit
-
+use_latency_first: Latency First Mode
 chips_placeholder: 'e.g: {0}, press Enter to add'
 hostname_placeholder: 'Leave blank and default to host name: {0}'
 off_text: Press to disable

--- a/easytier-gui/src-tauri/src/lib.rs
+++ b/easytier-gui/src-tauri/src/lib.rs
@@ -7,7 +7,7 @@ use anyhow::Context;
 use dashmap::DashMap;
 use easytier::{
     common::config::{
-        ConfigLoader, FileLoggerConfig, NetworkIdentity, PeerConfig, TomlConfigLoader,
+        ConfigLoader, FileLoggerConfig, Flags, NetworkIdentity, PeerConfig, TomlConfigLoader,
         VpnPortalConfig,
     },
     launcher::{NetworkInstance, NetworkInstanceRunningInfo},
@@ -60,6 +60,7 @@ struct NetworkConfig {
 
     listener_urls: Vec<String>,
     rpc_port: i32,
+    latency_first: bool,
 }
 
 impl NetworkConfig {
@@ -160,7 +161,9 @@ impl NetworkConfig {
                     })?,
             });
         }
-
+        let mut flags = Flags::default();
+        flags.latency_first = self.latency_first;
+        cfg.set_flags(flags);
         Ok(cfg)
     }
 }

--- a/easytier-gui/src/components/Config.vue
+++ b/easytier-gui/src/components/Config.vue
@@ -207,6 +207,15 @@ onMounted(async () => {
           <div class="flex flex-column gap-y-2">
             <div class="flex flex-row gap-x-9 flex-wrap">
               <div class="flex flex-column gap-2 basis-5/12 grow">
+                <div class="flex align-items-center">
+                  <Checkbox v-model="curNetwork.latency_first" input-id="use_latency_first" :binary="true" />
+                  <label for="use_latency_first" class="ml-2"> {{ t('use_latency_first') }} </label>
+                </div>
+              </div>
+            </div>
+
+            <div class="flex flex-row gap-x-9 flex-wrap">
+              <div class="flex flex-column gap-2 basis-5/12 grow">
                 <label for="hostname">{{ t('hostname') }}</label>
                 <InputText
                   id="hostname" v-model="curNetwork.hostname" aria-describedby="hostname-help" :format="true"

--- a/easytier-gui/src/types/network.ts
+++ b/easytier-gui/src/types/network.ts
@@ -31,6 +31,7 @@ export interface NetworkConfig {
 
   listener_urls: string[]
   rpc_port: number
+  latency_first: boolean
 }
 
 export function DEFAULT_NETWORK_CONFIG(): NetworkConfig {
@@ -62,6 +63,7 @@ export function DEFAULT_NETWORK_CONFIG(): NetworkConfig {
       'wg://0.0.0.0:11011',
     ],
     rpc_port: 0,
+    latency_first: true,
   }
 }
 


### PR DESCRIPTION
handle #285 

in the old behavior, the flags is not set, and it will be generated as default value in the first read. so the default value for the latency_first will be set to true according to the Default settings to Flag.

so the Vue code init the latency first to true.