### PR TITLE
feat: get network secret via os command execution

### DIFF
--- a/easytier/locales/app.yml
+++ b/easytier/locales/app.yml
@@ -19,6 +19,9 @@ core_clap:
   network_secret:
     en: "network secret to verify this node belongs to the vpn network"
     zh-CN: "网络密钥，用于验证此节点属于VPN网络"
+  network_secret_cmd:
+    en: "get network secret by executing os command"
+    zh-CN: "通过执行系统命令获取网络密钥"
   ipv4:
     en: "ipv4 address of this vpn node, if empty, this node will only forward packets and no TUN device will be created"
     zh-CN: "此VPN节点的IPv4地址，如果为空，则此节点将仅转发数据包，不会创建TUN设备"

--- a/easytier/src/easytier-core.rs
+++ b/easytier/src/easytier-core.rs
@@ -77,6 +77,12 @@ struct Cli {
     network_secret: String,
 
     #[arg(
+        long,
+        help = t!("core_clap.network_secret_cmd").to_string(),
+    )]
+    network_secret_cmd: Option<String>,
+
+    #[arg(
         short,
         long,
         help = t!("core_clap.ipv4").to_string()
@@ -427,6 +433,7 @@ impl TryFrom<&Cli> for TomlConfigLoader {
         cfg.set_network_identity(NetworkIdentity::new(
             cli.network_name.clone(),
             cli.network_secret.clone(),
+            cli.network_secret_cmd.clone(),
         ));
 
         cfg.set_dhcp(cli.dhcp);

--- a/easytier/src/launcher.rs
+++ b/easytier/src/launcher.rs
@@ -420,6 +420,7 @@ impl NetworkConfig {
         cfg.set_network_identity(NetworkIdentity::new(
             self.network_name.clone().unwrap_or_default(),
             self.network_secret.clone().unwrap_or_default(),
+            None,
         ));
 
         if !cfg.get_dhcp() {
@@ -522,7 +523,8 @@ impl NetworkConfig {
             let mut routes = Vec::<cidr::Ipv4Cidr>::with_capacity(self.routes.len());
             for route in self.routes.iter() {
                 routes.push(
-                    route.parse()
+                    route
+                        .parse()
                         .with_context(|| format!("failed to parse route: {}", route))?,
                 );
             }
@@ -543,9 +545,7 @@ impl NetworkConfig {
         if self.enable_socks5.unwrap_or_default() {
             if let Some(socks5_port) = self.socks5_port {
                 cfg.set_socks5_portal(Some(
-                    format!("socks5://0.0.0.0:{}", socks5_port)
-                        .parse()
-                        .unwrap(),
+                    format!("socks5://0.0.0.0:{}", socks5_port).parse().unwrap(),
                 ));
             }
         }

--- a/easytier/src/peers/foreign_network_manager.rs
+++ b/easytier/src/peers/foreign_network_manager.rs
@@ -642,6 +642,7 @@ mod tests {
             get_mock_global_ctx_with_network(Some(NetworkIdentity::new(
                 network.to_string(),
                 secret.to_string(),
+                None,
             ))),
             s,
         ));

--- a/easytier/src/peers/peer_ospf_route.rs
+++ b/easytier/src/peers/peer_ospf_route.rs
@@ -1199,6 +1199,7 @@ impl PeerRouteServiceImpl {
             let network_identity = NetworkIdentity {
                 network_name: key.network_name.clone(),
                 network_secret: None,
+                network_secret_cmd: None,
                 network_secret_digest: Some(
                     entry
                         .network_secret_digest

--- a/easytier/src/peers/tests.rs
+++ b/easytier/src/peers/tests.rs
@@ -30,8 +30,11 @@ pub async fn create_mock_peer_manager() -> Arc<PeerManager> {
 
 pub async fn create_mock_peer_manager_with_name(network_name: String) -> Arc<PeerManager> {
     let (s, _r) = create_packet_recv_chan();
-    let g =
-        get_mock_global_ctx_with_network(Some(NetworkIdentity::new(network_name, "".to_string())));
+    let g = get_mock_global_ctx_with_network(Some(NetworkIdentity::new(
+        network_name,
+        "".to_string(),
+        None,
+    )));
     let peer_mgr = Arc::new(PeerManager::new(RouteAlgoType::Ospf, g, s));
     peer_mgr.run().await.unwrap();
     peer_mgr

--- a/easytier/src/tests/three_node.rs
+++ b/easytier/src/tests/three_node.rs
@@ -384,6 +384,7 @@ pub async fn subnet_proxy_three_node_test(
                 cfg.set_network_identity(NetworkIdentity::new(
                     "public".to_string(),
                     "public".to_string(),
+                    None,
                 ));
             }
 
@@ -627,8 +628,11 @@ pub async fn foreign_network_forward_nic_data() {
     prepare_linux_namespaces();
 
     let center_node_config = get_inst_config("inst1", Some("net_a"), "10.144.144.1");
-    center_node_config
-        .set_network_identity(NetworkIdentity::new("center".to_string(), "".to_string()));
+    center_node_config.set_network_identity(NetworkIdentity::new(
+        "center".to_string(),
+        "".to_string(),
+        None,
+    ));
     let mut center_inst = Instance::new(center_node_config);
 
     let mut inst1 = Instance::new(get_inst_config("inst1", Some("net_b"), "10.144.145.1"));
@@ -836,8 +840,11 @@ pub async fn manual_reconnector(#[values(true, false)] is_foreign: bool) {
 
     let center_node_config = get_inst_config("inst1", Some("net_a"), "10.144.144.1");
     if is_foreign {
-        center_node_config
-            .set_network_identity(NetworkIdentity::new("center".to_string(), "".to_string()));
+        center_node_config.set_network_identity(NetworkIdentity::new(
+            "center".to_string(),
+            "".to_string(),
+            None,
+        ));
     }
     let mut center_inst = Instance::new(center_node_config);
 


### PR DESCRIPTION
add `--network-secret-cmd` to get network secret from os command execution. For example:

```bash
easytier-core -d -p tcp://public.easytier.cn:11010 --network-name test_net --network-secret-cmd "echo test_pass"
```

A more meaningful scenario with passage:

```bash
easytier-core -d -p tcp://public.easytier.cn:11010 --network-name test_net --network-secret-cmd "passage ET/pass"
```

tested on linux-x86_64