### PR TITLE
feat(ui): Display network names and optimize list loading

### DIFF
--- a/easytier-gui/src-tauri/src/lib.rs
+++ b/easytier-gui/src-tauri/src/lib.rs
@@ -8,7 +8,8 @@ use easytier::proto::api::manage::{
     WebClientServiceClientFactory,
 };
 use easytier::rpc_service::remote_client::{
-    ListNetworkInstanceIdsJsonResp, ListNetworkProps, RemoteClientManager, Storage,
+    GetNetworkMetasResponse, ListNetworkInstanceIdsJsonResp, ListNetworkProps, RemoteClientManager,
+    Storage,
 };
 use easytier::{
     common::config::{ConfigLoader, FileLoggerConfig, LoggingConfigBuilder, TomlConfigLoader},
@@ -247,6 +248,19 @@ fn load_configs(configs: Vec<NetworkConfig>, enabled_networks: Vec<String>) -> R
         .load_configs(configs, enabled_networks)
         .map_err(|e| e.to_string())?;
     Ok(())
+}
+
+#[tauri::command]
+async fn get_network_metas(
+    app: AppHandle,
+    instance_ids: Vec<uuid::Uuid>,
+) -> Result<GetNetworkMetasResponse, String> {
+    CLIENT_MANAGER
+        .get()
+        .unwrap()
+        .handle_get_network_metas(app, instance_ids)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 #[cfg(not(target_os = "android"))]
@@ -667,6 +681,7 @@ pub fn run() {
             validate_config,
             get_config,
             load_configs,
+            get_network_metas,
         ])
         .on_window_event(|_win, event| match event {
             #[cfg(not(target_os = "android"))]

--- a/easytier-gui/src/auto-imports.d.ts
+++ b/easytier-gui/src/auto-imports.d.ts
@@ -27,6 +27,7 @@ declare global {
   const getCurrentInstance: typeof import('vue')['getCurrentInstance']
   const getCurrentScope: typeof import('vue')['getCurrentScope']
   const getEasytierVersion: typeof import('./composables/backend')['getEasytierVersion']
+  const getNetworkMetas: typeof import('./composables/backend')['getNetworkMetas']
   const h: typeof import('vue')['h']
   const initMobileVpnService: typeof import('./composables/mobile_vpn')['initMobileVpnService']
   const inject: typeof import('vue')['inject']
@@ -139,6 +140,7 @@ declare module 'vue' {
     readonly getCurrentInstance: UnwrapRef<typeof import('vue')['getCurrentInstance']>
     readonly getCurrentScope: UnwrapRef<typeof import('vue')['getCurrentScope']>
     readonly getEasytierVersion: UnwrapRef<typeof import('./composables/backend')['getEasytierVersion']>
+    readonly getNetworkMetas: UnwrapRef<typeof import('./composables/backend')['getNetworkMetas']>
     readonly h: UnwrapRef<typeof import('vue')['h']>
     readonly initMobileVpnService: UnwrapRef<typeof import('./composables/mobile_vpn')['initMobileVpnService']>
     readonly inject: UnwrapRef<typeof import('vue')['inject']>

--- a/easytier-gui/src/composables/backend.ts
+++ b/easytier-gui/src/composables/backend.ts
@@ -1,5 +1,6 @@
 import { invoke } from '@tauri-apps/api/core'
 import { Api, type NetworkTypes } from 'easytier-frontend-lib'
+import { GetNetworkMetasResponse } from 'node_modules/easytier-frontend-lib/dist/modules/api'
 import { getAutoLaunchStatusAsync } from '~/modules/auto_launch'
 
 type NetworkConfig = NetworkTypes.NetworkConfig
@@ -62,4 +63,8 @@ export async function sendConfigs() {
   let networkList: NetworkConfig[] = JSON.parse(localStorage.getItem('networkList') || '[]');
   let autoStartInstIds = getAutoLaunchStatusAsync() ? JSON.parse(localStorage.getItem('autoStartInstIds') || '[]') : []
   return await invoke('load_configs', { configs: networkList, enabledNetworks: autoStartInstIds })
+}
+
+export async function getNetworkMetas(instanceIds: string[]) {
+  return await invoke<GetNetworkMetasResponse>('get_network_metas', { instanceIds })
 }

--- a/easytier-gui/src/modules/api.ts
+++ b/easytier-gui/src/modules/api.ts
@@ -40,5 +40,8 @@ export class GUIRemoteClient implements Api.RemoteClient {
             return { error: e + "" };
         }
     }
+    async get_network_metas(instance_ids: string[]): Promise<Api.GetNetworkMetasResponse> {
+        return await backend.getNetworkMetas(instance_ids);
+    }
 
 }

--- a/easytier-web/frontend-lib/src/modules/api.ts
+++ b/easytier-web/frontend-lib/src/modules/api.ts
@@ -26,6 +26,14 @@ export interface CollectNetworkInfoResponse {
     }
 }
 
+export interface NetworkMeta {
+    instance_name: string;
+}
+
+export interface GetNetworkMetasResponse {
+    metas: Record<string, NetworkMeta>;
+}
+
 export interface RemoteClient {
     validate_config(config: NetworkConfig): Promise<ValidateConfigResponse>;
     run_network(config: NetworkConfig): Promise<undefined>;
@@ -37,4 +45,5 @@ export interface RemoteClient {
     get_network_config(inst_id: string): Promise<NetworkConfig>;
     generate_config(config: NetworkConfig): Promise<GenerateConfigResponse>;
     parse_config(toml_config: string): Promise<ParseConfigResponse>;
+    get_network_metas(instance_ids: string[]): Promise<GetNetworkMetasResponse>;
 }

--- a/easytier-web/frontend/src/modules/api.ts
+++ b/easytier-web/frontend/src/modules/api.ts
@@ -243,6 +243,12 @@ class WebRemoteClient implements Api.RemoteClient {
             return { error: 'Unknown error: ' + error };
         }
     }
+    async get_network_metas(instance_ids: string[]): Promise<Api.GetNetworkMetasResponse> {
+        const response = await this.client.post<any, Api.GetNetworkMetasResponse>(`/machines/${this.machine_id}/networks/metas`, {
+            instance_ids: instance_ids
+        });
+        return response;
+    }
 }
 
 export default ApiClient;

--- a/easytier/src/rpc_service/remote_client.rs
+++ b/easytier/src/rpc_service/remote_client.rs
@@ -189,6 +189,28 @@ where
         Ok(())
     }
 
+    async fn handle_get_network_metas(
+        &self,
+        identify: T,
+        inst_ids: Vec<uuid::Uuid>,
+    ) -> Result<GetNetworkMetasResponse, RemoteClientError<E>> {
+        let mut metas = std::collections::HashMap::new();
+
+        for instance_id in inst_ids {
+            let config = self
+                .handle_get_network_config(identify.clone(), instance_id)
+                .await?;
+            metas.insert(
+                instance_id,
+                NetworkMeta {
+                    instance_name: config.network_name.unwrap_or_default(),
+                },
+            );
+        }
+
+        Ok(GetNetworkMetasResponse { metas })
+    }
+
     async fn handle_save_network_config(
         &self,
         identify: T,
@@ -253,6 +275,16 @@ pub enum ListNetworkProps {
 pub struct ListNetworkInstanceIdsJsonResp {
     running_inst_ids: Vec<crate::proto::common::Uuid>,
     disabled_inst_ids: Vec<crate::proto::common::Uuid>,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct NetworkMeta {
+    instance_name: String,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct GetNetworkMetasResponse {
+    metas: std::collections::HashMap<uuid::Uuid, NetworkMeta>,
 }
 
 pub trait PersistentConfig<E> {


### PR DESCRIPTION
## 概述

本 PR 的核心目标是提升用户体验，让网络选择下拉框能够显示易于理解的网络名称，而不是一长串的 UUID。为了实现这一目标，并确保在有大量网络实例时依然保持流畅的性能，我们引入了网络元数据（Network Meta）的获取机制，并对前端组件进行了性能优化。

## 主要变更

### 1. 功能：显示网络名称

-   **问题**：之前，在 Web UI 和桌面 GUI 的网络管理界面，网络选择下拉框中只显示网络的 UUID。这对于用户来说难以区分和记忆。
-   **解决方案**：现在，下拉框会优先显示用户在配置中设置的 `network_name`，并在名称为空时回退显示 UUID 的一部分。这使得识别和选择特定网络变得更加直观。

### 2. 性能优化：懒加载与虚拟滚动

-   **问题**：如果用户配置了大量的网络实例，一次性加载所有网络信息会导致前端卡顿和不必要的后端请求。
-   **解决方案**：我们对 `RemoteManagement.vue` 组件进行了重构，引入了**虚拟滚动（Virtual Scrolling）**和**懒加载（Lazy Loading）**机制：
    -   **虚拟滚动**：下拉列表只渲染当前可见的少数几个选项，而不是全部选项，极大地降低了 DOM 元素的数量。
    -   **懒加载**：仅在列表项即将进入可视区域时，前端才会向后端发起请求，获取该网络实例的元数据（如名称）。
    -   **缓存**：已获取的元数据会被缓存在前端，避免了重复请求。

    通过这些优化，即使用户有数百个网络实例，页面的初始加载速度和滚动体验也能保持流畅。

### 3. 后端支持：新增元数据 API

-   **Easytier (核心)**：在 `rpc_service::remote_client` 中新增了 `handle_get_network_metas` 方法，用于根据一组实例 ID 批量获取其元数据。
-   **Easytier-Web (Web API)**：添加了新的 REST API 端点 `POST /api/v1/machines/:machine-id/networks/metas`，将上述功能暴露给 Web 前端。
-   **Easytier-GUI (桌面端)**：添加了新的 Tauri 命令 `get_network_metas`，供桌面端 Vue 应用调用。

### 4. API 与类型定义

-   更新了 `frontend-lib` 中的 `RemoteClient` 接口和相关类型定义，以包含 `get_network_metas` 方法。
-   相应地更新了 Web 和 GUI 的前端 API 客户端实现。

## 集成测试

1.  导航到 Web UI 或打开桌面程序的网络管理页面。
2.  点击网络选择下拉框。
3.  **验证**：下拉框中的选项现在应该显示为 “网络名称 (UUID)”，如果网络名称未设置，则只显示 UUID。
4.  （可选）如果有大量的网络实例，快速滚动列表，**验证**页面保持流畅。可以打开浏览器开发者工具的网络面板，观察 `metas` 请求是随着滚动分批发出的。
5.  编辑一个正在运行的网络的配置，修改其 `network_name` 并保存。
6.  **验证**：下拉框中的名称应立即更新为新的名称。

close #1193