### PR TITLE
easytier-cli部分命令支持json输出

### DIFF
--- a/easytier/src/easytier-cli.rs
+++ b/easytier/src/easytier-cli.rs
@@ -1129,6 +1129,11 @@ async fn main() -> Result<(), Error> {
                 .ok_or(anyhow::anyhow!("node info not found"))?;
             match sub_cmd.sub_command {
                 Some(NodeSubCommand::Info) | None => {
+                    if cli.verbose || cli.output_format == OutputFormat::Json {
+                        println!("{}", serde_json::to_string_pretty(&node_info)?);
+                        return Ok(());
+                    }
+
                     let stun_info = node_info.stun_info.clone().unwrap_or_default();
                     let ip_list = node_info.ip_list.clone().unwrap_or_default();
 

--- a/easytier/src/easytier-cli.rs
+++ b/easytier/src/easytier-cli.rs
@@ -405,15 +405,7 @@ impl CommandHandler<'_> {
             items.push(p.into());
         }
 
-        match self.output_format {
-            OutputFormat::Table => {
-                println!("{}", tabled::Table::new(items).with(Style::modern()));
-            }
-            OutputFormat::Json => {
-                let json = serde_json::to_string_pretty(&items)?;
-                println!("{}", json);
-            }
-        }
+        print_output(&items, self.output_format)?;
 
         Ok(())
     }
@@ -665,15 +657,7 @@ impl CommandHandler<'_> {
             }
         }
 
-        match self.output_format {
-            OutputFormat::Table => {
-                println!("{}", tabled::Table::new(items).with(Style::modern()));
-            }
-            OutputFormat::Json => {
-                let json = serde_json::to_string_pretty(&items)?;
-                println!("{}", json);
-            }
-        }
+        print_output(&items, self.output_format)?;
 
         Ok(())
     }
@@ -951,6 +935,21 @@ impl Service {
     }
 }
 
+fn print_output<T>(items: &[T], format: &OutputFormat) -> Result<(), Error>
+where
+    T: tabled::Tabled + serde::Serialize,
+{
+    match format {
+        OutputFormat::Table => {
+            println!("{}", tabled::Table::new(items).with(Style::modern()));
+        }
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(items)?);
+        }
+    }
+    Ok(())
+}
+
 #[tokio::main]
 #[tracing::instrument]
 async fn main() -> Result<(), Error> {
@@ -1067,15 +1066,7 @@ async fn main() -> Result<(), Error> {
                 });
             }
 
-            match cli.output_format {
-                OutputFormat::Json => {
-                    let json = serde_json::to_string_pretty(&table_rows)?;
-                    println!("{}", json);
-                }
-                OutputFormat::Table => {
-                    println!("{}", tabled::Table::new(table_rows).with(Style::modern()));
-                }
-            }
+            print_output(&table_rows, &cli.output_format)?;
         }
         SubCommand::VpnPortal => {
             let vpn_portal_client = handler.get_vpn_portal_client().await?;
@@ -1277,15 +1268,7 @@ async fn main() -> Result<(), Error> {
                 })
                 .collect::<Vec<_>>();
 
-            match cli.output_format {
-                OutputFormat::Json => {
-                    let json = serde_json::to_string_pretty(&table_rows)?;
-                    println!("{}", json);
-                }
-                OutputFormat::Table => {
-                    println!("{}", tabled::Table::new(table_rows).with(Style::modern()));
-                }
-            }
+            print_output(&table_rows, &cli.output_format)?;
         }
     }
 

--- a/easytier/src/easytier-cli.rs
+++ b/easytier/src/easytier-cli.rs
@@ -1072,7 +1072,9 @@ async fn main() -> Result<(), Error> {
                     let json = serde_json::to_string_pretty(&table_rows)?;
                     println!("{}", json);
                 }
-                OutputFormat::Table => {}
+                OutputFormat::Table => {
+                    println!("{}", tabled::Table::new(table_rows).with(Style::modern()));
+                }
             }
         }
         SubCommand::VpnPortal => {


### PR DESCRIPTION
在 cli 根命令添加了一个-o/--output选项，对于已支持表格数据的子命令添加了json输出的支持，如
- easytier-cli -o json peer list
- easytier-cli -o json route list
- easytier-cli -o json peer-center
- easytier-cli -o json proxy

close #497 
close #809 