### PR TITLE
支持通过 --api-host 参数自定义 Web 前端的 API 服务器地址

### DIFF
--- a/easytier-web/frontend/index.html
+++ b/easytier-web/frontend/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/png" href="/easytier.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>EasyTier Dashboard</title>
+    <script src="/api_meta.js"></script>
   </head>
   <body>
     <div id="app"></div>

--- a/easytier-web/frontend/src/modules/api-host.ts
+++ b/easytier-web/frontend/src/modules/api-host.ts
@@ -1,9 +1,16 @@
-const defaultApiHost = 'https://config-server.easytier.cn';
-
 interface ApiHost {
     value: string;
     usedAt: number;
 }
+
+let apiMeta: {
+    api_host: string;
+} | undefined = (window as any).apiMeta;
+
+// remove trailing slashes from the URL
+const cleanUrl = (url: string) => url.replace(/\/+$/, '');
+
+const defaultApiHost = cleanUrl(apiMeta?.api_host ?? `${location.origin}${location.pathname}`);
 
 const isValidHttpUrl = (s: string): boolean => {
     let url;
@@ -45,7 +52,7 @@ const saveApiHost = (host: string) => {
     }
 
     let hosts = cleanAndLoadApiHosts();
-    const newHost: ApiHost = {value: host, usedAt: Date.now()};
+    const newHost: ApiHost = { value: host, usedAt: Date.now() };
     hosts = hosts.filter((h) => h.value !== host);
     hosts.push(newHost);
     localStorage.setItem('apiHosts', JSON.stringify(hosts));
@@ -61,4 +68,4 @@ const getInitialApiHost = (): string => {
     }
 };
 
-export {getInitialApiHost, cleanAndLoadApiHosts, saveApiHost}
+export { getInitialApiHost, cleanAndLoadApiHosts, saveApiHost }

--- a/easytier-web/frontend/vite.config.ts
+++ b/easytier-web/frontend/vite.config.ts
@@ -3,9 +3,20 @@ import vue from '@vitejs/plugin-vue'
 // import { viteSingleFile } from "vite-plugin-singlefile"
 
 const WEB_BASE_URL = process.env.WEB_BASE_URL || '';
+const API_BASE_URL = process.env.API_BASE_URL || 'http://localhost:11211';
 
 // https://vite.dev/config/
 export default defineConfig({
   base: WEB_BASE_URL,
   plugins: [vue(),/* viteSingleFile() */],
+  server: {
+    proxy: {
+      "/api": {
+        target: API_BASE_URL,
+      },
+      "/api_meta.js": {
+        target: API_BASE_URL,
+      },
+    }
+  }
 })

--- a/easytier-web/locales/app.yml
+++ b/easytier-web/locales/app.yml
@@ -28,3 +28,6 @@ cli:
   no_web:
     en: "Do not run the web dashboard server"
     zh-CN: "不运行 web dashboard 服务器"
+  api_host:
+    en: "The URL of the API server, used by the web frontend to connect to"
+    zh-CN: "API 服务器的 URL，用于 web 前端连接"

--- a/easytier-web/src/web/mod.rs
+++ b/easytier-web/src/web/mod.rs
@@ -1,8 +1,13 @@
-use axum::Router;
+use axum::{
+    extract::State,
+    http::header,
+    response::{IntoResponse, Response},
+    routing, Router,
+};
+use axum_embed::ServeEmbed;
 use easytier::common::scoped_task::ScopedTask;
 use rust_embed::RustEmbed;
 use std::net::SocketAddr;
-use axum_embed::ServeEmbed;
 use tokio::net::TcpListener;
 
 /// Embed assets for web dashboard, build frontend first
@@ -10,30 +15,72 @@ use tokio::net::TcpListener;
 #[folder = "frontend/dist/"]
 struct Assets;
 
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+struct ApiMetaResponse {
+    api_host: String,
+}
+
+async fn handle_api_meta(State(api_host): State<url::Url>) -> impl IntoResponse {
+    Response::builder()
+        .header(
+            header::CONTENT_TYPE,
+            "application/javascript; charset=utf-8",
+        )
+        .header(header::CACHE_CONTROL, "no-cache, no-store, must-revalidate")
+        .header(header::PRAGMA, "no-cache")
+        .header(header::EXPIRES, "0")
+        .body(format!(
+            "window.apiMeta = {}",
+            serde_json::to_string(&ApiMetaResponse {
+                api_host: api_host.to_string()
+            })
+            .unwrap(),
+        ))
+        .unwrap()
+}
+
+pub fn build_router(api_host: Option<url::Url>) -> Router {
+    let service = ServeEmbed::<Assets>::new();
+    let router = Router::new();
+
+    let router = if let Some(api_host) = api_host {
+        let sub_router = Router::new()
+            .route("/api_meta.js", routing::get(handle_api_meta))
+            .with_state(api_host);
+        router.merge(sub_router)
+    } else {
+        router
+    };
+
+    let router = router.fallback_service(service);
+
+    router
+}
+
 pub struct WebServer {
     bind_addr: SocketAddr,
+    router: Router,
     serve_task: Option<ScopedTask<()>>,
 }
 
 impl WebServer {
-    pub async fn new(bind_addr: SocketAddr) -> anyhow::Result<Self> {
+    pub async fn new(bind_addr: SocketAddr, router: Router) -> anyhow::Result<Self> {
         Ok(WebServer {
             bind_addr,
+            router,
             serve_task: None,
         })
     }
 
-    pub async fn start(&mut self) -> Result<(), anyhow::Error> {
+    pub async fn start(self) -> Result<ScopedTask<()>, anyhow::Error> {
         let listener = TcpListener::bind(self.bind_addr).await?;
-        let service = ServeEmbed::<Assets>::new();
-        let app = Router::new().fallback_service(service);
+        let app = self.router;
 
         let task = tokio::spawn(async move {
             axum::serve(listener, app).await.unwrap();
-        });
+        })
+        .into();
 
-        self.serve_task = Some(task.into());
-
-        Ok(())
+        Ok(task)
     }
 }


### PR DESCRIPTION
## 支持通过 --api-host 参数自定义 Web 前端的 API 服务器地址

### 设计思路

本 PR 主要通过以下几个改动实现了自定义 API 服务器地址的功能：

1. **命令行参数扩展**: 在 `easytier-web` 中新增 `--api-host` 参数，允许用户指定 Web 前端连接的 API 服务器地址

2. **动态 API 元数据注入**: 
   - 新增 `/api_meta.js` 端点，动态生成包含 API 服务器地址的 JavaScript 配置
   - 在 HTML 中引入该脚本，向前端注入 `window.apiMeta` 全局变量

3. **前端 API Host 自适应**:
   - 重构 `easytier-web/frontend/src/modules/api-host.ts` 模块，实现智能地址选择策略
   - 提供降级机制：本地存储历史地址 → 服务器注入地址（--api-host参数） → 当前访问地址
   - **未使用 --api-host 参数时**：服务器不会注入 `window.apiMeta`，前端会优先使用历史地址，没有历史记录时使用当前访问地址


### 场景说明
* 启用embed，web-server-port与api-server-port相同（或为空）：无需配置`api-host`参数，`/api_meta.js`返回`404`，当前访问地址作为API地址，能够正常使用。
* 启用embed，web-server-port与api-server-port不同：需要配置`api-host`参数，否则无法正常连接到API服务器。此时`/api_meta.js`会注入指定的API地址，前端将使用该地址进行API请求。
* 禁用embed：仅提供API服务，无Web界面。针对类似官方服务器这种web服务器与API服务器分离，但又没启用embed的场景，可以选择在web服务器中手动创建一个 `/api_meta.js` 文件，内容为 `window.apiMeta = {"api_host":"https://config-server.easytier.cn"}`。

### 集成测试
1. embed路由更改测试
- [x] 启用embed，不指定web端口(`cargo run --features embed --`): 访问`http://127.0.0.1:11211/`能够正常访问Web界面
- [x] 启用embed，指定web端口(`cargo run --features embed -- --web-server-port 8080`): 访问`http://127.0.0.1:8080/`能够正常访问Web界面
- [x] 禁用embed(`cargo run --`): 访问`http://127.0.0.1:11211/`能够正常访问API服务，但无法访问Web界面
2. API服务器地址注入测试(均在embed模式下进行，且localStorage无内容)
- [x] 不指定`--api-host`参数(`cargo run --features embed --`)
    - 访问`http://127.0.0.1:11211/`能够正常访问Web界面
    - 访问`http://127.0.0.1:11211/api_meta.js`返回404
    - 访问`http://127.0.0.1:11211/#/auth/register`能够正常加载验证码
- [x] api与web端口不通且指定`--api-host`参数(`cargo run --features embed -- --web-server-port 8080 --api-host http://127.0.0.1:11211`)
    - 访问`http://127.0.0.1:8080/`能够正常访问Web界面
    - 访问`http://127.0.0.1:8080/api_meta.js`能够正常返回API元数据(`window.apiMeta = {"api_host":"http://127.0.0.1:11211"}`)
    - 访问`http://127.0.0.1:8080/#/auth/register`能够正常加载验证码
- [x] `--api-host`参数合法性验证(`cargo run --features embed -- --api-host not_a_valid_host`): 程序panic报错：`error: invalid value 'not_a_valid_host' for '--api-host <API_HOST>': relative URL without a base`

close #867