### PR TITLE
Fix jemalloc warning on macOS

### DIFF
--- a/easytier/Cargo.toml
+++ b/easytier/Cargo.toml
@@ -258,9 +258,15 @@ jemallocator = { package = "tikv-jemallocator", version = "0.6.0", optional = tr
 ] }
 jemalloc-ctl = { package = "tikv-jemalloc-ctl", version = "0.6.0", optional = true, features = [
 ] }
+
+[target.'cfg(not(target_os = "macos"))'.dependencies]
 jemalloc-sys = { package = "tikv-jemalloc-sys", version = "0.6.0", features = [
     "background_threads_runtime_support",
     "background_threads",
+], optional = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+jemalloc-sys = { package = "tikv-jemalloc-sys", version = "0.6.0", features = [
 ], optional = true }
 
 [build-dependencies]


### PR DESCRIPTION
```
-> % easytier-core
<jemalloc>: option background_thread currently supports pthread only
```

```
-> % uname -a
Darwin Mac-mini 24.6.0 Darwin Kernel Version 24.6.0:
Mon Jul 14 11:30:40 PDT 2025;
root:xnu-11417.140.69~1/RELEASE_ARM64_T8132 arm64
```

Reference: https://github.com/apache/arrow/pull/5729