### PR TITLE
fix #367, panic because of duplicated peer id

### DIFF
--- a/easytier/src/proto/peer_rpc.proto
+++ b/easytier/src/proto/peer_rpc.proto
@@ -19,6 +19,7 @@ message RoutePeerInfo {
 
   string easytier_version = 10;
   common.PeerFeatureFlag feature_flag = 11;
+  uint64 peer_route_id = 12;
 }
 
 message PeerIdVersion {


### PR DESCRIPTION
introduce my peer route id and peer id is duplicated only when peer
route id is not same.

this problem occurs because update_self may increase my peer info
version and propagate to other nodes.
