### PR TITLE
feat: add support for secure TLS client configuration based on URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,6 +2186,7 @@ dependencies = [
  "rstest",
  "rust-i18n",
  "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_json",
  "serial_test",

--- a/easytier/Cargo.toml
+++ b/easytier/Cargo.toml
@@ -216,6 +216,7 @@ multimap = "0.10.0"
 version-compare = "0.2.0"
 hmac = "0.12.1"
 sha2 = "0.10.8"
+rustls-native-certs = "0.8.1"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows", target_os = "freebsd"))'.dependencies]
 machine-uid = "0.5.3"

--- a/easytier/src/tunnel/insecure_tls.rs
+++ b/easytier/src/tunnel/insecure_tls.rs
@@ -84,3 +84,62 @@ pub fn get_insecure_tls_cert<'a>() -> (Vec<CertificateDer<'a>>, PrivateKeyDer<'a
 
     (cert_chain, priv_key.into())
 }
+
+fn get_secure_tls_client_config() -> rustls::ClientConfig {
+    init_crypto_provider();
+    let mut root_store = rustls::RootCertStore::empty();
+    let certs = rustls_native_certs::load_native_certs().expect("could not load system certs");
+    root_store.add_parsable_certificates(certs);
+
+    rustls::ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth()
+}
+
+pub fn get_tls_client_config_by_url(url: &url::Url) -> rustls::ClientConfig {
+    let is_insecure = url.query_pairs().any(|(k, v)| k == "insecure" && v == "1");
+    let host_is_ip = match url.host() {
+        Some(url::Host::Ipv4(_)) => true,
+        Some(url::Host::Ipv6(_)) => true,
+        Some(url::Host::Domain(host)) => host.parse::<std::net::IpAddr>().is_ok(),
+        None => false,
+    };
+
+    if is_insecure || host_is_ip {
+        get_insecure_tls_client_config()
+    } else {
+        get_secure_tls_client_config()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    use url::Url;
+
+    #[rstest]
+    #[case("wss://127.0.0.1", true, "localhost")] // host is ipv4, should be insecure
+    #[case("wss://[::1]", true, "localhost")] // host is ipv6, should be insecure
+    #[case("quic://127.0.0.1", true, "127.0.0.1")] // host is ipv4, should be insecure
+    #[case("quic://[::1]", true, "localhost")] // host is ipv6, should be insecure
+    #[case("wss://example.com", false, "example.com")] // host is domain, no insecure=1, should be secure
+    #[case("wss://example.com?insecure=1", true, "example.com")] // insecure=1, should be insecure
+    fn test_get_tls_client_config_by_url(
+        #[case] url: Url,
+        #[case] expect_insecure: bool,
+        #[case] expect_domain: &str,
+    ) {
+        let expect_config = if expect_insecure {
+            get_insecure_tls_client_config()
+        } else {
+            get_secure_tls_client_config()
+        };
+        // let url = Url::parse(url_str).unwrap();
+        let config = get_tls_client_config_by_url(&url);
+        assert_eq!(format!("{:?}", config), format!("{:?}", expect_config));
+
+        let domain = ServerName::try_from(url.domain().unwrap_or("localhost")).unwrap();
+        assert_eq!(domain.to_str(), expect_domain);
+    }
+}

--- a/easytier/src/tunnel/quic.rs
+++ b/easytier/src/tunnel/quic.rs
@@ -19,12 +19,12 @@ use quinn::{
 
 use super::{
     check_scheme_and_get_socket_addr,
-    insecure_tls::{get_insecure_tls_cert, get_insecure_tls_client_config},
+    insecure_tls::{get_insecure_tls_cert, get_tls_client_config_by_url},
     IpVersion, Tunnel, TunnelConnector, TunnelError, TunnelListener,
 };
 
-pub fn configure_client() -> ClientConfig {
-    let client_crypto = QuicClientConfig::try_from(get_insecure_tls_client_config()).unwrap();
+pub fn configure_client(url: &url::Url) -> ClientConfig {
+    let client_crypto = QuicClientConfig::try_from(get_tls_client_config_by_url(url)).unwrap();
     let mut client_config = ClientConfig::new(Arc::new(client_crypto));
 
     // // Create a new TransportConfig and set BBR
@@ -251,11 +251,13 @@ impl TunnelConnector for QUICTunnelConnector {
         };
 
         let mut endpoint = Endpoint::client(local_addr.parse().unwrap())?;
-        endpoint.set_default_client_config(configure_client());
+        endpoint.set_default_client_config(configure_client(&self.addr));
+
+        let server_name = self.addr.domain().unwrap_or("localhost");
 
         // connect to server
         let connection = endpoint
-            .connect(addr, "localhost")
+            .connect(addr, server_name)
             .unwrap()
             .await
             .with_context(|| "connect failed")?;
@@ -329,13 +331,13 @@ mod tests {
     async fn ipv6_domain_pingpong() {
         let listener = QUICTunnelListener::new("quic://[::1]:31016".parse().unwrap());
         let mut connector =
-            QUICTunnelConnector::new("quic://test.easytier.top:31016".parse().unwrap());
+            QUICTunnelConnector::new("quic://test.easytier.top:31016?insecure=1".parse().unwrap());
         connector.set_ip_version(IpVersion::V6);
         _tunnel_pingpong(listener, connector).await;
 
         let listener = QUICTunnelListener::new("quic://127.0.0.1:31016".parse().unwrap());
         let mut connector =
-            QUICTunnelConnector::new("quic://test.easytier.top:31016".parse().unwrap());
+            QUICTunnelConnector::new("quic://test.easytier.top:31016?insecure=1".parse().unwrap());
         connector.set_ip_version(IpVersion::V4);
         _tunnel_pingpong(listener, connector).await;
     }

--- a/easytier/src/tunnel/websocket.rs
+++ b/easytier/src/tunnel/websocket.rs
@@ -12,7 +12,7 @@ use tokio_websockets::{ClientBuilder, Limits, MaybeTlsStream, Message};
 use zerocopy::AsBytes;
 
 use super::TunnelInfo;
-use crate::tunnel::insecure_tls::get_insecure_tls_client_config;
+use crate::tunnel::insecure_tls::get_tls_client_config_by_url;
 
 use super::{
     common::{setup_sokcet2, wait_for_connect_futures, TunnelWrapper},
@@ -199,9 +199,8 @@ impl WSTunnelConnector {
 
         let c = ClientBuilder::from_uri(http::Uri::try_from(addr.to_string()).unwrap());
         let stream: MaybeTlsStream<TcpStream> = if is_wss {
-            init_crypto_provider();
             let tls_conn =
-                tokio_rustls::TlsConnector::from(Arc::new(get_insecure_tls_client_config()));
+                tokio_rustls::TlsConnector::from(Arc::new(get_tls_client_config_by_url(&addr)));
             // Modify SNI logic: use "localhost" as SNI for url without domain to avoid IP blocking.
             let sni = match addr.domain() {
                 None => "localhost".to_string(),


### PR DESCRIPTION
### 添加TLS 证书验证支持

本次更新旨在增强 `QUIC` 和 `WebSocket (WSS)` 连接的安全性。在此之前，所有 TLS 连接都默认跳过服务器证书验证，这可能导致中间人攻击（MITM）的风险。

为了解决这个问题，我们引入了默认的证书验证机制，同时保留了在特定场景下使用不安全连接的灵活性。

#### 主要变更

1.  **动态 TLS 配置**:
    *   新增 `get_tls_client_config_by_url` 函数，该函数会根据 URL 的特征动态选择 TLS 客户端配置。
    *   **默认行为**: 当连接到域名时，将使用 `rustls-native-certs` 加载系统内置的根证书，并对服务器证书进行严格验证。
    *   **例外情况**: 在以下情况下，将自动切换到不安全的 TLS 模式（跳过证书验证）：
        *   连接目标是 IP 地址（因为证书通常不会颁发给 IP）。
        *   连接 URL 中明确包含 `insecure=1` 查询参数。

2.  **QUIC 和 WebSocket (WSS) 更新**:
    *   `QUIC` 和 `WSS` 的连接器现在使用上述动态配置逻辑。
    *   修复了 `QUIC` 连接中服务器名称指示（SNI）未正确设置的问题，现在会根据 URL 的主机名自动设置，确保多域名服务器的证书验证正确。

3.  **依赖项**:
    *   添加了 `rustls-native-certs` 依赖，用于访问系统根证书库。

#### 集成测试
- [x] `easytier-core` 使用 `wss` 连接到 由cloudflare tunnel反代到使用`ws`的`easytier-web`，验证证书通过，并能够正常使用。


这些变更显著提升了 EasyTier 的默认安全性，使其符合现代网络安全标准，同时保留了必要的向前兼容性。
