### PR TITLE
core: hide default STUN servers from cli

### DIFF
--- a/easytier/src/common/config.rs
+++ b/easytier/src/common/config.rs
@@ -10,6 +10,7 @@ use cidr::IpCidr;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    common::stun::StunInfoCollector,
     proto::{
         acl::Acl,
         common::{CompressionAlgoPb, PortForwardConfigPb, SocketType},
@@ -833,6 +834,12 @@ impl ConfigLoader for TomlConfigLoader {
 
         let mut config = self.config.lock().unwrap().clone();
         config.flags = Some(flag_map);
+        if config.stun_servers == Some(StunInfoCollector::get_default_servers()) {
+            config.stun_servers = None;
+        }
+        if config.stun_servers_v6 == Some(StunInfoCollector::get_default_servers_v6()) {
+            config.stun_servers_v6 = None;
+        }
         toml::to_string_pretty(&config).unwrap()
     }
 }

--- a/easytier/src/easytier-core.rs
+++ b/easytier/src/easytier-core.rs
@@ -1071,7 +1071,13 @@ fn win_service_main(arg: Vec<std::ffi::OsString>) {
 
     _ = win_service_set_work_dir(&arg[0]);
 
-    let cli = Cli::parse();
+    let mut cli = Cli::parse();
+    if let Some(stun_servers) = &mut cli.network_options.stun_servers {
+        stun_servers.retain(|s| !s.trim().is_empty());
+    }
+    if let Some(stun_servers_v6) = &mut cli.network_options.stun_servers_v6 {
+        stun_servers_v6.retain(|s| !s.trim().is_empty());
+    }
 
     let stop_notify_send = Arc::new(Notify::new());
     let stop_notify_recv = Arc::clone(&stop_notify_send);
@@ -1279,7 +1285,16 @@ async fn main() -> ExitCode {
     set_prof_active(true);
     let _monitor = std::thread::spawn(memory_monitor);
 
-    let cli = Cli::parse();
+    let mut cli = Cli::parse();
+
+    // for --stun-servers="", we want vec![], but clap will give vec![""], hack for that
+    if let Some(stun_servers) = &mut cli.network_options.stun_servers {
+        stun_servers.retain(|s| !s.trim().is_empty());
+    }
+    if let Some(stun_servers_v6) = &mut cli.network_options.stun_servers_v6 {
+        stun_servers_v6.retain(|s| !s.trim().is_empty());
+    }
+
     if let Some(shell) = cli.gen_autocomplete {
         let mut cmd = Cli::command();
         easytier::print_completions(shell, &mut cmd, "easytier-core");


### PR DESCRIPTION
- Hide default STUN Server configuration from cli logs.
- Hack the clap output for empty Vec<>