### PR TITLE
Support custom STUN servers configuration

### DIFF
--- a/easytier/src/arch/windows.rs
+++ b/easytier/src/arch/windows.rs
@@ -82,7 +82,7 @@ pub fn find_interface_index(iface_name: &str) -> io::Result<u32> {
     tracing::error!("Failed to find interface index for {}", iface_name);
     Err(io::Error::new(
         io::ErrorKind::NotFound,
-        format!("{}", iface_name),
+        iface_name.to_string(),
     ))
 }
 

--- a/easytier/src/common/global_ctx.rs
+++ b/easytier/src/common/global_ctx.rs
@@ -112,7 +112,12 @@ impl GlobalCtx {
 
         let (event_bus, _) = tokio::sync::broadcast::channel(8);
 
-        let stun_info_collection = Arc::new(StunInfoCollector::new_with_default_servers());
+        let stun_servers = config_fs.get_stun_servers();
+        let stun_info_collection = Arc::new(if stun_servers.is_empty() {
+            StunInfoCollector::new_with_default_servers()
+        } else {
+            StunInfoCollector::new(stun_servers)
+        });
 
         let enable_exit_node = config_fs.get_flags().enable_exit_node || cfg!(target_env = "ohos");
         let proxy_forward_by_system = config_fs.get_flags().proxy_forward_by_system;

--- a/easytier/src/common/ifcfg/win/types.rs
+++ b/easytier/src/common/ifcfg/win/types.rs
@@ -43,10 +43,9 @@ pub fn convert_ipv4addr_to_inaddr(ip: &Ipv4Addr) -> winapi::shared::inaddr::in_a
 pub fn convert_ipv6addr_to_inaddr(ip: &Ipv6Addr) -> winapi::shared::in6addr::in6_addr {
     let mut winaddr = winapi::shared::in6addr::in6_addr::default();
     let octets = ip.octets();
-    for i in 0..octets.len() {
+    for (i, _) in octets.iter().enumerate() {
         unsafe { winaddr.u.Byte_mut()[i] = octets[i] };
     }
-
     winaddr
 }
 

--- a/easytier/src/common/ifcfg/win/types.rs
+++ b/easytier/src/common/ifcfg/win/types.rs
@@ -44,7 +44,8 @@ pub fn convert_ipv6addr_to_inaddr(ip: &Ipv6Addr) -> winapi::shared::in6addr::in6
     let mut winaddr = winapi::shared::in6addr::in6_addr::default();
     let octets = ip.octets();
     for (i, _) in octets.iter().enumerate() {
-        unsafe { winaddr.u.Byte_mut()[i] = octets[i] };
+    for (i, &octet) in octets.iter().enumerate() {
+        unsafe { winaddr.u.Byte_mut()[i] = octet };
     }
     winaddr
 }

--- a/easytier/src/common/ifcfg/win/types.rs
+++ b/easytier/src/common/ifcfg/win/types.rs
@@ -43,7 +43,6 @@ pub fn convert_ipv4addr_to_inaddr(ip: &Ipv4Addr) -> winapi::shared::inaddr::in_a
 pub fn convert_ipv6addr_to_inaddr(ip: &Ipv6Addr) -> winapi::shared::in6addr::in6_addr {
     let mut winaddr = winapi::shared::in6addr::in6_addr::default();
     let octets = ip.octets();
-    for (i, _) in octets.iter().enumerate() {
     for (i, &octet) in octets.iter().enumerate() {
         unsafe { winaddr.u.Byte_mut()[i] = octet };
     }

--- a/easytier/src/common/ifcfg/windows.rs
+++ b/easytier/src/common/ifcfg/windows.rs
@@ -35,7 +35,7 @@ fn format_win_error(error: u32) -> String {
             null_mut(),
             error,
             0,
-            buffer.as_mut_ptr() as *mut u16,
+            buffer.as_mut_ptr(),
             size,
             null_mut(),
         );
@@ -43,9 +43,7 @@ fn format_win_error(error: u32) -> String {
     let str_end = buffer.iter().position(|&b| b == 0).unwrap_or(buffer.len());
     format!(
         "{} (code: {})",
-        String::from_utf16_lossy(&buffer[..str_end])
-            .trim()
-            .to_string(),
+        String::from_utf16_lossy(&buffer[..str_end]).trim(),
         error
     )
 }

--- a/easytier/src/common/stun.rs
+++ b/easytier/src/common/stun.rs
@@ -736,8 +736,8 @@ impl StunInfoCollector {
     }
 
     pub fn get_default_servers() -> Vec<String> {
-        // NOTICE: we may need to choose stun stun server based on geo location
-        // stun server cross nation may return a external ip address with high latency and loss rate
+        // NOTICE: we may need to choose stun server based on geolocation
+        // stun server cross nation may return an external ip address with high latency and loss rate
         [
             "txt:stun.easytier.cn",
             "stun.miwifi.com",

--- a/easytier/src/easytier-cli.rs
+++ b/easytier/src/easytier-cli.rs
@@ -2060,12 +2060,12 @@ mod win_service_manager {
             let service = self
                 .service_manager
                 .create_service(&service_info, ServiceAccess::ALL_ACCESS)
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+                .map_err(io::Error::other)?;
 
             if let Some(s) = description {
                 service
                     .set_description(s.clone())
-                    .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+                    .map_err(io::Error::other)?;
             }
 
             if let Some(work_dir) = ctx.working_directory {
@@ -2079,33 +2079,27 @@ mod win_service_manager {
             let service = self
                 .service_manager
                 .open_service(ctx.label.to_qualified_name(), ServiceAccess::ALL_ACCESS)
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+                .map_err(io::Error::other)?;
 
-            service
-                .delete()
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+            service.delete().map_err(io::Error::other)
         }
 
         fn start(&self, ctx: ServiceStartCtx) -> io::Result<()> {
             let service = self
                 .service_manager
                 .open_service(ctx.label.to_qualified_name(), ServiceAccess::ALL_ACCESS)
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+                .map_err(io::Error::other)?;
 
-            service
-                .start(&[] as &[&OsStr])
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+            service.start(&[] as &[&OsStr]).map_err(io::Error::other)
         }
 
         fn stop(&self, ctx: ServiceStopCtx) -> io::Result<()> {
             let service = self
                 .service_manager
                 .open_service(ctx.label.to_qualified_name(), ServiceAccess::ALL_ACCESS)
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+                .map_err(io::Error::other)?;
 
-            _ = service
-                .stop()
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            _ = service.stop().map_err(io::Error::other)?;
 
             Ok(())
         }
@@ -2117,10 +2111,7 @@ mod win_service_manager {
         fn set_level(&mut self, level: ServiceLevel) -> io::Result<()> {
             match level {
                 ServiceLevel::System => Ok(()),
-                _ => Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "Unsupported service level",
-                )),
+                _ => Err(io::Error::other("Unsupported service level")),
             }
         }
 
@@ -2136,13 +2127,11 @@ mod win_service_manager {
                             return Ok(ServiceStatus::NotInstalled);
                         }
                     }
-                    return Err(io::Error::new(io::ErrorKind::Other, e));
+                    return Err(io::Error::other(e));
                 }
             };
 
-            let status = service
-                .query_status()
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            let status = service.query_status().map_err(io::Error::other)?;
 
             match status.current_state {
                 windows_service::service::ServiceState::Stopped => Ok(ServiceStatus::Stopped(None)),

--- a/easytier/src/easytier-core.rs
+++ b/easytier/src/easytier-core.rs
@@ -555,6 +555,15 @@ struct NetworkOptions {
         default_missing_value = "true"
     )]
     enable_relay_foreign_network_kcp: Option<bool>,
+
+    #[arg(
+        long,
+        env = "ET_STUN_SERVERS",
+        value_delimiter = ',',
+        help = t!("core_clap.stun_servers").to_string(),
+        num_args = 0..
+    )]
+    stun_servers: Option<Vec<String>>,
 }
 
 #[derive(Parser, Debug)]
@@ -923,6 +932,10 @@ impl NetworkOptions {
         let mut old_udp_whitelist = cfg.get_udp_whitelist();
         old_udp_whitelist.extend(self.udp_whitelist.clone());
         cfg.set_udp_whitelist(old_udp_whitelist);
+
+        if let Some(stun_servers) = &self.stun_servers {
+            cfg.set_stun_servers(stun_servers.clone());
+        }
 
         Ok(())
     }

--- a/easytier/src/instance/dns_server/system_config/windows.rs
+++ b/easytier/src/instance/dns_server/system_config/windows.rs
@@ -39,7 +39,7 @@ impl InterfaceControl {
                 if matches!(e.kind(), io::ErrorKind::NotFound) {
                     Ok(()) // 忽略不存在的值
                 } else {
-                    Err(e.into())
+                    Err(e)
                 }
             }
         }
@@ -106,10 +106,7 @@ impl InterfaceControl {
             .output()
             .expect("failed to execute process");
         if !output.status.success() {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                "Failed to flush DNS cache",
-            ));
+            return Err(io::Error::other("Failed to flush DNS cache"));
         }
         Ok(())
     }
@@ -122,10 +119,7 @@ impl InterfaceControl {
             .output()
             .expect("failed to execute process");
         if !output.status.success() {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                "Failed to register DNS",
-            ));
+            return Err(io::Error::other("Failed to register DNS"));
         }
         Ok(())
     }

--- a/easytier/src/instance/virtual_nic.rs
+++ b/easytier/src/instance/virtual_nic.rs
@@ -399,7 +399,7 @@ impl VirtualNic {
                 Err(e) => {
                     println!("Failed to add Easytier to firewall allowlist, Subnet proxy and KCP proxy may not work properly. error: {}", e);
                     println!("You can add firewall rules manually, or use --use-smoltcp to run with user-space TCP/IP stack.");
-                    println!("");
+                    println!();
                 }
             }
 
@@ -409,7 +409,7 @@ impl VirtualNic {
             }
 
             if !dev_name.is_empty() {
-                config.tun_name(format!("{}", dev_name));
+                config.tun_name(&dev_name);
             } else {
                 use rand::distributions::Distribution as _;
                 let c = crate::arch::windows::interface_count()?;

--- a/easytier/src/utils.rs
+++ b/easytier/src/utils.rs
@@ -117,7 +117,7 @@ pub fn utf8_or_gbk_to_string(s: &[u8]) -> String {
         utf8_str
     } else {
         // 如果解码失败，则尝试使用GBK解码
-        if let Ok(gbk_str) = GBK.decode(&s, DecoderTrap::Strict) {
+        if let Ok(gbk_str) = GBK.decode(s, DecoderTrap::Strict) {
             gbk_str
         } else {
             String::from_utf8_lossy(s).to_string()


### PR DESCRIPTION
This patch adds the functionality to support a custom STUN server list configuration, allowing users to have full control over outgoing traffic.