### PR TITLE
feat: add support for secure TLS client configuration based on URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,6 +2186,7 @@ dependencies = [
  "rstest",
  "rust-i18n",
  "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_json",
  "serial_test",

--- a/easytier/Cargo.toml
+++ b/easytier/Cargo.toml
@@ -216,6 +216,7 @@ multimap = "0.10.0"
 version-compare = "0.2.0"
 hmac = "0.12.1"
 sha2 = "0.10.8"
+rustls-native-certs = "0.8.1"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows", target_os = "freebsd"))'.dependencies]
 machine-uid = "0.5.3"

--- a/easytier/src/gateway/quic_proxy.rs
+++ b/easytier/src/gateway/quic_proxy.rs
@@ -113,9 +113,12 @@ impl NatDstConnector for NatDstQUICConnector {
             return Err(anyhow::anyhow!("no quic port found for dst peer: {}", dst_peer).into());
         };
 
+        let quic_url = format!("quic://{}:{}", dst_ipv4, quic_port);
+        let url = url::Url::parse(&quic_url).unwrap();
+
         let mut endpoint = Endpoint::client("0.0.0.0:0".parse().unwrap())
             .with_context(|| format!("failed to create QUIC endpoint for src: {}", src))?;
-        endpoint.set_default_client_config(configure_client());
+        endpoint.set_default_client_config(configure_client(&url));
 
         // connect to server
         let connection = {
@@ -123,7 +126,7 @@ impl NatDstConnector for NatDstQUICConnector {
             endpoint
                 .connect(
                     SocketAddr::new(dst_ipv4.into(), quic_port as u16),
-                    "localhost",
+                    url.host_str().unwrap_or("localhost"),
                 )
                 .unwrap()
                 .await

--- a/easytier/src/tunnel/websocket.rs
+++ b/easytier/src/tunnel/websocket.rs
@@ -12,7 +12,7 @@ use tokio_websockets::{ClientBuilder, Limits, MaybeTlsStream, Message};
 use zerocopy::AsBytes;
 
 use super::TunnelInfo;
-use crate::tunnel::insecure_tls::get_insecure_tls_client_config;
+use crate::tunnel::insecure_tls::get_tls_client_config_by_url;
 
 use super::{
     common::{setup_sokcet2, wait_for_connect_futures, TunnelWrapper},
@@ -199,9 +199,8 @@ impl WSTunnelConnector {
 
         let c = ClientBuilder::from_uri(http::Uri::try_from(addr.to_string()).unwrap());
         let stream: MaybeTlsStream<TcpStream> = if is_wss {
-            init_crypto_provider();
             let tls_conn =
-                tokio_rustls::TlsConnector::from(Arc::new(get_insecure_tls_client_config()));
+                tokio_rustls::TlsConnector::from(Arc::new(get_tls_client_config_by_url(&addr)));
             // Modify SNI logic: use "localhost" as SNI for url without domain to avoid IP blocking.
             let sni = match addr.domain() {
                 None => "localhost".to_string(),


### PR DESCRIPTION
### 添加TLS 证书验证支持

本次更新旨在增强 `QUIC` 和 `WebSocket (WSS)` 连接的安全性。在此之前，所有 TLS 连接都默认跳过服务器证书验证，这可能导致中间人攻击（MITM）的风险。

为了解决这个问题，我们引入了默认的证书验证机制，同时保留了在特定场景下使用不安全连接的灵活性。

#### 主要变更

1.  **动态 TLS 配置**:
    *   新增 `get_tls_client_config_by_url` 函数，该函数会根据 URL 的特征动态选择 TLS 客户端配置。
    *   **默认行为**: 当连接到域名时，将使用 `rustls-native-certs` 加载系统内置的根证书，并对服务器证书进行严格验证。
    *   **例外情况**: 在以下情况下，将自动切换到不安全的 TLS 模式（跳过证书验证）：
        *   连接目标是 IP 地址（因为证书通常不会颁发给 IP）。
        *   连接 URL 中明确包含 `insecure=1` 查询参数。

2.  **QUIC 和 WebSocket (WSS) 更新**:
    *   `QUIC` 和 `WSS` 的连接器现在使用上述动态配置逻辑。
    *   修复了 `QUIC` 连接中服务器名称指示（SNI）未正确设置的问题，现在会根据 URL 的主机名自动设置，确保多域名服务器的证书验证正确。

3.  **依赖项**:
    *   添加了 `rustls-native-certs` 依赖，用于访问系统根证书库。

#### 集成测试
- [x] `easytier-core` 使用 `wss` 连接到 由cloudflare tunnel反代到使用`ws`的`easytier-web`，验证证书通过，并能够正常使用。


这些变更显著提升了 EasyTier 的默认安全性，使其符合现代网络安全标准，同时保留了必要的向前兼容性。
