### PR TITLE
Fix panic when DNS resolution for STUN server returns only IPv6 addrs.

### DIFF
--- a/easytier/src/common/stun.rs
+++ b/easytier/src/common/stun.rs
@@ -56,6 +56,8 @@ impl HostResolverIter {
                     self.ips = ips
                         .filter(|x| x.is_ipv4())
                         .choose_multiple(&mut rand::thread_rng(), self.max_ip_per_domain as usize);
+                    
+                    if self.ips.is_empty() {return self.next().await;}
                 }
                 Err(e) => {
                     tracing::warn!(?host, ?e, "lookup host for stun failed");


### PR DESCRIPTION
In my network environment, `stunserver.stunprotocol.org` somehow resolved to `[::1]` and caused panic in [`stun.rs:L67`](https://github.com/EasyTier/EasyTier/blob/63821e56bccf12b59e0ddd3173629835e51a0406/easytier/src/common/stun.rs#L67).

This PR fix the panic issue.