### PR TITLE
make the panic message more useful

### DIFF
--- a/easytier/locales/app.yml
+++ b/easytier/locales/app.yml
@@ -120,3 +120,8 @@ core_clap:
   ipv6_listener:
     en: "the url of the ipv6 listener, e.g.: tcp://[::]:11010, if not set, will listen on random udp port"
     zh-CN: "IPv6 监听器的URL，例如：tcp://[::]:11010，如果未设置，将在随机UDP端口上监听"
+
+core_app:
+  panic_backtrace_save:
+    en: "backtrace saved to easytier-panic.log"
+    zh-CN: "回溯信息已保存到easytier-panic.log"

--- a/easytier/src/easytier-cli.rs
+++ b/easytier/src/easytier-cli.rs
@@ -28,6 +28,9 @@ use easytier::{
     tunnel::tcp::TcpTunnelConnector,
     utils::{cost_to_str, float_to_str, PeerRoutePair},
 };
+use humansize::format_size;
+use tabled::settings::Style;
+rust_i18n::i18n!("locales", fallback = "en");
 
 #[derive(Parser, Debug)]
 #[command(name = "easytier-cli", author, version = EASYTIER_VERSION, about, long_about = None)]

--- a/easytier/src/easytier-cli.rs
+++ b/easytier/src/easytier-cli.rs
@@ -28,8 +28,7 @@ use easytier::{
     tunnel::tcp::TcpTunnelConnector,
     utils::{cost_to_str, float_to_str, PeerRoutePair},
 };
-use humansize::format_size;
-use tabled::settings::Style;
+
 rust_i18n::i18n!("locales", fallback = "en");
 
 #[derive(Parser, Debug)]

--- a/easytier/src/lib.rs
+++ b/easytier/src/lib.rs
@@ -19,3 +19,4 @@ pub mod web_client;
 mod tests;
 
 pub const VERSION: &str = common::constants::EASYTIER_VERSION;
+rust_i18n::i18n!("locales", fallback = "en");

--- a/easytier/src/utils.rs
+++ b/easytier/src/utils.rs
@@ -128,7 +128,20 @@ pub fn setup_panic_handler() {
     use std::io::Write;
     std::panic::set_hook(Box::new(|info| {
         let backtrace = backtrace::Backtrace::force_capture();
-        println!("panic occurred: {:?}, backtrace: {:#?}", info, backtrace);
+        let payload = info.payload();
+        let payload_str: Option<&str> = if let Some(s) = payload.downcast_ref::<&str>() {
+            Some(s)
+        } else if let Some(s) = payload.downcast_ref::<String>() {
+            Some(s)
+        } else {
+            None
+        };
+
+        if let Some(payload_str) = payload_str {
+            println!("panic occurred: {}", payload_str);
+        } else {
+            println!("panic occurred");
+        }
         let _ = std::fs::File::create("easytier-panic.log")
             .and_then(|mut f| f.write_all(format!("{:?}\n{:#?}", info, backtrace).as_bytes()));
         std::process::exit(1);

--- a/easytier/src/utils.rs
+++ b/easytier/src/utils.rs
@@ -138,11 +138,15 @@ pub fn setup_panic_handler() {
         };
 
         if let Some(payload_str) = payload_str {
-            println!("panic occurred: payload:{}, location: {:?}", payload_str, info.location());
+            println!(
+                "panic occurred: payload:{}, location: {:?}",
+                payload_str,
+                info.location()
+            );
         } else {
             println!("panic occurred: location: {:?}", info.location());
         }
-        println!("backtrace saved to easytier-panic.log");
+        println!("{}", rust_i18n::t!("core_app.panic_backtrace_save"));
         let _ = std::fs::File::create("easytier-panic.log")
             .and_then(|mut f| f.write_all(format!("{:?}\n{:#?}", info, backtrace).as_bytes()));
         std::process::exit(1);

--- a/easytier/src/utils.rs
+++ b/easytier/src/utils.rs
@@ -138,10 +138,11 @@ pub fn setup_panic_handler() {
         };
 
         if let Some(payload_str) = payload_str {
-            println!("panic occurred: {}", payload_str);
+            println!("panic occurred: payload:{}, location: {:?}", payload_str, info.location());
         } else {
-            println!("panic occurred");
+            println!("panic occurred: location: {:?}", info.location());
         }
+        println!("backtrace saved to easytier-panic.log");
         let _ = std::fs::File::create("easytier-panic.log")
             .and_then(|mut f| f.write_all(format!("{:?}\n{:#?}", info, backtrace).as_bytes()));
         std::process::exit(1);


### PR DESCRIPTION
when panic happend, previouse panic info:
panic occurred: PanicHookInfo { payload: **Any { .. },** location: Location { file: "easytier/src/easytier-core.rs", line: 680, col: 9 }, can_unwind: true, force_no_backtrace: false }

the new panic info:

panic occurred: payload:launcher error: "anyhow error: failed to add listener tcp://0.0.0.0:11010", location: Some(Location { file: "easytier/src/easytier-core.rs", line: 680, col: 9 })
backtrace saved to easytier-panic.log