### PR TITLE
add FOREGROUND_SERVICE for no_tun mode, not using vpn service

### DIFF
--- a/easytier-gui/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/easytier-gui/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+
     <application
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
@@ -18,6 +22,12 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service
+            android:name=".MainForegroundService"
+            android:foregroundServiceType="dataSync"
+            android:enabled="true"
+            android:exported="false">
+        </service>
 
         <provider
           android:name="androidx.core.content.FileProvider"

--- a/easytier-gui/src-tauri/gen/android/app/src/main/java/com/kkrainbow/easytier/MainActivity.kt
+++ b/easytier-gui/src-tauri/gen/android/app/src/main/java/com/kkrainbow/easytier/MainActivity.kt
@@ -3,8 +3,6 @@ package com.kkrainbow.easytier
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
-
 class MainActivity : TauriActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/easytier-gui/src-tauri/gen/android/app/src/main/java/com/kkrainbow/easytier/MainActivity.kt
+++ b/easytier-gui/src-tauri/gen/android/app/src/main/java/com/kkrainbow/easytier/MainActivity.kt
@@ -1,3 +1,22 @@
 package com.kkrainbow.easytier
 
-class MainActivity : TauriActivity()
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+class MainActivity : TauriActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        initService()
+    }
+
+    private fun initService() {
+        val serviceIntent = Intent(this, MainForegroundService::class.java)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            startForegroundService(serviceIntent)
+        } else {
+            startService(serviceIntent)
+        }
+    }
+}

--- a/easytier-gui/src-tauri/gen/android/app/src/main/java/com/kkrainbow/easytier/MainForegroundService.kt
+++ b/easytier-gui/src-tauri/gen/android/app/src/main/java/com/kkrainbow/easytier/MainForegroundService.kt
@@ -1,0 +1,64 @@
+package com.kkrainbow.easytier
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import android.util.Log
+
+class MainForegroundService : Service() {
+    companion object {
+        const val CHANNEL_ID = "easytier_channel"
+        const val NOTIFICATION_ID = 1355
+        // You can add more constants if needed
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        createNotificationChannel()
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("easytier Running")
+            .setContentText("easytier is available on localhost")
+            .setSmallIcon(android.R.drawable.ic_menu_manage)
+            .build()
+       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+          try {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "easytier notice",
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+            val manager = getSystemService(NotificationManager::class.java)
+            manager?.createNotificationChannel(channel)
+            } catch (e: Exception) {
+                Log.e("MainForegroundService", "Failed to create notification channel", e)
+            }
+        }
+    }
+}

--- a/easytier-gui/src/composables/mobile_vpn.ts
+++ b/easytier-gui/src/composables/mobile_vpn.ts
@@ -133,12 +133,6 @@ async function onNetworkInstanceChange() {
   }
 
   // if use no tun mode, stop the vpn service
-  const no_tun = networkStore.isNoTunEnabled(insts[0])
-  if (no_tun) {
-    console.error('no tun mode, stop vpn service')
-    await doStopVpn()
-    return
-  }
 
   let network_length = curNetworkInfo?.my_node_info?.virtual_ipv4.network_length
   if (!network_length) {
@@ -187,12 +181,29 @@ async function watchNetworkInstance() {
   console.error('vpn service watch network instance')
 }
 
+function isNoTunEnabled() {
+  const insts = networkStore.networkInstanceIds
+  if (!insts) {
+    return
+  }
+  const no_tun = networkStore.isNoTunEnabled(insts[0])
+  if (no_tun) {
+    return true
+  }
+}
+
 export async function initMobileVpnService() {
+  if (isNoTunEnabled()) {
+    return
+  }
   await registerVpnServiceListener()
   await watchNetworkInstance()
 }
 
 export async function prepareVpnService() {
+  if (isNoTunEnabled()) {
+    return
+  }
   console.log('prepare vpn')
   const prepare_ret = await prepare_vpn()
   console.log('prepare vpn', JSON.stringify((prepare_ret)))

--- a/easytier-gui/src/composables/mobile_vpn.ts
+++ b/easytier-gui/src/composables/mobile_vpn.ts
@@ -115,6 +115,10 @@ function getRoutesForVpn(routes: Route[]): string[] {
 async function onNetworkInstanceChange() {
   console.error('vpn service watch network instance change ids', JSON.stringify(networkStore.networkInstanceIds))
   const insts = networkStore.networkInstanceIds
+  const no_tun = networkStore.isNoTunEnabled(insts[0])
+  if (no_tun) {
+    return
+  }
   if (!insts) {
     await doStopVpn()
     return
@@ -181,12 +185,11 @@ async function watchNetworkInstance() {
   console.error('vpn service watch network instance')
 }
 
-function isNoTunEnabled() {
-  const insts = networkStore.networkInstanceIds
-  if (!insts) {
+function isNoTunEnabled(instanceId: string | undefined) {
+  if (!instanceId) {
     return false
   }
-  const no_tun = networkStore.isNoTunEnabled(insts[0])
+  const no_tun = networkStore.isNoTunEnabled(instanceId)
   if (no_tun) {
     return true
   }
@@ -194,15 +197,12 @@ function isNoTunEnabled() {
 }
 
 export async function initMobileVpnService() {
-  if (isNoTunEnabled()) {
-    return
-  }
   await registerVpnServiceListener()
   await watchNetworkInstance()
 }
 
-export async function prepareVpnService() {
-  if (isNoTunEnabled()) {
+export async function prepareVpnService(instanceId: string) {
+  if (isNoTunEnabled(instanceId)) {
     return
   }
   console.log('prepare vpn')

--- a/easytier-gui/src/composables/mobile_vpn.ts
+++ b/easytier-gui/src/composables/mobile_vpn.ts
@@ -184,12 +184,13 @@ async function watchNetworkInstance() {
 function isNoTunEnabled() {
   const insts = networkStore.networkInstanceIds
   if (!insts) {
-    return
+    return false
   }
   const no_tun = networkStore.isNoTunEnabled(insts[0])
   if (no_tun) {
     return true
   }
+  return false
 }
 
 export async function initMobileVpnService() {

--- a/easytier-gui/src/composables/mobile_vpn.ts
+++ b/easytier-gui/src/composables/mobile_vpn.ts
@@ -117,6 +117,7 @@ async function onNetworkInstanceChange() {
   const insts = networkStore.networkInstanceIds
   const no_tun = networkStore.isNoTunEnabled(insts[0])
   if (no_tun) {
+    await doStopVpn()
     return
   }
   if (!insts) {
@@ -135,8 +136,6 @@ async function onNetworkInstanceChange() {
     await doStopVpn()
     return
   }
-
-  // if use no tun mode, stop the vpn service
 
   let network_length = curNetworkInfo?.my_node_info?.virtual_ipv4.network_length
   if (!network_length) {

--- a/easytier-gui/src/pages/index.vue
+++ b/easytier-gui/src/pages/index.vue
@@ -102,7 +102,7 @@ networkStore.$subscribe(async () => {
 
 async function runNetworkCb(cfg: NetworkTypes.NetworkConfig, cb: () => void) {
   if (type() === 'android') {
-    await prepareVpnService()
+    await prepareVpnService(cfg.instance_id)
     networkStore.clearNetworkInstances()
   }
   else {


### PR DESCRIPTION
1. add FOREGROUND_SERVICE related code, connection not to be **blocked by android system** when apps running in background
2. no_tun mode not enabling vpnservice, makeing other app to use vpnservice

issue releated: 
https://github.com/EasyTier/EasyTier/issues/1021 
https://github.com/EasyTier/EasyTier/issues/689



 ### 
1. 增加前台FOREGROUND_SERVICE的相关代码，避免应用进入后台后网络断开等问题
2. no_tun 模式(勾选socks5做代理)，只是一个普通的后台服务，不启动vpnservice，这样就能允许其他app使用vpnservice服务 

 实测2台安卓环境勾选了 enable-kcp-proxy 和use_smoltcp 能够p2p直连
 
