### PR TITLE
Fix #1255: Using mimalloc for Linux LoongArch64

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -192,7 +192,7 @@ jobs:
             if [[ $OS =~ ^windows.*$ ]]; then
               SUFFIX=.exe
               CORE_FEATURES="--features=mimalloc"
-            elif [[ $TARGET =~ ^riscv64.*$ ]]; then
+            elif [[ $TARGET =~ ^riscv64.*$ || $TARGET =~ ^loongarch64.*$ ]]; then
               CORE_FEATURES="--features=mimalloc"
             else
               CORE_FEATURES="--features=jemalloc"


### PR DESCRIPTION
在 Loongson 3B6000 + AOSC OS 上进行了测试，换成 mimalloc 后工作正常，不再出现 `Unsupported system page size` 错误。