### PR TITLE
fix(easytier-gui): restore window correctly when clicking tray icon while minimized

### DIFF
--- a/easytier-gui/src-tauri/src/lib.rs
+++ b/easytier-gui/src-tauri/src/lib.rs
@@ -108,7 +108,12 @@ fn set_tun_fd(instance_id: String, fd: i32) -> Result<(), String> {
 fn toggle_window_visibility<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
     if let Some(window) = app.get_webview_window("main") {
         if window.is_visible().unwrap_or_default() {
-            let _ = window.hide();
+            if window.is_minimized().unwrap_or_default() {
+                let _ = window.unminimize();
+                let _ = window.set_focus();
+            } else {
+                let _ = window.hide();
+            }
         } else {
             let _ = window.show();
             let _ = window.set_focus();


### PR DESCRIPTION
fix(easytier-gui): restore window correctly when clicking tray icon while minimized

以前在最小化窗口时单击托盘图标会错误地切换任务栏图标的可见性。

这一改变实现了预期的行为：
- 当窗口最小化时：单击托盘将窗口恢复到原始状态
- 当窗口可见时：托盘单击最小化到托盘
- 当窗口隐藏时：单击托盘恢复窗口

该修复通过提供标准的托盘交互行为来增强用户体验。包括必要的事件处理窗口状态转换。