### PR TITLE
refactor: change magicdns to internal redirect

### DIFF
--- a/easytier/src/instance/dns_server/server_instance.rs
+++ b/easytier/src/instance/dns_server/server_instance.rs
@@ -471,7 +471,7 @@ impl MagicDnsServerInstance {
         tun_inet: Ipv4Inet,
         fake_ip: Ipv4Addr,
     ) -> Result<Self, anyhow::Error> {
-        let tcp_listener = TcpTunnelListener::new(MAGIC_DNS_INSTANCE_ADDR.parse().unwrap());
+        let tcp_listener = TcpTunnelListener::new(MAGIC_DNS_INSTANCE_ADDR.parse()?);
         let mut rpc_server = StandAloneServer::new(tcp_listener);
         rpc_server.serve().await?;
 
@@ -482,12 +482,10 @@ impl MagicDnsServerInstance {
                 GeneralConfigBuilder::default()
                     .listen_udp(format!("{}:0", bind_addr))
                     .listen_tcp(format!("{}:0", bind_addr))
-                    .build()
-                    .unwrap(),
+                    .build()?,
             )
             .excluded_forward_nameservers(vec![fake_ip.into()])
-            .build()
-            .unwrap();
+            .build()?;
         let mut dns_server = Server::new(dns_config);
         dns_server.run().await?;
 

--- a/easytier/src/instance/dns_server/server_instance.rs
+++ b/easytier/src/instance/dns_server/server_instance.rs
@@ -323,11 +323,18 @@ impl MagicDnsServerInstanceData {
             let udp_packet = UdpPacket::new(&zc_packet.payload()[ip_header_length..])?;
 
             let src_port = udp_packet.get_source();
+            let dst_port = udp_packet.get_destination();
+            
+            // Remove this to support any UDP port
+            if dst_port != 53 {
+                return None;
+            }
+            
             let request_payload = udp_packet.payload();
 
             (
                 src_port,
-                udp_packet.get_destination(),
+                dst_port,
                 Request::new(
                     MessageRequest::from_bytes(request_payload).ok()?,
                     SocketAddr::from(SocketAddrV4::new(src_ip, src_port)),

--- a/easytier/src/instance/dns_server/server_instance.rs
+++ b/easytier/src/instance/dns_server/server_instance.rs
@@ -485,15 +485,8 @@ impl MagicDnsServerInstance {
         let mut rpc_server = StandAloneServer::new(tcp_listener);
         rpc_server.serve().await?;
 
-        let bind_addr = tun_inet.address();
-
         let dns_config = RunConfigBuilder::default()
-            .general(
-                GeneralConfigBuilder::default()
-                    .listen_udp(format!("{}:0", bind_addr))
-                    .listen_tcp(format!("{}:0", bind_addr))
-                    .build()?,
-            )
+            .general(GeneralConfigBuilder::default().build()?)
             .excluded_forward_nameservers(vec![fake_ip.into()])
             .build()?;
         let mut dns_server = Server::new(dns_config);

--- a/easytier/src/instance/dns_server/server_instance.rs
+++ b/easytier/src/instance/dns_server/server_instance.rs
@@ -165,6 +165,14 @@ impl MagicDnsServerRpc for MagicDnsServerInstanceData {
         Ok(Default::default())
     }
 
+    async fn heartbeat(
+        &self,
+        _ctrl: Self::Controller,
+        _input: Void,
+    ) -> crate::proto::rpc_types::error::Result<Void> {
+        Ok(Default::default())
+    }
+
     async fn update_dns_record(
         &self,
         ctrl: Self::Controller,
@@ -209,14 +217,6 @@ impl MagicDnsServerRpc for MagicDnsServerInstanceData {
         }
         Ok(GetDnsRecordResponse { records: ret })
     }
-
-    async fn heartbeat(
-        &self,
-        _ctrl: Self::Controller,
-        _input: Void,
-    ) -> crate::proto::rpc_types::error::Result<Void> {
-        Ok(Default::default())
-    }
 }
 
 // This should only be used for UDP response.
@@ -259,7 +259,7 @@ impl ResponseHandler for ResponseWrapper {
         encoder.set_max_size(max_size);
         response
             .destructive_emit(&mut encoder)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+            .map_err(|e| io::Error::new(ErrorKind::Other, e))
     }
 }
 

--- a/easytier/src/instance/dns_server/server_instance.rs
+++ b/easytier/src/instance/dns_server/server_instance.rs
@@ -1,4 +1,4 @@
-// single-instance server in one machine, every easytier instance that has ip address and tun device will try create a server instance.
+// single-instance server in one machine, every easytier instance that has ip address and tun device will try to create a server instance.
 
 // magic dns client will connect to this server to update the dns records.
 // magic dns server will add the dns server ip address to the tun device, and forward the dns request to the dns server
@@ -121,7 +121,7 @@ impl MagicDnsServerInstanceData {
         self.dns_server
             .upsert(
                 LowerName::from_str(zone)
-                    .with_context(|| "Invalid zone name, expect fomat like \"et.net.\"")?,
+                    .with_context(|| "Invalid zone name, expect format like \"et.net.\"")?,
                 Arc::new(authority),
             )
             .await;

--- a/easytier/src/instance/dns_server/server_instance.rs
+++ b/easytier/src/instance/dns_server/server_instance.rs
@@ -54,7 +54,6 @@ use pnet::packet::{
     udp::{self, MutableUdpPacket},
     MutablePacket, Packet,
 };
-use std::io::ErrorKind;
 use std::net::{SocketAddr, SocketAddrV4};
 use std::sync::Mutex;
 use std::{collections::BTreeMap, io, net::Ipv4Addr, str::FromStr, sync::Arc, time::Duration};
@@ -324,12 +323,12 @@ impl MagicDnsServerInstanceData {
 
             let src_port = udp_packet.get_source();
             let dst_port = udp_packet.get_destination();
-            
+
             // Remove this to support any UDP port
             if dst_port != 53 {
                 return None;
             }
-            
+
             let request_payload = udp_packet.payload();
 
             (

--- a/easytier/src/instance/dns_server/server_instance.rs
+++ b/easytier/src/instance/dns_server/server_instance.rs
@@ -245,9 +245,9 @@ impl ResponseHandler for ResponseWrapper {
         let mut buffer = self
             .response
             .lock()
-            .map_err(|_| io::Error::new(ErrorKind::Other, "lock poisoned"))?;
+            .map_err(|_| io::Error::other("lock poisoned"))?;
 
-        let mut encoder = BinEncoder::new(&mut *buffer);
+        let mut encoder = BinEncoder::new(&mut  buffer);
 
         // `max_size` should be u16::MAX for protocol other than UDP.
         let max_size = if let Some(edns) = response.get_edns() {
@@ -259,7 +259,7 @@ impl ResponseHandler for ResponseWrapper {
         encoder.set_max_size(max_size);
         response
             .destructive_emit(&mut encoder)
-            .map_err(|e| io::Error::new(ErrorKind::Other, e))
+            .map_err(|e| io::Error::other(e))
     }
 }
 

--- a/easytier/src/instance/dns_server/server_instance.rs
+++ b/easytier/src/instance/dns_server/server_instance.rs
@@ -218,6 +218,8 @@ impl MagicDnsServerRpc for MagicDnsServerInstanceData {
     }
 }
 
+// This should only be used for UDP response.
+// For other protocols, the variable `max_size` in `send_response` should be u16::MAX.
 #[derive(Clone)]
 pub struct ResponseWrapper {
     response: Arc<Mutex<Vec<u8>>>,
@@ -246,6 +248,7 @@ impl ResponseHandler for ResponseWrapper {
 
         let mut encoder = BinEncoder::new(&mut *buffer);
 
+        // `max_size` should be u16::MAX for protocol other than UDP.
         let max_size = if let Some(edns) = response.get_edns() {
             edns.max_payload()
         } else {

--- a/easytier/src/instance/dns_server/server_instance.rs
+++ b/easytier/src/instance/dns_server/server_instance.rs
@@ -258,7 +258,7 @@ impl ResponseHandler for ResponseWrapper {
         encoder.set_max_size(max_size);
         response
             .destructive_emit(&mut encoder)
-            .map_err(|e| io::Error::other(e))
+            .map_err(io::Error::other)
     }
 }
 

--- a/easytier/src/instance/dns_server/server_instance.rs
+++ b/easytier/src/instance/dns_server/server_instance.rs
@@ -246,7 +246,7 @@ impl ResponseHandler for ResponseWrapper {
             .lock()
             .map_err(|_| io::Error::other("lock poisoned"))?;
 
-        let mut encoder = BinEncoder::new(&mut  buffer);
+        let mut encoder = BinEncoder::new(&mut buffer);
 
         // `max_size` should be u16::MAX for protocol other than UDP.
         let max_size = if let Some(edns) = response.get_edns() {


### PR DESCRIPTION
为解决 resolve #1419 ，在内部直接读取 DNS 请求包并发回响应，而不是转发给监听端口。

- fake_ip (100.100.100.101) 上的 DNS 服务不再支持 DNS-over-TCP
- ~~现在可以向 fake_ip 的任意 UDP 端口请求 DNS~~
- ~~暂时保留 hickory-dns 对 tun_ip 动态端口的监听，未来可以作为可选功能，让 DNS 服务器监听指定 IP/端口~~