### PR TITLE
fix peer rpc compatibility issue

### DIFF
--- a/easytier/src/proto/rpc_impl/packet.rs
+++ b/easytier/src/proto/rpc_impl/packet.rs
@@ -159,7 +159,10 @@ pub fn build_rpc_packet(
         let cur_packet = RpcPacket {
             from_peer,
             to_peer,
-            descriptor: if cur_offset == 0 {
+            descriptor: if cur_offset == 0
+                || compression_info.algo == CompressionAlgoPb::None as i32
+            {
+                // old version must have descriptor on every piece
                 Some(rpc_desc.clone())
             } else {
                 None


### PR DESCRIPTION
every rpc packet should contains descriptor if sent to old version et.
