### PR TITLE
set hostname when connecting to config-server

### DIFF
--- a/easytier-web/frontend/src/components/DeviceManagement.vue
+++ b/easytier-web/frontend/src/components/DeviceManagement.vue
@@ -160,6 +160,7 @@ const createNewNetwork = async () => {
 
 const newNetwork = () => {
     newNetworkConfig.value = NetworkTypes.DEFAULT_NETWORK_CONFIG();
+    newNetworkConfig.value.hostname = deviceInfo.value?.hostname;
     isEditing.value = false;
     showCreateNetworkDialog.value = true;
 }

--- a/easytier-web/src/client_manager/mod.rs
+++ b/easytier-web/src/client_manager/mod.rs
@@ -128,7 +128,7 @@ mod tests {
         mgr.serve(Box::new(listener)).await.unwrap();
 
         let connector = UdpTunnelConnector::new("udp://127.0.0.1:54333".parse().unwrap());
-        let _c = WebClient::new(connector, "test");
+        let _c = WebClient::new(connector, "test", "test");
 
         wait_for_condition(
             || async { mgr.client_sessions.len() == 1 },

--- a/easytier/src/easytier-core.rs
+++ b/easytier/src/easytier-core.rs
@@ -869,9 +869,18 @@ async fn run_main(cli: Cli) -> anyhow::Result<()> {
         let mut flags = global_ctx.get_flags();
         flags.bind_device = false;
         global_ctx.set_flags(flags);
+        let hostname = match cli.hostname {
+            None => {
+                gethostname::gethostname().to_string_lossy().to_string()
+            }
+            Some(hostname) => {
+                hostname.to_string()
+            }
+        };
         let _wc = web_client::WebClient::new(
             create_connector_by_url(c_url.as_str(), &global_ctx, IpVersion::Both).await?,
             token.to_string(),
+            hostname
         );
         tokio::signal::ctrl_c().await.unwrap();
         DNSTunnelConnector::new("".parse().unwrap(), global_ctx);

--- a/easytier/src/web_client/controller.rs
+++ b/easytier/src/web_client/controller.rs
@@ -19,13 +19,15 @@ use crate::{
 
 pub struct Controller {
     token: String,
+    hostname: String,
     instance_map: DashMap<uuid::Uuid, NetworkInstance>,
 }
 
 impl Controller {
-    pub fn new(token: String) -> Self {
+    pub fn new(token: String, hostname: String) -> Self {
         Controller {
             token,
+            hostname,
             instance_map: DashMap::new(),
         }
     }
@@ -79,6 +81,10 @@ impl Controller {
 
     pub fn token(&self) -> String {
         self.token.clone()
+    }
+
+    pub fn hostname(&self) -> String {
+        self.hostname.clone()
     }
 }
 

--- a/easytier/src/web_client/mod.rs
+++ b/easytier/src/web_client/mod.rs
@@ -11,8 +11,9 @@ pub struct WebClient {
 }
 
 impl WebClient {
-    pub fn new<T: TunnelConnector + 'static, S: ToString>(connector: T, token: S) -> Self {
-        let controller = Arc::new(controller::Controller::new(token.to_string()));
+    pub fn new<T: TunnelConnector + 'static, S: ToString, H: ToString>(connector: T, token: S, hostname: H) -> Self {
+        let controller = Arc::new(controller::Controller::new(token.to_string(),
+                                                              hostname.to_string()));
 
         let controller_clone = controller.clone();
         let tasks = ScopedTask::from(tokio::spawn(async move {

--- a/easytier/src/web_client/session.rs
+++ b/easytier/src/web_client/session.rs
@@ -73,7 +73,7 @@ impl Session {
         let mid = get_machine_id();
         let inst_id = uuid::Uuid::new_v4();
         let token = controller.upgrade().unwrap().token();
-        let hostname = gethostname::gethostname().to_string_lossy().to_string();
+        let hostname = controller.upgrade().unwrap().hostname();
 
         let ctx_clone = ctx.clone();
         let mut tick = interval(std::time::Duration::from_secs(1));


### PR DESCRIPTION
Use `--hostname xxx` to set the device name when connecting to config-server, so that you can easily identify the device on the DeviceList web page when it‘s inconvenient to modify the device hostname in the os。If not set, use the device hostname as the default value。

For example:
 ```shell
easytier-core -w udp://127.0.0.1:22020/user --hostname MyDevice
 ```

![image](https://github.com/user-attachments/assets/f3292467-048b-4725-9e01-a9238634e1ba)

Fill the `hostname` field with the value of `--hostname` when creating new network in web

![image](https://github.com/user-attachments/assets/e36b8e26-d068-4e49-9d6c-3c16990e45fb)
