### PR TITLE
feat(gui): 优化数据表列标题样式防止换行

### DIFF
--- a/easytier-web/frontend-lib/src/components/Status.vue
+++ b/easytier-web/frontend-lib/src/components/Status.vue
@@ -466,4 +466,8 @@ function showEventLogs() {
 .p-timeline :deep(.p-timeline-event-opposite) {
   @apply flex-none;
 }
+
+:deep(.p-datatable .p-datatable-column-title) {
+  white-space: nowrap;
+}
 </style>


### PR DESCRIPTION
优化前：
<img width="780" height="287" alt="image" src="https://github.com/user-attachments/assets/57a52055-5afe-4ad4-a16f-d0a66b29d701" />

优化后：
<img width="748" height="165" alt="image" src="https://github.com/user-attachments/assets/139ef73a-b5bf-4c65-8043-5604e0639107" />
