### PR TITLE
fix bugs

### DIFF
--- a/easytier/src/connector/manual.rs
+++ b/easytier/src/connector/manual.rs
@@ -297,12 +297,14 @@ impl ManualConnectorManager {
 
         connector.lock().await.set_ip_version(ip_version);
 
-        set_bind_addr_for_peer_connector(
-            connector.lock().await.as_mut(),
-            ip_version == IpVersion::V4,
-            &ip_collector,
-        )
-        .await;
+        if data.global_ctx.config.get_flags().bind_device {
+            set_bind_addr_for_peer_connector(
+                connector.lock().await.as_mut(),
+                ip_version == IpVersion::V4,
+                &ip_collector,
+            )
+            .await;
+        }
 
         data.global_ctx.issue_event(GlobalCtxEvent::Connecting(
             connector.lock().await.remote_url().clone(),

--- a/easytier/src/peers/peer_ospf_route.rs
+++ b/easytier/src/peers/peer_ospf_route.rs
@@ -1739,7 +1739,6 @@ impl RouteSessionManager {
                         continue;
                     }
                     let _ = self.stop_session(*peer_id);
-                    assert_ne!(Some(*peer_id), cur_dst_peer_id_to_initiate);
                 }
             }
 


### PR DESCRIPTION
1. if peers disconnected before stop session, may crash at the assert.
2. bind_device flag should take effect on manual connector.
