### PR TITLE
fix(web_client): 将报告时间格式从字符串更改为RFC 3339格式

### DIFF
--- a/easytier/src/web_client/session.rs
+++ b/easytier/src/web_client/session.rs
@@ -95,7 +95,7 @@ impl Session {
 
                     easytier_version: EASYTIER_VERSION.to_string(),
                     hostname: hostname.clone(),
-                    report_time: chrono::Local::now().to_string(),
+                    report_time: chrono::Local::now().to_rfc3339(),
 
                     running_network_instances: controller
                         .list_network_instance_ids()


### PR DESCRIPTION
## 修复 Safari 浏览器日期解析


<img width="553" alt="image" src="https://github.com/user-attachments/assets/a957a93c-40b6-458d-b344-94d7ee223b7a" />



- .to_string(): `2025-03-19 18:41:15.291050 +08:00`

    <img width="339" alt="image" src="https://github.com/user-attachments/assets/f02b0d75-9cd7-44e8-bb14-01dbf68cf7b1" />

- .to_rfc3339(): `2025-03-19T18:41:14.776855+08:00`
    
    
    <img width="371" alt="image" src="https://github.com/user-attachments/assets/c21ea1eb-a307-4ea9-b317-95da44509534" />


