### PR TITLE
fix(acl): acl group cache add self group info

### DIFF
--- a/easytier/src/peers/peer_ospf_route.rs
+++ b/easytier/src/peers/peer_ospf_route.rs
@@ -707,6 +707,18 @@ impl SyncedRouteInfo {
             }
         }
     }
+
+    fn update_my_group_trusts(&self, my_peer_id: PeerId, global_ctx: &ArcGlobalCtx) {
+        let mut my_group_map = HashMap::new();
+        let mut my_group_names = Vec::new();
+        for group in global_ctx.get_acl_groups(my_peer_id) {
+            my_group_map.insert(group.group_name.clone(), group.group_proof);
+            my_group_names.push(group.group_name);
+        }
+        self.group_trust_map.insert(my_peer_id, my_group_map);
+        self.group_trust_map_cache
+            .insert(my_peer_id, Arc::new(my_group_names));
+    }
 }
 
 type PeerGraph = Graph<PeerId, usize, Directed>;
@@ -2145,6 +2157,9 @@ impl RouteSessionManager {
                     peer_infos,
                     &service_impl.global_ctx.get_acl_group_declarations(),
                 );
+            service_impl
+                .synced_route_info
+                .update_my_group_trusts(my_peer_id, &service_impl.global_ctx);
             session.update_dst_saved_peer_info_version(peer_infos);
             need_update_route_table = true;
         }

--- a/easytier/src/peers/peer_ospf_route.rs
+++ b/easytier/src/peers/peer_ospf_route.rs
@@ -525,6 +525,7 @@ impl SyncedRouteInfo {
         let new_version = new.version;
         let old_version = old.version;
         *old = new;
+        drop(old);
 
         if new_version != old_version {
             self.update_my_group_trusts(my_peer_id);


### PR DESCRIPTION
问题: 当 ACL 入站规则的目标组或出站规则的来源组被设置时，该规则无法被正确匹配，导致ACL策略失效。
原因: ACL 组的缓存信息中，未包含该组自身的数据，使得在规则匹配时无法识别自己。
修复: 已修复此问题，但节点信息更新时，同时将自身组信息更新进缓存中，确保 ACL 组的缓存信息总是包含其自身，保障规则匹配的准确性。

close #1443