### PR TITLE
allow proxy packets to be forwarded by system kernel

### DIFF
--- a/easytier/locales/app.yml
+++ b/easytier/locales/app.yml
@@ -96,6 +96,9 @@ core_clap:
   enable_exit_node:
     en: "allow this node to be an exit node"
     zh-CN: "允许此节点成为出口节点"
+  proxy_forward_by_system:
+    en: "forward packet to proxy networks via system kernel, disable internal nat for network proxy"
+    zh-CN: "通过系统内核转发子网代理数据包，禁用内置NAT"
   no_tun:
     en: "do not create TUN device, can use subnet proxy to access node"
     zh-CN: "不创建TUN设备，可以使用子网代理访问节点"

--- a/easytier/src/common/config.rs
+++ b/easytier/src/common/config.rs
@@ -20,6 +20,7 @@ pub fn gen_default_flags() -> Flags {
         mtu: 1380,
         latency_first: false,
         enable_exit_node: false,
+        proxy_forward_by_system: false,
         no_tun: false,
         use_smoltcp: false,
         relay_network_whitelist: "*".to_string(),

--- a/easytier/src/common/global_ctx.rs
+++ b/easytier/src/common/global_ctx.rs
@@ -68,6 +68,7 @@ pub struct GlobalCtx {
     running_listeners: Mutex<Vec<url::Url>>,
 
     enable_exit_node: bool,
+    proxy_forward_by_system: bool,
     no_tun: bool,
 
     feature_flags: AtomicCell<PeerFeatureFlag>,
@@ -99,6 +100,7 @@ impl GlobalCtx {
         let stun_info_collection = Arc::new(StunInfoCollector::new_with_default_servers());
 
         let enable_exit_node = config_fs.get_flags().enable_exit_node;
+        let proxy_forward_by_system = config_fs.get_flags().proxy_forward_by_system;
         let no_tun = config_fs.get_flags().no_tun;
 
         let mut feature_flags = PeerFeatureFlag::default();
@@ -125,6 +127,7 @@ impl GlobalCtx {
             running_listeners: Mutex::new(Vec::new()),
 
             enable_exit_node,
+            proxy_forward_by_system,
             no_tun,
 
             feature_flags: AtomicCell::new(feature_flags),
@@ -271,6 +274,10 @@ impl GlobalCtx {
 
     pub fn enable_exit_node(&self) -> bool {
         self.enable_exit_node
+    }
+
+    pub fn proxy_forward_by_system(&self) -> bool {
+        self.proxy_forward_by_system
     }
 
     pub fn no_tun(&self) -> bool {

--- a/easytier/src/easytier-core.rs
+++ b/easytier/src/easytier-core.rs
@@ -243,6 +243,13 @@ struct Cli {
 
     #[arg(
         long,
+        help = t!("core_clap.proxy_forward_by_system").to_string(),
+        default_value = "false"
+    )]
+    proxy_forward_by_system: bool,
+
+    #[arg(
+        long,
         help = t!("core_clap.no_tun").to_string(),
         default_value = "false"
     )]
@@ -561,6 +568,7 @@ impl TryFrom<&Cli> for TomlConfigLoader {
             f.mtu = mtu as u32;
         }
         f.enable_exit_node = cli.enable_exit_node;
+        f.proxy_forward_by_system = cli.proxy_forward_by_system;
         f.no_tun = cli.no_tun || cfg!(not(feature = "tun"));
         f.use_smoltcp = cli.use_smoltcp;
         if let Some(wl) = cli.relay_network_whitelist.as_ref() {

--- a/easytier/src/instance/instance.rs
+++ b/easytier/src/instance/instance.rs
@@ -65,7 +65,9 @@ impl IpProxy {
     }
 
     async fn start(&self) -> Result<(), Error> {
-        if (self.global_ctx.get_proxy_cidrs().is_empty() || self.started.load(Ordering::Relaxed))
+        if (self.global_ctx.get_proxy_cidrs().is_empty()
+            || self.global_ctx.proxy_forward_by_system()
+            || self.started.load(Ordering::Relaxed))
             && !self.global_ctx.enable_exit_node()
             && !self.global_ctx.no_tun()
         {

--- a/easytier/src/proto/common.proto
+++ b/easytier/src/proto/common.proto
@@ -29,6 +29,7 @@ message FlagsInConfig {
   bool disable_kcp_input = 19;
   // allow relay kcp packets (for public server, this can reduce the throughput)
   bool disable_relay_kcp = 20;
+  bool proxy_forward_by_system = 21;
 }
 
 message RpcDescriptor {


### PR DESCRIPTION
In the current implementation of the proxy network feature, an internal NAT is used to enable non-gateway devices to participate in point-to-network networking, which is a fantastic functionality. However, for gateway devices, NAT is unnecessary, and its use can prevent accurate tracing of packets back to their source.

Therefore, in this PR, the `--proxy-forward-by-system` option has been added to directly deliver proxy network packets to the NIC device, allowing the system kernel to handle the packets forwarding. Additionally, delegating NAT to the system kernel instead of performing it in user space may offer some performance improvements (unverified).