### PR TITLE
Add support for Linux RISC-V 64

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -19,6 +19,10 @@ SYSROOT = "/usr/local/ohos-sdk/linux/native/sysroot"
 linker = "aarch64-unknown-linux-musl-gcc"
 rustflags = ["-C", "target-feature=+crt-static"]
 
+[target.riscv64gc-unknown-linux-musl]
+linker = "riscv64-unknown-linux-musl-gcc"
+rustflags = ["-C", "target-feature=+crt-static"]
+
 [target.'cfg(all(windows, target_env = "msvc"))']
 rustflags = ["-C", "target-feature=+crt-static"]
 

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -83,6 +83,9 @@ jobs:
           - TARGET: x86_64-unknown-linux-musl
             OS: ubuntu-22.04
             ARTIFACT_NAME: linux-x86_64
+          - TARGET: riscv64gc-unknown-linux-musl
+            OS: ubuntu-22.04
+            ARTIFACT_NAME: linux-riscv64
           - TARGET: mips-unknown-linux-musl
             OS: ubuntu-22.04
             ARTIFACT_NAME: linux-mips
@@ -189,6 +192,8 @@ jobs:
             if [[ $OS =~ ^windows.*$ ]]; then
               SUFFIX=.exe
               CORE_FEATURES="--features=mimalloc"
+            elif [[ $TARGET =~ ^riscv64.*$ ]]; then
+              CORE_FEATURES="--features=mimalloc"
             else
               CORE_FEATURES="--features=jemalloc"
             fi
@@ -255,7 +260,7 @@ jobs:
             TAG=$GITHUB_SHA
           fi
 
-          if [[ $OS =~ ^ubuntu.*$ && ! $TARGET =~ ^.*freebsd$ && ! $TARGET =~ ^loongarch.*$ ]]; then
+          if [[ $OS =~ ^ubuntu.*$ && ! $TARGET =~ ^.*freebsd$ && ! $TARGET =~ ^loongarch.*$ && ! $TARGET =~ ^riscv64.*$ ]]; then
             UPX_VERSION=4.2.4
             curl -L https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-amd64_linux.tar.xz -s | tar xJvf -
             cp upx-${UPX_VERSION}-amd64_linux/upx .

--- a/.github/workflows/install_rust.sh
+++ b/.github/workflows/install_rust.sh
@@ -15,6 +15,8 @@ if [[ $OS =~ ^ubuntu.*$ ]]; then
     # if target is mips or mipsel, we should use soft-float version of musl
     if [[ $TARGET =~ ^mips.*$ || $TARGET =~ ^mipsel.*$ ]]; then
         MUSL_TARGET=${TARGET}sf
+    elif [[ $TARGET =~ ^riscv64gc-.*$ ]]; then
+        MUSL_TARGET=${TARGET/#riscv64gc-/riscv64-}
     fi
     if [[ $MUSL_TARGET =~ musl ]]; then
         mkdir -p ./musl_gcc


### PR DESCRIPTION
我们需要在 Linux RISC-V 64 平台上部署 EasyTier，所以希望 EasyTier 能够提供 `riscv64gc-unknown-linux-musl` 目标的分发。

本 PR 我已经测试过，能够正常构建 ([GitHub Action 日志](https://github.com/Glavo/EasyTier/actions/runs/16543671076/job/46788382385))，并且在 Milk-V Megrez (CPU 是 EIC7700X) 上能够正常工作。