### PR TITLE
Allow using `--proxy-forward-by-system` together with `--enable-exit-node`

### DIFF
--- a/easytier/src/instance/instance.rs
+++ b/easytier/src/instance/instance.rs
@@ -70,11 +70,17 @@ impl IpProxy {
 
     async fn start(&self) -> Result<(), Error> {
         if (self.global_ctx.get_proxy_cidrs().is_empty()
-            || self.global_ctx.proxy_forward_by_system()
             || self.started.load(Ordering::Relaxed))
             && !self.global_ctx.enable_exit_node()
             && !self.global_ctx.no_tun()
         {
+            return Ok(());
+        }
+
+        // Actually, if this node is enabled as an exit node,
+        // we still can use the system stack to forward packets.
+        if self.global_ctx.proxy_forward_by_system()
+          && !self.global_ctx.no_tun() {
             return Ok(());
         }
 


### PR DESCRIPTION
The current implementation continues to use TCP/UDP/ICMP proxies even when --proxy-forward-by-system is specified, due to the peer also being configured as an exit node.

However, with proper iptables and iproute2 configuration, traffic routed through an exit node can still be handled by the system's network stack without relying on userspace proxies.

This patch relaxes the condition and allows forwarding as long as a TUN device is present.