### PR TITLE
fix bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8486,8 +8486,8 @@ dependencies = [
 
 [[package]]
 name = "thunk-rs"
-version = "0.3.4"
-source = "git+https://github.com/easytier/thunk.git#403f0d26d3d5bcfdfd76c23e36e517f19fe891e0"
+version = "0.3.5"
+source = "git+https://github.com/easytier/thunk.git#cbbeec75a66b7b3cf0824ae890d9d06bcfb9d1f3"
 
 [[package]]
 name = "tiff"

--- a/easytier/src/connector/manual.rs
+++ b/easytier/src/connector/manual.rs
@@ -15,7 +15,7 @@ use tokio::{
 };
 
 use crate::{
-    common::{join_joinset_background, PeerId},
+    common::{dns::socket_addrs, join_joinset_background, PeerId},
     peers::peer_conn::PeerConnId,
     proto::{
         cli::{
@@ -373,7 +373,7 @@ impl ManualConnectorManager {
         if u.scheme() == "ring" || u.scheme() == "txt" || u.scheme() == "srv" {
             ip_versions.push(IpVersion::Both);
         } else {
-            let addrs = match u.socket_addrs(|| Some(1000)) {
+            let addrs = match socket_addrs(&u, || Some(1000)).await {
                 Ok(addrs) => addrs,
                 Err(e) => {
                     data.global_ctx.issue_event(GlobalCtxEvent::ConnectError(

--- a/easytier/src/connector/udp_hole_punch/mod.rs
+++ b/easytier/src/connector/udp_hole_punch/mod.rs
@@ -270,7 +270,7 @@ impl UdpHoePunchConnectorData {
 
     #[tracing::instrument(skip(self))]
     async fn cone_to_cone(self: Arc<Self>, task_info: PunchTaskInfo) -> Result<(), Error> {
-        let mut backoff = BackOff::new(vec![0, 1000, 2000, 4000, 4000, 8000, 8000, 16000]);
+        let mut backoff = BackOff::new(vec![1000, 1000, 2000, 4000, 4000, 8000, 8000, 16000]);
 
         loop {
             backoff.sleep_for_next_backoff().await;
@@ -293,7 +293,8 @@ impl UdpHoePunchConnectorData {
 
     #[tracing::instrument(skip(self))]
     async fn sym_to_cone(self: Arc<Self>, task_info: PunchTaskInfo) -> Result<(), Error> {
-        let mut backoff = BackOff::new(vec![0, 1000, 2000, 4000, 4000, 8000, 8000, 16000, 64000]);
+        let mut backoff =
+            BackOff::new(vec![1000, 1000, 2000, 4000, 4000, 8000, 8000, 16000, 64000]);
         let mut round = 0;
         let mut port_idx = rand::random();
 
@@ -338,7 +339,8 @@ impl UdpHoePunchConnectorData {
 
     #[tracing::instrument(skip(self))]
     async fn both_easy_sym(self: Arc<Self>, task_info: PunchTaskInfo) -> Result<(), Error> {
-        let mut backoff = BackOff::new(vec![0, 1000, 2000, 4000, 4000, 8000, 8000, 16000, 64000]);
+        let mut backoff =
+            BackOff::new(vec![1000, 1000, 2000, 4000, 4000, 8000, 8000, 16000, 64000]);
 
         loop {
             backoff.sleep_for_next_backoff().await;


### PR DESCRIPTION
1. avoid dns query hangs the thread
2. avoid deadloop when stun query failed because of no ipv4 addr.
3. make quic input error non-fatal.
4. remove ring tunnel from connection map to avoid mem leak.
