### PR TITLE
fix(ohrs): update collect_network_infos to use synchronous method

### DIFF
--- a/easytier-contrib/easytier-ohrs/src/lib.rs
+++ b/easytier-contrib/easytier-ohrs/src/lib.rs
@@ -92,7 +92,7 @@ pub fn stop_network_instance(inst_names: Vec<String>) {
 #[napi]
 pub fn collect_network_infos() -> Vec<KeyValuePair> {
     let mut result = Vec::new();
-    match INSTANCE_MANAGER.collect_network_infos() {
+    match INSTANCE_MANAGER.collect_network_infos_sync() {
         Ok(map) => {
             for (uuid, info) in map.iter() {
                 // convert value to json string


### PR DESCRIPTION
修复由于 #1441 中将NetworkInstanceManager::collect_network_infos改为异步方法导致 ohrs 构建失败的问题