### PR TITLE
feat(gui): add macOS dock icon visibility control

### DIFF
--- a/easytier-gui/src-tauri/src/lib.rs
+++ b/easytier-gui/src-tauri/src/lib.rs
@@ -31,6 +31,23 @@ fn easytier_version() -> Result<String, String> {
 }
 
 #[tauri::command]
+fn set_dock_visibility(app: tauri::AppHandle, visible: bool) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        use tauri::ActivationPolicy;
+        app.set_activation_policy(if visible {
+            ActivationPolicy::Regular
+        } else {
+            ActivationPolicy::Accessory
+        })
+        .map_err(|e| e.to_string())?;
+    }
+    #[cfg(not(target_os = "macos"))]
+    let _ = (app, visible);
+    Ok(())
+}
+
+#[tauri::command]
 fn is_autostart() -> Result<bool, String> {
     let args: Vec<String> = std::env::args().collect();
     println!("{:?}", args);
@@ -243,7 +260,8 @@ pub fn run() {
             set_logging_level,
             set_tun_fd,
             is_autostart,
-            easytier_version
+            easytier_version,
+            set_dock_visibility
         ])
         .on_window_event(|_win, event| match event {
             #[cfg(not(target_os = "android"))]

--- a/easytier-gui/src/modules/dock_visibility.ts
+++ b/easytier-gui/src/modules/dock_visibility.ts
@@ -1,0 +1,18 @@
+import { invoke } from '@tauri-apps/api/core'
+
+export async function loadDockVisibilityAsync(visible: boolean): Promise<boolean> {
+  try {
+    await invoke('set_dock_visibility', { visible })
+    localStorage.setItem('dock_visibility', JSON.stringify(visible))
+    return visible
+  }
+  catch (e) {
+    console.error('Failed to set dock visibility:', e)
+    return getDockVisibilityStatus()
+  }
+}
+
+export function getDockVisibilityStatus(): boolean {
+  const stored = localStorage.getItem('dock_visibility')
+  return stored !== null ? JSON.parse(stored) : true
+}

--- a/easytier-gui/src/pages/index.vue
+++ b/easytier-gui/src/pages/index.vue
@@ -13,6 +13,7 @@ import { NetworkTypes, Config, Status, Utils, I18nUtils, ConfigEditDialog } from
 import { isAutostart, setLoggingLevel } from '~/composables/network'
 import { useTray } from '~/composables/tray'
 import { getAutoLaunchStatusAsync as getAutoLaunchStatus, loadAutoLaunchStatusAsync } from '~/modules/auto_launch'
+import { getDockVisibilityStatus, loadDockVisibilityAsync } from '~/modules/dock_visibility'
 
 const { t, locale } = useI18n()
 const visible = ref(false)
@@ -176,6 +177,14 @@ const setting_menu_items = ref([
     command: async () => {
       await loadAutoLaunchStatusAsync(!getAutoLaunchStatus())
     },
+  },
+  {
+    label: () => getDockVisibilityStatus() ? t('hide_dock_icon') : t('show_dock_icon'),
+    icon: 'pi pi-eye-slash',
+    command: async () => {
+      await loadDockVisibilityAsync(!getDockVisibilityStatus())
+    },
+    visible: () => type() === 'macos',
   },
   {
     label: () => t('logging'),

--- a/easytier-web/frontend-lib/src/locales/cn.yaml
+++ b/easytier-web/frontend-lib/src/locales/cn.yaml
@@ -44,6 +44,8 @@ logging_open_dir: 打开日志目录
 logging_copy_dir: 复制日志路径
 disable_auto_launch: 关闭开机自启
 enable_auto_launch: 开启开机自启
+hide_dock_icon: 隐藏 Dock 图标
+show_dock_icon: 显示 Dock 图标
 exit: 退出
 chips_placeholder: 例如： {0}, 输入后在下拉框中选择生效
 hostname_placeholder: '留空默认为主机名: {0}'

--- a/easytier-web/frontend-lib/src/locales/en.yaml
+++ b/easytier-web/frontend-lib/src/locales/en.yaml
@@ -44,6 +44,8 @@ logging_open_dir: Open Log Directory
 logging_copy_dir: Copy Log Path
 disable_auto_launch: Disable Launch on Reboot
 enable_auto_launch: Enable Launch on Reboot
+hide_dock_icon: Hide Dock Icon
+show_dock_icon: Show Dock Icon
 exit: Exit
 use_latency_first: Latency First Mode
 chips_placeholder: 'e.g: {0}, select from the dropdown after input'


### PR DESCRIPTION
### Motivation

在 macOS 平台上，Dock 通常用于放置用户频繁交互的主应用程序。对于像 EasyTier 这样需要长时间在后台运行的工具型应用，一个持久固定的 Dock 图标会造成不必要的空间占用和视觉干扰。

此 PR 旨在使 EasyTier 的行为与 macOS 平台上的其他主流网络及系统工具（例如 Tailscale, Dropbox 等）保持一致，允许用户通过菜单栏图标来管理应用，从而为 macOS 用户提供一个更原生、更简洁的用户体验。

### Solution

在 macOS 的菜单栏图标下拉菜单中增加了一个新的选项：“隐藏 Dock 图标 (Hide Dock Icon)”。

  - 当用户勾选此选项后，应用的 Dock 图标将被移除。
  - 应用会继续作为后台代理程序正常运行。
  - 用户可以随时取消勾选，以恢复 Dock 图标的显示。

技术上，该功能通过调用标准的 macOS `NSApplication.setActivationPolicy` API 在 `.regular` 和 `.accessory` 两种模式间切换来实现。所有代码变更均限定在 Darwin 平台相关的文件中，对 Windows 和 Linux 版本没有影响。

### 验证 (Verification)

  * **macOS:** 构建产物已在 **macOS 15.6.1** 版本上验证，功能可正常使用（Dock 图标的隐藏与显示），且不影响核心应用运行。
  * **Windows:** 已在最新版本的 **Windows 11** 中验证，“隐藏 Dock 图标”的选项被正确地隐藏，确认了此变更是MacOS平台特定的，没有引入回归问题。

### Demonstration

![PixPin_2025-09-02_15-30-39](https://github.com/user-attachments/assets/abe10409-343d-4f21-b70b-4d02a659d126)