### PR TITLE
easytier-web 添加支持通过websocket连接

### DIFF
--- a/easytier-web/src/main.rs
+++ b/easytier-web/src/main.rs
@@ -12,7 +12,7 @@ use easytier::{
         constants::EASYTIER_VERSION,
         error::Error,
     },
-    tunnel::{tcp::TcpTunnelListener, udp::UdpTunnelListener, TunnelListener},
+    tunnel::{tcp::TcpTunnelListener, udp::UdpTunnelListener, websocket::WSTunnelListener, TunnelListener},
     utils::{init_logger, setup_panic_handler},
 };
 
@@ -27,7 +27,7 @@ mod web;
 rust_i18n::i18n!("locales", fallback = "en");
 
 #[derive(Parser, Debug)]
-#[command(name = "easytier-core", author, version = EASYTIER_VERSION , about, long_about = None)]
+#[command(name = "easytier-web", author, version = EASYTIER_VERSION , about, long_about = None)]
 struct Cli {
     #[arg(short, long, default_value = "et.db", help = t!("cli.db").to_string())]
     db: String,
@@ -95,6 +95,7 @@ pub fn get_listener_by_url(l: &url::Url) -> Result<Box<dyn TunnelListener>, Erro
     Ok(match l.scheme() {
         "tcp" => Box::new(TcpTunnelListener::new(l.clone())),
         "udp" => Box::new(UdpTunnelListener::new(l.clone())),
+        "ws" => Box::new(WSTunnelListener::new(l.clone())),
         _ => {
             return Err(Error::InvalidUrl(l.to_string()));
         }


### PR DESCRIPTION
通过`easytier-web -p ws`启动web并创建测试用户xxx
然后`easytier-core -w ws://127.0.0.1:22020/xxx` 可正常连接
通过cloudflare tunnel将22020转发到公网https后可以通过`easytier-core -w wss://your.example.domain/xxx`连接

<img width="1840" alt="image" src="https://github.com/user-attachments/assets/29218dba-e5c5-4e28-b6fd-c61e8f16abe5" />

<img width="1162" alt="image" src="https://github.com/user-attachments/assets/3e521a2c-2b02-429d-8cbc-f999fb853665" />


close #798 