### PR TITLE
Set Category of the TUN device's network profile to 1 in Windows Registry

### DIFF
--- a/easytier/src/common/global_ctx.rs
+++ b/easytier/src/common/global_ctx.rs
@@ -227,6 +227,10 @@ impl GlobalCtx {
         self.config.get_flags()
     }
 
+    pub fn set_flags(&self, flags: Flags) {
+        self.config.set_flags(flags);
+    }
+
     pub fn get_128_key(&self) -> [u8; 16] {
         let mut key = [0u8; 16];
         let secret = self


### PR DESCRIPTION
On Windows, newly added virtual network cards are set to "Public network" by default, causing the Windows built-in firewall to reject all inbound traffic from the virtual network card. Many services, such as Samba, Remote Desktop, Jellyfin are affected by this.

Changing the Category of the TUN device's network profile to 1 in Windows Registry makes it to be "Private network".