### PR TITLE
fix(gui): 修复 macOS Dock/托盘切换时无法激活窗口的问题

### DIFF
--- a/easytier-gui/src/pages/index.vue
+++ b/easytier-gui/src/pages/index.vue
@@ -139,6 +139,8 @@ async function updateNetworkInfos() {
 
 let intervalId = 0
 onMounted(async () => {
+  await loadDockVisibilityAsync(getDockVisibilityStatus())
+
   intervalId = window.setInterval(async () => {
     await updateNetworkInfos()
   }, 500)


### PR DESCRIPTION
Dock 图标和状态栏图标的行为都遵循同一套规则：

- 如果窗口当前不可见（隐藏或最小化），点击时应该恢复显示并聚焦。
- **如果窗口可见但未获得焦点，点击时应把它带到前台并聚焦。（优化这个）**
- 如果窗口已可见且正获得焦点，再次点击时就把窗口隐藏。