### PR TITLE
cli: improve peer table display with shorter columns for small display

### DIFF
--- a/easytier/src/easytier-cli.rs
+++ b/easytier/src/easytier-cli.rs
@@ -484,12 +484,19 @@ impl CommandHandler<'_> {
             ipv4: String,
             hostname: String,
             cost: String,
+            #[tabled(rename = "lat")]
             lat_ms: String,
+            #[tabled(rename = "loss")]
             loss_rate: String,
+            #[tabled(rename = "rx")]
             rx_bytes: String,
+            #[tabled(rename = "tx")]
             tx_bytes: String,
+            #[tabled(rename = "tunnel")]
             tunnel_proto: String,
+            #[tabled(rename = "NAT")]
             nat_type: String,
+            #[tabled(skip)]
             id: String,
             version: String,
         }
@@ -511,7 +518,7 @@ impl CommandHandler<'_> {
                     } else {
                         route.path_latency_latency_first().to_string()
                     },
-                    loss_rate: float_to_str(p.get_loss_rate().unwrap_or(0.0), 3),
+                    loss_rate: format!("{:.1}%", p.get_loss_rate().unwrap_or(0.0) * 100.0),
                     rx_bytes: format_size(p.get_rx_bytes().unwrap_or(0), humansize::DECIMAL),
                     tx_bytes: format_size(p.get_tx_bytes().unwrap_or(0), humansize::DECIMAL),
                     tunnel_proto: p
@@ -1460,7 +1467,7 @@ where
 {
     match format {
         OutputFormat::Table => {
-            println!("{}", tabled::Table::new(items).with(Style::modern()));
+            println!("{}", tabled::Table::new(items).with(Style::markdown()));
         }
         OutputFormat::Json => {
             println!("{}", serde_json::to_string_pretty(items)?);
@@ -1752,7 +1759,7 @@ async fn main() -> Result<(), Error> {
                         builder.push_record(vec![format!("Listener {}", idx).as_str(), l]);
                     }
 
-                    println!("{}", builder.build().with(Style::modern()));
+                    println!("{}", builder.build().with(Style::markdown()));
                 }
                 Some(NodeSubCommand::Config) => {
                     println!("{}", node_info.config);

--- a/easytier/src/easytier-cli.rs
+++ b/easytier/src/easytier-cli.rs
@@ -518,7 +518,7 @@ impl CommandHandler<'_> {
                         .unwrap_or_default(),
                     hostname: route.hostname.clone(),
                     cost: cost_to_str(route.cost),
-                    lat_ms: format!("{:>7.2}", lat_ms),
+                    lat_ms: format!("{:.2}", lat_ms),
                     loss_rate: format!("{:.1}%", p.get_loss_rate().unwrap_or(0.0) * 100.0),
                     rx_bytes: format_size(p.get_rx_bytes().unwrap_or(0), humansize::DECIMAL),
                     tx_bytes: format_size(p.get_tx_bytes().unwrap_or(0), humansize::DECIMAL),


### PR DESCRIPTION
- Add short column names for latency, loss rate, rx/tx bytes, tunnel protocol and NAT type
- Format loss rate as percentage with one decimal place
- Change table style from modern to markdown for better readability