### PR TITLE
refactor: get_running_info fn replace status polling with direct calls

### DIFF
--- a/easytier-contrib/easytier-ffi/src/lib.rs
+++ b/easytier-contrib/easytier-ffi/src/lib.rs
@@ -202,7 +202,7 @@ pub unsafe extern "C" fn collect_network_infos(
         std::slice::from_raw_parts_mut(infos, max_length)
     };
 
-    let collected_infos = match INSTANCE_MANAGER.collect_network_infos() {
+    let collected_infos = match INSTANCE_MANAGER.collect_network_infos_sync() {
         Ok(infos) => infos,
         Err(e) => {
             set_error_msg(&format!("failed to collect network infos: {}", e));

--- a/easytier-contrib/easytier-uptime/src/health_checker.rs
+++ b/easytier-contrib/easytier-uptime/src/health_checker.rs
@@ -497,7 +497,7 @@ impl HealthChecker {
         instance_mgr: Arc<NetworkInstanceManager>,
         // return version, response time on healthy, conn_count
     ) -> anyhow::Result<(String, u64, u32)> {
-        let Some(instance) = instance_mgr.get_network_info(&inst_id) else {
+        let Some(instance) = instance_mgr.get_network_info(&inst_id).await else {
             anyhow::bail!("healthy check node is not started");
         };
 

--- a/easytier-gui/src-tauri/src/lib.rs
+++ b/easytier-gui/src-tauri/src/lib.rs
@@ -93,9 +93,10 @@ fn retain_network_instance(instance_ids: Vec<String>) -> Result<(), String> {
 }
 
 #[tauri::command]
-fn collect_network_infos() -> Result<BTreeMap<String, NetworkInstanceRunningInfo>, String> {
+async fn collect_network_infos() -> Result<BTreeMap<String, NetworkInstanceRunningInfo>, String> {
     let infos = INSTANCE_MANAGER
         .collect_network_infos()
+        .await
         .map_err(|e| e.to_string())?;
 
     let mut ret = BTreeMap::new();

--- a/easytier/src/easytier-core.rs
+++ b/easytier/src/easytier-core.rs
@@ -1218,7 +1218,7 @@ async fn run_main(cli: Cli) -> anyhow::Result<()> {
 
     tokio::select! {
         _ = manager.wait() => {
-            let infos = manager.collect_network_infos()?;
+            let infos = manager.collect_network_infos().await?;
             let errs = infos
                 .into_values()
                 .filter_map(|info| info.error_msg)

--- a/easytier/src/peers/rpc_service.rs
+++ b/easytier/src/peers/rpc_service.rs
@@ -7,8 +7,9 @@ use crate::{
     proto::{
         api::instance::{
             AclManageRpc, DumpRouteRequest, DumpRouteResponse, GetAclStatsRequest,
-            GetAclStatsResponse, GetWhitelistRequest, GetWhitelistResponse,
-            ListForeignNetworkRequest, ListForeignNetworkResponse, ListGlobalForeignNetworkRequest,
+            GetAclStatsResponse, GetForeignNetworkSummaryRequest, GetForeignNetworkSummaryResponse,
+            GetWhitelistRequest, GetWhitelistResponse, ListForeignNetworkRequest,
+            ListForeignNetworkResponse, ListGlobalForeignNetworkRequest,
             ListGlobalForeignNetworkResponse, ListPeerRequest, ListPeerResponse, ListRouteRequest,
             ListRouteResponse, PeerInfo, PeerManageRpc, ShowNodeInfoRequest, ShowNodeInfoResponse,
         },
@@ -137,6 +138,20 @@ impl PeerManageRpc for PeerManagerRpcService {
         Ok(weak_upgrade(&self.peer_manager)?
             .list_global_foreign_network()
             .await)
+    }
+
+    async fn get_foreign_network_summary(
+        &self,
+        _: BaseController,
+        _request: GetForeignNetworkSummaryRequest,
+    ) -> Result<GetForeignNetworkSummaryResponse, rpc_types::error::Error> {
+        Ok(GetForeignNetworkSummaryResponse {
+            summary: Some(
+                weak_upgrade(&self.peer_manager)?
+                    .get_foreign_network_summary()
+                    .await,
+            ),
+        })
     }
 
     async fn show_node_info(

--- a/easytier/src/proto/api_config.proto
+++ b/easytier/src/proto/api_config.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 import "common.proto";
 import "acl.proto";
 import "api_instance.proto";
+import "api_manage.proto";
 
 package api.config;
 
@@ -69,6 +70,15 @@ message PatchConfigRequest {
 
 message PatchConfigResponse {}
 
+message GetConfigRequest {
+  api.instance.InstanceIdentifier instance = 1;
+}
+
+message GetConfigResponse {
+  api.manage.NetworkConfig config = 1;
+}
+
 service ConfigRpc {
   rpc PatchConfig(PatchConfigRequest) returns (PatchConfigResponse);
+  rpc GetConfig(GetConfigRequest) returns (GetConfigResponse);
 }

--- a/easytier/src/proto/api_instance.proto
+++ b/easytier/src/proto/api_instance.proto
@@ -139,6 +139,12 @@ message ListGlobalForeignNetworkResponse {
   map<uint32, ForeignNetworks> foreign_networks = 1;
 }
 
+message GetForeignNetworkSummaryRequest { InstanceIdentifier instance = 1; }
+
+message GetForeignNetworkSummaryResponse {
+  peer_rpc.RouteForeignNetworkSummary summary = 1;
+}
+
 service PeerManageRpc {
   rpc ListPeer(ListPeerRequest) returns (ListPeerResponse);
   rpc ListRoute(ListRouteRequest) returns (ListRouteResponse);
@@ -148,6 +154,8 @@ service PeerManageRpc {
   rpc ListGlobalForeignNetwork(ListGlobalForeignNetworkRequest)
       returns (ListGlobalForeignNetworkResponse);
   rpc ShowNodeInfo(ShowNodeInfoRequest) returns (ShowNodeInfoResponse);
+  rpc GetForeignNetworkSummary(GetForeignNetworkSummaryRequest)
+      returns (GetForeignNetworkSummaryResponse);
 }
 
 enum ConnectorStatus {

--- a/easytier/src/rpc_service/config.rs
+++ b/easytier/src/rpc_service/config.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use crate::{
     instance_manager::NetworkInstanceManager,
     proto::{
-        api::config::{ConfigRpc, PatchConfigRequest, PatchConfigResponse},
+        api::config::{
+            ConfigRpc, GetConfigRequest, GetConfigResponse, PatchConfigRequest, PatchConfigResponse,
+        },
         rpc_types::{self, controller::BaseController},
     },
 };
@@ -31,6 +33,17 @@ impl ConfigRpc for ConfigRpcService {
         super::get_instance_service(&self.instance_manager, &input.instance)?
             .get_config_service()
             .patch_config(ctrl, input)
+            .await
+    }
+
+    async fn get_config(
+        &self,
+        ctrl: Self::Controller,
+        input: GetConfigRequest,
+    ) -> Result<GetConfigResponse, rpc_types::error::Error> {
+        super::get_instance_service(&self.instance_manager, &input.instance)?
+            .get_config_service()
+            .get_config(ctrl, input)
             .await
     }
 }

--- a/easytier/src/rpc_service/instance_manage.rs
+++ b/easytier/src/rpc_service/instance_manage.rs
@@ -76,7 +76,8 @@ impl WebClientService for InstanceManageRpcService {
         let mut ret = NetworkInstanceRunningInfoMap {
             map: self
                 .manager
-                .collect_network_infos()?
+                .collect_network_infos()
+                .await?
                 .into_iter()
                 .map(|(k, v)| (k.to_string(), v))
                 .collect(),

--- a/easytier/src/rpc_service/peer_manage.rs
+++ b/easytier/src/rpc_service/peer_manage.rs
@@ -78,6 +78,17 @@ impl PeerManageRpc for PeerManageRpcService {
             .await
     }
 
+    async fn get_foreign_network_summary(
+        &self,
+        ctrl: Self::Controller,
+        req: crate::proto::api::instance::GetForeignNetworkSummaryRequest,
+    ) -> crate::proto::rpc_types::error::Result<instance::GetForeignNetworkSummaryResponse> {
+        super::get_instance_service(&self.instance_manager, &req.instance)?
+            .get_peer_manage_service()
+            .get_foreign_network_summary(ctrl, req)
+            .await
+    }
+
     async fn show_node_info(
         &self,
         ctrl: Self::Controller,


### PR DESCRIPTION
## get_running_info废除状态获取轮询，改用方法直接调用

### 概述

本次变更旨在优化应用内的状态获取机制。旧的实现依赖于在 `EasyTierLauncher` 中运行一个后台任务，通过轮询方式持续获取和缓存节点状态（如节点信息、路由、Peer列表等）。这种方式会造成不必要的资源消耗，并且存在数据延迟的可能。

为了解决这些问题，我们废除了轮询机制，重构为通过 RPC 服务进行按需、直接的方法调用来获取最新状态。这一改动统一了状态获取的渠道，简化了内部逻辑，并显著提升了应用的性能和响应速度。

### 主要变更

1. 移除后台状态轮询任务:
   - 删除了在 `EasyTierLauncher` 中用于定期刷新节点、路由和 Peer 信息的后台任务。
   - 移除了依赖此缓存机制的直接状态获取方法（如 `get_node_info`, `get_peers`, `get_routes` 等）。

2. 实现基于 RPC 的按需状态获取:
   - `NetworkInstance::get_running_info` 方法被修改为 `async` 函数。
   - 现在它通过调用实例的 `api_service` (RPC 接口) 来实时获取运行信息，确保了数据的一致性和实时性。

3. 扩展 RPC API 以支持新模式:
   - 在 `PeerManageRpc` 服务中新增了 `GetForeignNetworkSummary` 接口。
   - 在 `ConfigRpc` 服务中新增了 `GetConfig` 接口。
   - 相关的 `.proto` 文件和 RPC 服务实现也已同步更新，以支持新的数据查询需求。

4. 核心服务适配:
   - `InstanceManager::collect_network_infos` 方法调整为 `async`，以支持异步获取所有实例的信息。
   - 更新了 RPC 服务实现，以支持新的 API 调用。


### 带来的好处

- __架构简化__: 移除了复杂的状态缓存和轮询逻辑，使得 `EasyTierLauncher` 的职责更单一。
- __性能提升__: 变更为按需获取数据，避免了后台任务的持续轮询，降低了 CPU 和内存的使用。

### 集成测试
- 已测试连接到web后，各功能正常。
- FFI和GUI未测试，理论上不受影响。