### PR TITLE
forward original peer info in ospf route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,6 +671,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,7 +699,7 @@ dependencies = [
  "bitflags 2.8.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -1917,6 +1923,8 @@ dependencies = [
  "pnet",
  "prost",
  "prost-build",
+ "prost-reflect",
+ "prost-reflect-build",
  "prost-types",
  "quinn",
  "rand 0.8.5",
@@ -3710,6 +3718,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "logos"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7251356ef8cb7aec833ddf598c6cb24d17b689d20b993f9d11a3d764e34e6458"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59f80069600c0d66734f5ff52cc42f2dabd6b29d205f333d61fd7832e9e9963f"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax 0.8.4",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24fb722b06a9dc12adb0963ed585f19fc61dc5413e6a9be9422ef92c091e731d"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "loom"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4580,6 +4621,15 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
 version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
@@ -5340,7 +5390,7 @@ checksum = "f8650aabb6c35b860610e9cff5dc1af886c9e25073b7b1712a68972af4281302"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -5360,7 +5410,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e92b959d24e05a3e2da1d0beb55b48bc8a97059b8336ea617780bd6addbbfb5a"
+dependencies = [
+ "base64 0.22.1",
+ "logos",
+ "once_cell",
+ "prost",
+ "prost-reflect-derive",
+ "prost-types",
+ "serde",
+ "serde-value",
+]
+
+[[package]]
+name = "prost-reflect-build"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e2537231d94dd2778920c2ada37dd9eb1ac0325bb3ee3ee651bd44c1134123"
+dependencies = [
+ "prost-build",
+ "prost-reflect",
+]
+
+[[package]]
+name = "prost-reflect-derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fce6b22f15cc8d8d400a2b98ad29202b33bd56c7d9ddd815bc803a807ecb65"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -6311,7 +6398,7 @@ dependencies = [
  "bigdecimal",
  "chrono",
  "inherent",
- "ordered-float",
+ "ordered-float 3.9.2",
  "rust_decimal",
  "sea-query-derive",
  "serde_json",
@@ -6449,6 +6536,16 @@ dependencies = [
  "erased-serde",
  "serde",
  "typeid",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float 2.10.1",
+ "serde",
 ]
 
 [[package]]

--- a/easytier/Cargo.toml
+++ b/easytier/Cargo.toml
@@ -188,6 +188,12 @@ async-compression = { version = "0.4.17", default-features = false, features = [
 
 kcp-sys = { git = "https://github.com/EasyTier/kcp-sys" }
 
+prost-reflect = { version = "0.14.5", features = [
+    "serde",
+    "derive",
+    "text-format"
+] }
+
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows", target_os = "freebsd"))'.dependencies]
 machine-uid = "0.5.3"
 
@@ -208,6 +214,7 @@ globwalk = "0.8.1"
 regex = "1"
 prost-build = "0.13.2"
 rpc_build = { package = "easytier-rpc-build", version = "0.1.0", features = ["internal-namespace"] }
+prost-reflect-build = { version = "0.14.0" }
 
 [target.'cfg(windows)'.build-dependencies]
 reqwest = { version = "0.11", features = ["blocking"] }

--- a/easytier/src/connector/udp_hole_punch/sym_to_cone.rs
+++ b/easytier/src/connector/udp_hole_punch/sym_to_cone.rs
@@ -284,6 +284,7 @@ impl PunchSymToConeHoleClient {
                 BaseController {
                     timeout_ms: 4000,
                     trace_id: 0,
+                    ..Default::default()
                 },
                 req,
             )
@@ -314,6 +315,7 @@ impl PunchSymToConeHoleClient {
                 BaseController {
                     timeout_ms: 4000,
                     trace_id: 0,
+                    ..Default::default()
                 },
                 req,
             )

--- a/easytier/src/peers/peer_conn_ping.rs
+++ b/easytier/src/peers/peer_conn_ping.rs
@@ -1,5 +1,4 @@
 use std::{
-    fmt::Debug,
     sync::{
         atomic::{AtomicU32, Ordering},
         Arc,

--- a/easytier/src/proto/mod.rs
+++ b/easytier/src/proto/mod.rs
@@ -9,3 +9,6 @@ pub mod web;
 
 #[cfg(test)]
 pub mod tests;
+
+const DESCRIPTOR_POOL_BYTES: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/file_descriptor_set.bin"));

--- a/easytier/src/proto/rpc_types/controller.rs
+++ b/easytier/src/proto/rpc_types/controller.rs
@@ -1,4 +1,9 @@
-pub trait Controller: Send + Sync + 'static {
+use std::sync::{Arc, Mutex};
+
+use bytes::Bytes;
+
+// Controller must impl clone and all cloned controllers share the same data
+pub trait Controller: Send + Sync + Clone + 'static {
     fn timeout_ms(&self) -> i32 {
         5000
     }
@@ -10,12 +15,29 @@ pub trait Controller: Send + Sync + 'static {
     fn trace_id(&self) -> i32 {
         0
     }
+
+    fn set_raw_input(&mut self, _raw_input: Bytes) {}
+    fn get_raw_input(&self) -> Option<Bytes> {
+        None
+    }
+
+    fn set_raw_output(&mut self, _raw_output: Bytes) {}
+    fn get_raw_output(&self) -> Option<Bytes> {
+        None
+    }
 }
 
 #[derive(Debug)]
+pub struct BaseControllerRawData {
+    pub raw_input: Option<Bytes>,
+    pub raw_output: Option<Bytes>,
+}
+
+#[derive(Debug, Clone)]
 pub struct BaseController {
     pub timeout_ms: i32,
     pub trace_id: i32,
+    pub raw_data: Arc<Mutex<BaseControllerRawData>>,
 }
 
 impl Controller for BaseController {
@@ -34,6 +56,22 @@ impl Controller for BaseController {
     fn trace_id(&self) -> i32 {
         self.trace_id
     }
+
+    fn set_raw_input(&mut self, raw_input: Bytes) {
+        self.raw_data.lock().unwrap().raw_input = Some(raw_input);
+    }
+
+    fn get_raw_input(&self) -> Option<Bytes> {
+        self.raw_data.lock().unwrap().raw_input.clone()
+    }
+
+    fn set_raw_output(&mut self, raw_output: Bytes) {
+        self.raw_data.lock().unwrap().raw_output = Some(raw_output);
+    }
+
+    fn get_raw_output(&self) -> Option<Bytes> {
+        self.raw_data.lock().unwrap().raw_output.clone()
+    }
 }
 
 impl Default for BaseController {
@@ -41,6 +79,10 @@ impl Default for BaseController {
         Self {
             timeout_ms: 5000,
             trace_id: 0,
+            raw_data: Arc::new(Mutex::new(BaseControllerRawData {
+                raw_input: None,
+                raw_output: None,
+            })),
         }
     }
 }


### PR DESCRIPTION
prost doesn't support unknown field, and these info may be lost when
they go through a old version node.
