### PR TITLE
improve http connector

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,6 @@ jobs:
 
       - name: Run tests
         run: |
-          sudo -E env "PATH=$PATH" cargo test --no-default-features --features=full --verbose
+          sudo -E env "PATH=$PATH" cargo test --no-default-features --features=full --verbose -- --test-threads=1 --nocapture
           sudo chown -R $USER:$USER ./target
           sudo chown -R $USER:$USER ~/.cargo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3139,9 +3139,10 @@ dependencies = [
 [[package]]
 name = "http_req"
 version = "0.13.1"
-source = "git+https://github.com/EasyTier/http_req.git#e6d9e93c43c940f56f45e91b0923bcea53a718ea"
+source = "git+https://github.com/EasyTier/http_req.git#b10aa9fc0db3067cc3d2174683a87250b80a1ea9"
 dependencies = [
  "base64 0.22.1",
+ "rand 0.8.5",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",

--- a/easytier/src/connector/dns_connector.rs
+++ b/easytier/src/connector/dns_connector.rs
@@ -1,14 +1,8 @@
-use std::{
-    net::SocketAddr,
-    pin::Pin,
-    sync::{Arc, RwLock},
-};
+use std::{net::SocketAddr, sync::Arc};
 
 use crate::{
     common::{error::Error, global_ctx::ArcGlobalCtx},
-    tunnel::{
-        Tunnel, TunnelConnector, TunnelError, ZCPacketSink, ZCPacketStream, PROTO_PORT_OFFSET,
-    },
+    tunnel::{Tunnel, TunnelConnector, TunnelError, PROTO_PORT_OFFSET},
 };
 use anyhow::Context;
 use dashmap::DashSet;

--- a/easytier/src/connector/dns_connector.rs
+++ b/easytier/src/connector/dns_connector.rs
@@ -243,8 +243,7 @@ impl super::TunnelConnector for DNSTunnelConnector {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::global_ctx::{tests::get_mock_global_ctx, GlobalCtx};
-    use std::sync::Arc;
+    use crate::common::global_ctx::tests::get_mock_global_ctx;
 
     #[tokio::test]
     async fn test_txt() {

--- a/easytier/src/connector/manual.rs
+++ b/easytier/src/connector/manual.rs
@@ -365,9 +365,12 @@ impl ManualConnectorManager {
             "cannot get ip from url"
         )));
         for ip_version in ip_versions {
+            let use_long_timeout = dead_url.starts_with("http")
+                || dead_url.starts_with("srv")
+                || dead_url.starts_with("txt");
             let ret = timeout(
                 // allow http connector to wait longer
-                std::time::Duration::from_secs(if dead_url.starts_with("http") { 20 } else { 2 }),
+                std::time::Duration::from_secs(if use_long_timeout { 20 } else { 2 }),
                 Self::conn_reconnect_with_ip_version(
                     data.clone(),
                     dead_url.clone(),


### PR DESCRIPTION
1. use ipv4 first when connect to http server.
2. allow redirect to url like: http://tcp://p.com:11010
3. dns should also use long timeout