### PR TITLE
节点信息组件添加隧道协议字段

### DIFF
--- a/easytier-web/frontend-lib/src/components/Status.vue
+++ b/easytier-web/frontend-lib/src/components/Status.vue
@@ -106,6 +106,10 @@ function ipFormat(info: PeerRoutePair) {
   return ip ? `${IPv4.fromNumber(ip.address.addr)}/${ip.network_length}` : ''
 }
 
+function tunnelProto(info: PeerRoutePair) {
+  return [...new Set(info.peer?.conns.map(c => c.tunnel?.tunnel_type))].join(',')
+}
+
 const myNodeInfo = computed(() => {
   if (!props.curNetworkInst)
     return {} as NodeInfo
@@ -311,7 +315,7 @@ function showEventLogs() {
       <Timeline v-else :value="dialogContent">
         <template #opposite="slotProps">
           <small class="text-surface-500 dark:text-surface-400">{{ useTimeAgo(Date.parse(slotProps.item.time))
-            }}</small>
+          }}</small>
         </template>
         <template #content="slotProps">
           <HumanEvent :event="slotProps.item.event" />
@@ -408,6 +412,7 @@ function showEventLogs() {
               </template>
             </Column>
             <Column :field="routeCost" :header="t('route_cost')" />
+            <Column :field="tunnelProto" :header="t('tunnel_proto')" />
             <Column :field="latencyMs" :header="t('latency')" />
             <Column :field="txBytes" :header="t('upload_bytes')" />
             <Column :field="rxBytes" :header="t('download_bytes')" />

--- a/easytier-web/frontend-lib/src/locales/cn.yaml
+++ b/easytier-web/frontend-lib/src/locales/cn.yaml
@@ -64,6 +64,7 @@ event_log: 事件日志
 peer_info: 节点信息
 hostname: 主机名
 route_cost: 路由
+tunnel_proto: 协议
 latency: 延迟
 upload_bytes: 上传
 download_bytes: 下载

--- a/easytier-web/frontend-lib/src/locales/en.yaml
+++ b/easytier-web/frontend-lib/src/locales/en.yaml
@@ -62,6 +62,7 @@ show_event_log: Show Event Log
 event_log: Event Log
 peer_info: Peer Info
 route_cost: Route Cost
+tunnel_proto: Protocol
 hostname: Hostname
 latency: Latency
 upload_bytes: Upload


### PR DESCRIPTION
理论上web和gui都会加上，但我本地启不起来gui，因此只测了web。
<img width="871" alt="image" src="https://github.com/user-attachments/assets/cee1ab21-f00e-4aec-8b18-c03ffe422502" />

另外是否考虑允许表格横向滚动？不然的话有些字换行了挤在一起不大好看。如果需要我一起加一下。

close #922