### PR TITLE
修复配置生成器右侧输入框在夜间模式下背景是白色的问题

### DIFF
--- a/easytier-web/frontend/src/components/ConfigGenerator.vue
+++ b/easytier-web/frontend/src/components/ConfigGenerator.vue
@@ -82,7 +82,7 @@ const parseConfig = async () => {
                 <Textarea 
                     v-model="toml_config" 
                     spellcheck="false"
-                    class="w-full flex-grow p-2 bg-gray-100 whitespace-pre-wrap font-mono border-none focus:outline-none resize-none" 
+                    class="w-full flex-grow p-2 whitespace-pre-wrap font-mono resize-none" 
                     placeholder="Press 'Run Network' to generate TOML configuration, or paste your TOML configuration here to parse it"
                 ></Textarea>
                 <div class="mt-3 flex justify-center">


### PR DESCRIPTION
移除了`bg-gray-100`并将样式调整为与web中的配置编辑弹窗基本保持一致
<img width="1407" alt="image" src="https://github.com/user-attachments/assets/592f1d85-b5a1-49d8-acf9-bc4f130accb3" />
