### PR TITLE
Hybrid mode

### DIFF
--- a/easytier-contrib/easytier-ffi/src/lib.rs
+++ b/easytier-contrib/easytier-ffi/src/lib.rs
@@ -2,7 +2,7 @@ use std::sync::Mutex;
 
 use dashmap::DashMap;
 use easytier::{
-    common::config::{ConfigLoader as _, TomlConfigLoader},
+    common::config::{ConfigFileControl, ConfigLoader as _, TomlConfigLoader},
     instance_manager::NetworkInstanceManager,
 };
 
@@ -128,13 +128,14 @@ pub unsafe extern "C" fn run_network_instance(cfg_str: *const std::ffi::c_char) 
         return -1;
     }
 
-    let instance_id = match INSTANCE_MANAGER.run_network_instance(cfg, false) {
-        Ok(id) => id,
-        Err(e) => {
-            set_error_msg(&format!("failed to start instance: {}", e));
-            return -1;
-        }
-    };
+    let instance_id =
+        match INSTANCE_MANAGER.run_network_instance(cfg, false, ConfigFileControl::STATIC_CONFIG) {
+            Ok(id) => id,
+            Err(e) => {
+                set_error_msg(&format!("failed to start instance: {}", e));
+                return -1;
+            }
+        };
 
     INSTANCE_NAME_ID_MAP.insert(inst_name, instance_id);
 

--- a/easytier-contrib/easytier-ohrs/src/lib.rs
+++ b/easytier-contrib/easytier-ohrs/src/lib.rs
@@ -1,6 +1,6 @@
 mod native_log;
 
-use easytier::common::config::{ConfigLoader, TomlConfigLoader};
+use easytier::common::config::{ConfigFileControl, ConfigLoader, TomlConfigLoader};
 use easytier::common::constants::EASYTIER_VERSION;
 use easytier::instance_manager::NetworkInstanceManager;
 use napi_derive_ohos::napi;
@@ -75,7 +75,9 @@ pub fn run_network_instance(cfg_str: String) -> bool {
     {
         return false;
     }
-    INSTANCE_MANAGER.run_network_instance(cfg, false).unwrap();
+    INSTANCE_MANAGER
+        .run_network_instance(cfg, false, ConfigFileControl::STATIC_CONFIG)
+        .unwrap();
     true
 }
 

--- a/easytier-contrib/easytier-uptime/src/health_checker.rs
+++ b/easytier-contrib/easytier-uptime/src/health_checker.rs
@@ -8,7 +8,7 @@ use anyhow::Context as _;
 use dashmap::DashMap;
 use easytier::{
     common::{
-        config::{ConfigLoader, NetworkIdentity, PeerConfig, TomlConfigLoader},
+        config::{ConfigFileControl, ConfigLoader, NetworkIdentity, PeerConfig, TomlConfigLoader},
         scoped_task::ScopedTask,
     },
     defer,
@@ -391,7 +391,7 @@ impl HealthChecker {
                 .delete_network_instance(vec![cfg.get_id()]);
         });
         self.instance_mgr
-            .run_network_instance(cfg.clone(), false)
+            .run_network_instance(cfg.clone(), false, ConfigFileControl::STATIC_CONFIG)
             .with_context(|| "failed to run network instance")?;
 
         let now = Instant::now();
@@ -435,7 +435,7 @@ impl HealthChecker {
         );
 
         self.instance_mgr
-            .run_network_instance(cfg.clone(), true)
+            .run_network_instance(cfg.clone(), true, ConfigFileControl::STATIC_CONFIG)
             .with_context(|| "failed to run network instance")?;
         self.inst_id_map.insert(node_id, cfg.get_id());
 

--- a/easytier-gui/src/composables/backend.ts
+++ b/easytier-gui/src/composables/backend.ts
@@ -15,8 +15,8 @@ export async function generateNetworkConfig(tomlConfig: string) {
   return invoke<NetworkConfig>('generate_network_config', { tomlConfig })
 }
 
-export async function runNetworkInstance(cfg: NetworkConfig) {
-  return invoke('run_network_instance', { cfg })
+export async function runNetworkInstance(cfg: NetworkConfig, save: boolean) {
+  return invoke('run_network_instance', { cfg, save })
 }
 
 export async function collectNetworkInfo(instanceId: string) {

--- a/easytier-gui/src/composables/mobile_vpn.ts
+++ b/easytier-gui/src/composables/mobile_vpn.ts
@@ -160,7 +160,7 @@ export async function onNetworkInstanceChange(instanceId: string) {
     }
     catch (e) {
       console.error('start vpn service failed, stop all other network insts.', e)
-      await runNetworkInstance(config);
+      await runNetworkInstance(config, true); //on android config should always be saved
     }
   }
 }

--- a/easytier-gui/src/modules/api.ts
+++ b/easytier-gui/src/modules/api.ts
@@ -5,8 +5,8 @@ export class GUIRemoteClient implements Api.RemoteClient {
     async validate_config(config: NetworkTypes.NetworkConfig): Promise<Api.ValidateConfigResponse> {
         return backend.validateConfig(config);
     }
-    async run_network(config: NetworkTypes.NetworkConfig): Promise<undefined> {
-        await backend.runNetworkInstance(config);
+    async run_network(config: NetworkTypes.NetworkConfig, save: boolean): Promise<undefined> {
+        await backend.runNetworkInstance(config, save);
     }
     async get_network_info(inst_id: string): Promise<NetworkTypes.NetworkInstanceRunningInfo | undefined> {
         return backend.collectNetworkInfo(inst_id).then(infos => infos.info.map[inst_id]);

--- a/easytier-web/frontend-lib/src/modules/api.ts
+++ b/easytier-web/frontend-lib/src/modules/api.ts
@@ -26,8 +26,27 @@ export interface CollectNetworkInfoResponse {
     }
 }
 
+export namespace ConfigFilePermission {
+    export type Flags = number;
+    export const READ_ONLY: Flags = 1 << 0;
+    export const NO_DELETE: Flags = 1 << 1;
+    export function hasPermission(perm: Flags, flag: Flags): boolean {
+        return (perm & flag) === flag;
+    }
+    export function isRemoveSaveable(perm: Flags): boolean {
+        return !hasPermission(perm, NO_DELETE);
+    }
+    export function isEditable(perm: Flags): boolean {
+        return !hasPermission(perm, READ_ONLY);
+    }
+    export function isDeletable(perm: Flags): boolean {
+        return !hasPermission(perm, NO_DELETE);
+    }
+}
+
 export interface NetworkMeta {
-    instance_name: string;
+    network_name: string;
+    config_permission: ConfigFilePermission.Flags;
 }
 
 export interface GetNetworkMetasResponse {
@@ -36,7 +55,7 @@ export interface GetNetworkMetasResponse {
 
 export interface RemoteClient {
     validate_config(config: NetworkConfig): Promise<ValidateConfigResponse>;
-    run_network(config: NetworkConfig): Promise<undefined>;
+    run_network(config: NetworkConfig, save: boolean): Promise<undefined>;
     get_network_info(inst_id: string): Promise<NetworkInstanceRunningInfo | undefined>;
     list_network_instance_ids(): Promise<ListNetworkInstanceIdResponse>;
     delete_network(inst_id: string): Promise<undefined>;

--- a/easytier-web/frontend/src/modules/api.ts
+++ b/easytier-web/frontend/src/modules/api.ts
@@ -193,9 +193,10 @@ class WebRemoteClient implements Api.RemoteClient {
         });
         return response;
     }
-    async run_network(config: NetworkTypes.NetworkConfig): Promise<undefined> {
+    async run_network(config: NetworkTypes.NetworkConfig, save: boolean): Promise<undefined> {
         await this.client.post<string>(`/machines/${this.machine_id}/networks`, {
             config: config,
+            save: save
         });
     }
     async get_network_info(inst_id: string): Promise<NetworkTypes.NetworkInstanceRunningInfo | undefined> {

--- a/easytier-web/src/client_manager/session.rs
+++ b/easytier-web/src/client_manager/session.rs
@@ -280,6 +280,7 @@ impl Session {
                             config: Some(
                                 serde_json::from_str::<NetworkConfig>(&c.network_config).unwrap(),
                             ),
+                            overwrite: false,
                         },
                     )
                     .await;

--- a/easytier-web/src/db/mod.rs
+++ b/easytier-web/src/db/mod.rs
@@ -155,7 +155,7 @@ impl Storage<(UserIdInDb, Uuid), user_running_network_configs::Model, DbErr> for
         (user_id, _): (UserIdInDb, Uuid),
         network_inst_id: Uuid,
         disabled: bool,
-    ) -> Result<user_running_network_configs::Model, DbErr> {
+    ) -> Result<(), DbErr> {
         use entity::user_running_network_configs as urnc;
 
         urnc::Entity::update_many()
@@ -169,15 +169,7 @@ impl Storage<(UserIdInDb, Uuid), user_running_network_configs::Model, DbErr> for
             .exec(self.orm_db())
             .await?;
 
-        urnc::Entity::find()
-            .filter(urnc::Column::UserId.eq(user_id))
-            .filter(urnc::Column::NetworkInstanceId.eq(network_inst_id.to_string()))
-            .one(self.orm_db())
-            .await?
-            .ok_or(DbErr::RecordNotFound(format!(
-                "Network config not found for user {} and network instance {}",
-                user_id, network_inst_id
-            )))
+        Ok(())
     }
 
     async fn list_network_configs(

--- a/easytier-web/src/restful/network.rs
+++ b/easytier-web/src/restful/network.rs
@@ -59,6 +59,7 @@ struct SaveNetworkJsonReq {
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 struct RunNetworkJsonReq {
     config: NetworkConfig,
+    save: bool,
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
@@ -132,6 +133,7 @@ impl NetworkApi {
             .handle_run_network_instance(
                 (Self::get_user_id(&auth_session)?, machine_id),
                 payload.config,
+                payload.save,
             )
             .await
             .map_err(convert_error)?;

--- a/easytier/locales/app.yml
+++ b/easytier/locales/app.yml
@@ -18,6 +18,9 @@ core_clap:
   config_file:
     en: "path to the config file, NOTE: the options set by cmdline args will override options in config file"
     zh-CN: "配置文件路径，注意：命令行中的配置的选项会覆盖配置文件中的选项"
+  config_dir:
+    en: "Load all .toml files in the directory to start network instances, and store the received configurations in this directory."
+    zh-CN: "加载目录中的所有 .toml 文件以启动网络实例，并将下发的配置保存在此目录中。"
   generate_completions:
     en: "generate shell completions"
     zh-CN: "生成 shell 补全脚本"

--- a/easytier/src/launcher.rs
+++ b/easytier/src/launcher.rs
@@ -1,4 +1,4 @@
-use crate::common::config::PortForwardConfig;
+use crate::common::config::{ConfigFileControl, PortForwardConfig};
 use crate::proto::api::{self, manage};
 use crate::proto::rpc_types::controller::BaseController;
 use crate::rpc_service::InstanceRpcService;
@@ -284,13 +284,15 @@ pub type NetworkInstanceRunningInfo = crate::proto::api::manage::NetworkInstance
 pub struct NetworkInstance {
     config: TomlConfigLoader,
     launcher: Option<EasyTierLauncher>,
+    config_file_control: ConfigFileControl,
 }
 
 impl NetworkInstance {
-    pub fn new(config: TomlConfigLoader) -> Self {
+    pub fn new(config: TomlConfigLoader, config_file_control: ConfigFileControl) -> Self {
         Self {
             config,
             launcher: None,
+            config_file_control,
         }
     }
 
@@ -387,6 +389,10 @@ impl NetworkInstance {
         self.config.get_inst_name()
     }
 
+    pub fn get_network_name(&self) -> String {
+        self.config.get_network_identity().network_name
+    }
+
     pub fn set_tun_fd(&mut self, tun_fd: i32) {
         if let Some(launcher) = self.launcher.as_ref() {
             launcher.data.tun_fd.write().unwrap().replace(tun_fd);
@@ -420,6 +426,10 @@ impl NetworkInstance {
         self.launcher
             .as_ref()
             .map(|launcher| launcher.data.instance_stop_notifier.clone())
+    }
+
+    pub fn get_config_file_control(&self) -> &ConfigFileControl {
+        &self.config_file_control
     }
 
     pub fn get_latest_error_msg(&self) -> Option<String> {

--- a/easytier/src/proto/api_manage.proto
+++ b/easytier/src/proto/api_manage.proto
@@ -112,6 +112,12 @@ message NetworkInstanceRunningInfoMap {
   map<string, NetworkInstanceRunningInfo> map = 1;
 }
 
+message NetworkMeta {
+  common.UUID inst_id = 1;
+  string network_name = 2;
+  uint32 config_permission = 3;
+}
+
 message ValidateConfigRequest { NetworkConfig config = 1; }
 
 message ValidateConfigResponse { string toml_config = 1; }
@@ -119,6 +125,7 @@ message ValidateConfigResponse { string toml_config = 1; }
 message RunNetworkInstanceRequest {
   common.UUID inst_id = 1;
   NetworkConfig config = 2;
+  bool overwrite = 3;
 }
 
 message RunNetworkInstanceResponse { common.UUID inst_id = 1; }
@@ -143,6 +150,14 @@ message DeleteNetworkInstanceResponse {
   repeated common.UUID remain_inst_ids = 1;
 }
 
+message GetNetworkInstanceConfigRequest { common.UUID inst_id = 1; }
+
+message GetNetworkInstanceConfigResponse { NetworkConfig config = 1; }
+
+message ListNetworkInstanceMetaRequest { repeated common.UUID inst_ids = 1; }
+
+message ListNetworkInstanceMetaResponse { repeated NetworkMeta metas = 1; }
+
 service WebClientService {
   rpc ValidateConfig(ValidateConfigRequest) returns (ValidateConfigResponse) {}
   rpc RunNetworkInstance(RunNetworkInstanceRequest)
@@ -155,4 +170,8 @@ service WebClientService {
       returns (ListNetworkInstanceResponse) {}
   rpc DeleteNetworkInstance(DeleteNetworkInstanceRequest)
       returns (DeleteNetworkInstanceResponse) {}
+  rpc GetNetworkInstanceConfig(GetNetworkInstanceConfigRequest)
+      returns (GetNetworkInstanceConfigResponse) {}
+  rpc ListNetworkInstanceMeta(ListNetworkInstanceMetaRequest)
+      returns (ListNetworkInstanceMetaResponse) {}
 }

--- a/easytier/src/rpc_service/instance_manage.rs
+++ b/easytier/src/rpc_service/instance_manage.rs
@@ -1,10 +1,10 @@
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use crate::{
-    common::config::ConfigLoader,
+    common::config::{ConfigFileControl, ConfigFilePermission, ConfigLoader},
     instance_manager::NetworkInstanceManager,
     proto::{
-        api::manage::*,
+        api::{config::GetConfigRequest, manage::*},
         rpc_types::{self, controller::BaseController},
     },
 };
@@ -46,11 +46,59 @@ impl WebClientService for InstanceManageRpcService {
         if let Some(inst_id) = req.inst_id {
             cfg.set_id(inst_id.into());
         }
-        self.manager.run_network_instance(cfg, true)?;
-        println!("instance {} started", id);
-        Ok(RunNetworkInstanceResponse {
+        let resp = RunNetworkInstanceResponse {
             inst_id: Some(id.into()),
-        })
+        };
+
+        let mut control = if let Some(control) = self.manager.get_instance_config_control(&id) {
+            if !req.overwrite {
+                return Ok(resp);
+            }
+            if control.is_read_only() {
+                return Err(
+                    anyhow::anyhow!("instance {} is read-only, cannot be overwritten", id).into(),
+                );
+            }
+
+            if let Some(path) = control.path.as_ref() {
+                let real_control = ConfigFileControl::from_path(path.clone()).await;
+                if real_control.is_read_only() {
+                    return Err(anyhow::anyhow!(
+                        "config file {} is read-only, cannot be overwritten",
+                        path.display()
+                    )
+                    .into());
+                }
+            }
+
+            self.manager.delete_network_instance(vec![id])?;
+
+            control.clone()
+        } else if let Some(config_dir) = self.manager.get_config_dir() {
+            ConfigFileControl::new(
+                Some(config_dir.join(format!("{}.toml", id))),
+                ConfigFilePermission::default(),
+            )
+        } else {
+            ConfigFileControl::new(None, ConfigFilePermission::default())
+        };
+
+        if !control.is_read_only() {
+            if let Some(config_file) = control.path.as_ref() {
+                if let Err(e) = std::fs::write(config_file, cfg.dump()) {
+                    tracing::warn!(
+                        "failed to write config file {}: {}",
+                        config_file.display(),
+                        e
+                    );
+                    control.set_read_only(true);
+                }
+            }
+        }
+
+        self.manager.run_network_instance(cfg, true, control)?;
+        println!("instance {} started", id);
+        Ok(resp)
     }
 
     async fn retain_network_instance(
@@ -124,12 +172,79 @@ impl WebClientService for InstanceManageRpcService {
         _: BaseController,
         req: DeleteNetworkInstanceRequest,
     ) -> Result<DeleteNetworkInstanceResponse, rpc_types::error::Error> {
-        let remain_inst_ids = self
+        let inst_ids: HashSet<uuid::Uuid> = req.inst_ids.into_iter().map(Into::into).collect();
+        let inst_ids = self
             .manager
-            .delete_network_instance(req.inst_ids.into_iter().map(Into::into).collect())?;
+            .iter()
+            .filter(|v| inst_ids.contains(v.key()))
+            .filter(|v| v.get_config_file_control().is_deletable())
+            .map(|v| *v.key())
+            .collect::<Vec<_>>();
+        let config_files = inst_ids
+            .iter()
+            .filter_map(|id| {
+                self.manager
+                    .get_instance_config_control(id)
+                    .and_then(|control| control.path.clone())
+            })
+            .collect::<Vec<_>>();
+        let remain_inst_ids = self.manager.delete_network_instance(inst_ids)?;
         println!("instance {:?} retained", remain_inst_ids);
+        for config_file in config_files {
+            if let Err(e) = std::fs::remove_file(&config_file) {
+                tracing::warn!(
+                    "failed to remove config file {}: {}",
+                    config_file.display(),
+                    e
+                );
+            }
+        }
         Ok(DeleteNetworkInstanceResponse {
             remain_inst_ids: remain_inst_ids.into_iter().map(Into::into).collect(),
         })
+    }
+
+    async fn get_network_instance_config(
+        &self,
+        _: BaseController,
+        req: GetNetworkInstanceConfigRequest,
+    ) -> Result<GetNetworkInstanceConfigResponse, rpc_types::error::Error> {
+        let inst_id: uuid::Uuid = req
+            .inst_id
+            .ok_or_else(|| anyhow::anyhow!("instance id is required"))?
+            .into();
+        let config = self
+            .manager
+            .get_instance_service(&inst_id)
+            .ok_or_else(|| anyhow::anyhow!("instance service not found"))?
+            .get_config_service()
+            .get_config(BaseController::default(), GetConfigRequest::default())
+            .await?
+            .config;
+        Ok(GetNetworkInstanceConfigResponse { config })
+    }
+
+    async fn list_network_instance_meta(
+        &self,
+        _: BaseController,
+        req: ListNetworkInstanceMetaRequest,
+    ) -> Result<ListNetworkInstanceMetaResponse, rpc_types::error::Error> {
+        let mut metas = Vec::with_capacity(req.inst_ids.len());
+        for inst_id in req.inst_ids {
+            let inst_id: uuid::Uuid = (inst_id).into();
+            let Some(control) = self.manager.get_instance_config_control(&inst_id) else {
+                continue;
+            };
+            let Some(name) = self.manager.get_network_instance_name(&inst_id) else {
+                continue;
+            };
+            let meta = NetworkMeta {
+                inst_id: Some(inst_id.into()),
+                network_name: name,
+                config_permission: control.permission.into(),
+            };
+            metas.push(meta);
+        }
+        Ok(ListNetworkInstanceMetaResponse { metas })
     }
 }

--- a/easytier/src/rpc_service/mod.rs
+++ b/easytier/src/rpc_service/mod.rs
@@ -79,18 +79,23 @@ fn get_instance_service(
     let id = if let Some(api::instance::instance_identifier::Selector::Id(id)) = selector {
         (*id).into()
     } else {
-        let ids = instance_manager.filter_network_instance(|_, i| {
-            if let Some(api::instance::instance_identifier::Selector::InstanceSelector(selector)) =
-                selector
-            {
-                if let Some(name) = selector.name.as_ref() {
-                    if i.get_inst_name() != *name {
-                        return false;
+        let ids = instance_manager
+            .iter()
+            .filter(|v| {
+                if let Some(api::instance::instance_identifier::Selector::InstanceSelector(
+                    selector,
+                )) = selector
+                {
+                    if let Some(name) = selector.name.as_ref() {
+                        if v.get_inst_name() != *name {
+                            return false;
+                        }
                     }
                 }
-            }
-            true
-        });
+                true
+            })
+            .map(|v| *v.key())
+            .collect::<Vec<_>>();
         match ids.len() {
             0 => return Err(anyhow::anyhow!("No instance matches the selector")),
             1 => ids[0],

--- a/easytier/src/web_client/controller.rs
+++ b/easytier/src/web_client/controller.rs
@@ -35,4 +35,8 @@ impl Controller {
     pub fn get_rpc_service(&self) -> InstanceManageRpcService {
         InstanceManageRpcService::new(self.manager.clone())
     }
+
+    pub(super) fn notify_manager_stopping(&self) {
+        self.manager.notify_stop_check();
+    }
 }


### PR DESCRIPTION
## PR 摘要

本次 PR 引入了两项核心功能增强，旨在提升 EasyTier 的配置灵活性和管理模式：

1.  **支持基于目录的配置加载 (`conf.d` 模式)**: `easytier-core` 现在可以从指定目录（如 `conf.d/`）加载所有 `.toml` 文件来启动网络实例。同时，所有通过远程客户端（Web UI, GUI）下发的网络配置也将被持久化到该目录中，形成统一的配置管理入口。
2.  **启用混合运行模式**: `easytier-core` 服务现在支持"混合模式"运行，即可以同时加载本地配置文件，并接受远程客户端(Web) 的连接进行管理。这使得 `core` 可以作为一个常驻服务，无缝地结合本地静态配置和动态远程管理。

为实现以上目标，本次更新引入了更精细的权限控制模型，并增强了客户端与核心服务之间的状态同步机制，确保了在复杂场景下数据的一致性和操作的可靠性。

### 主要变更

#### 1. 支持基于目录的配置加载与持久化 (conf.d 模式)

为了提供更灵活的配置管理方式，并统一本地配置和远程配置的存储，引入了 `conf.d` 风格的目录加载机制：

*   **目录扫描与加载**: 在 `easytier/src/common/config.rs` 和 `easytier/src/launcher.rs` 中，扩展了配置加载逻辑，使其能够扫描指定目录下的所有 `.toml` 文件，并将每一个文件作为一个独立的网络实例进行加载。
*   **统一的持久化路径**: 当通过 Web UI 或其他远程客户端创建或修改网络配置时，这些配置现在会被保存为独立的 `.toml` 文件到 `conf.d` 目录中。这确保了远程下发的配置在 `core` 服务重启后依然存在，并与手动创建的本地配置文件一同被加载，实现了配置来源的统一。

#### 2. 支持混合配置模式与远程管理

为了让 `easytier-core` 能够作为常驻服务，同时处理本地配置和远程管理，进行了以下改进：

*   **实现混合模式运行**: `easytier-core` 现在可以无缝地在混合模式下工作。它既可以加载和运行本地配置文件（如 `config.toml` 或 `conf.d/` 目录）中定义的网络，也可以同时接受来自 Web UI 或 GUI 的连接，并管理远程下发的网络实例。
*   **保证服务持续性 (WebClientGuard)**: 为了实现这一点，引入了 `WebClientGuard` 机制（在 `instance_manager.rs` 和 `web_client/mod.rs` 中）。这是一个基于 RAII 模式的实现，它确保只要有任何一个远程客户端（如 Web UI）处于连接状态，`easytier-core` 进程就不会因为没有本地运行的网络实例而自动退出。这个改动极大地提升了远程管理的稳定性和用户体验，用户现在可以启动一个不带任何本地配置的 `core` 实例，然后完全通过 Web 界面进行网络的创建、配置和管理。

#### 3. 引入网络实例权限控制模型

为了在混合模式下清晰地管理不同来源（例如，本地只读文件、`conf.d` 目录文件、远程客户端动态创建）的网络实例，本次 PR 引入了一套精确且统一的权限控制模型。该模型确保了所有操作都遵循预期的权限规则，防止了非法修改或删除。

*   **权限的单一事实来源 (`ConfigFileControl`)**: 权限控制的核心是 `easytier/src/common/config.rs` 中定义的 `ConfigFileControl` 结构体。`easytier-core` 在加载每个网络实例时，会为其创建一个 `ConfigFileControl` 对象，该对象包含了实例的持久化路径 (`path`) 和一个权限位掩码 (`permission`)。这个对象是该实例所有权限判断的唯一依据。

*   **权限的确定逻辑**: 权限位在 `load_config_from_file` 函数中根据以下规则确定：
    *   **只读 (`READ_ONLY`)**: 如果配置文件所在的 **文件系统** 将文件标记为只读，则该实例自动获得 `READ_ONLY` 权限。
    *   **不可删除 (`NO_DELETE`)**: 如果配置文件 **不是** 位于 `conf.d` 风格的配置目录中（例如，通过 `--config-file` 参数指定的单个配置文件），则该实例自动获得 `NO_DELETE` 权限。
    *   **默认权限**: 由远程客户端创建并保存到 `conf.d` 目录中的网络实例，默认拥有完整的读、写、删除权限。

*   **通过 gRPC 暴露权限**: 为了让客户端能够感知权限，`easytier/src/proto/api_manage.proto` 中新增了 `ListNetworkInstanceMeta` RPC 方法。
    *   该方法返回 `NetworkMeta` 消息列表，其中 `config_permission` 字段是一个 `uint32` 类型的位掩码，直接对应于 `ConfigFileControl` 中的 `permission` 标志位。这使得客户端可以通过解析这些标志位来了解每个实例的具体权限。

*   **服务端强制执行权限**: `easytier/src/rpc_service/instance_manage.rs` 中实现了 gRPC 服务端逻辑。
    *   在执行 `run_network_instance` (用于修改) 和 `delete_network_instance` 等敏感操作前，服务端会严格检查对应实例的 `ConfigFileControl` 中的权限位。
    *   例如，如果一个实例被标记为 `READ_ONLY`，任何尝试通过 `run_network_instance` 覆盖其配置的请求都将被拒绝。同样，如果一个实例被标记为 `NO_DELETE`，`delete_network_instance` 请求也会失败。这从根本上保证了权限模型的强制执行。

通过这套机制，权限不再是分散在各个模块中的模糊概念，而是成为一个集中管理、来源清晰、严格执行的核心特性，为混合模式下的稳定运行提供了坚实的基础。

下面是不同配置来源下的具体权限行为矩阵：

| 配置来源 | 远程修改配置 | 远程停止/删除 |
| :--- | :---: | :---: |
| 单个配置文件 (`--config-file`) | ✅ | ❌ |
| 单个只读配置文件 | ❌ | ❌ |
| `conf.d` 目录中的文件 | ✅ | ✅ |
| `conf.d` 目录中的只读文件 | ❌ | ❌ |
| Web下发 | ✅ | ✅ |
| 命令行、FFI、标准输入 | ❌ | ❌ |

#### 4. 增强客户端与核心的状态同步

为了根除客户端（尤其是 Web UI）显示状态陈旧或与后端不一致的问题，进行了以下改进：

*   **“实时优先，缓存回退”策略**：在 `easytier/src/rpc_service/remote_client.rs` 中，客户端的数据获取逻辑被重构。它会优先尝试通过 gRPC 从 `easytier-core` 获取最新的实时配置。如果 `core` 服务不可达，它会智能地回退到从本地 `SeaORM` 数据库 (`easytier-web/src/db/`) 中读取上一份已知的配置。这个策略在保证数据实时性的同时，也提升了客户端的容错能力。
*   **前端类型安全与 API 调用**: 在 `easytier-web/frontend-lib/src/modules/api.ts` 中，定义了与后端 `NetworkMeta` 匹配的 TypeScript 类型，并提供了 `get_network_metas` 函数用于调用新的 RESTful API，确保了前后端数据契约的一致性。
*   **权限驱动的 UI**:
    *   **Web UI**: `RemoteManagement.vue` 组件现在会调用 `get_network_metas` 获取每个网络的实时权限。
    *   **GUI**: `easytier-gui` 中的 Vue 组件通过 Tauri `invoke` 调用 Rust 后端的 `get_network_metas` 命令。该命令在 `easytier-gui/src-tauri/src/lib.rs` 中实现，它复用了与 Web 服务端相同的 `RemoteClientManager` 逻辑，通过 gRPC 与 `easytier-core` 通信。
    *   **统一行为**: 两个客户端都会根据返回的 `config_permission` 和 `can_stop` 权限，动态地禁用（`:disabled`）“编辑”、“删除”和“停止”等操作按钮，为用户提供清晰、准确的操作指引，防止用户尝试执行不允许的操作。
*   **统一的客户端操作流程**:
    *   在 **禁用/启用** 网络时，无论是 Web 还是 GUI，客户端都会先从 `core` 获取最新的配置，然后再执行相应的 `run` 或 `delete` 操作，避免了使用过时配置启动网络的问题。
    *   对于支持远程存储的网络，在 **运行** 、 **保存** 、 **停止** 时，配置会被同步到客户端的持久化存储中，确保了离线或重启后的配置一致性。

### 集成测试

#### 新core搭配新web
> FFI 未测试，行为应与命令行一致  

|          | 修改  | 停止  | 本地文件 | 远程存储 | 状态展示 | 测试通过 |
| -------- | --- | --- | ---- | ---- | ---- | ---- |
| 命令行      | N   | N   | N    | N    | Y    | √    |
| FFI      | N   | N   | N    | N    | Y    | -    |
| 标准输入     | N   | N   | N    | N    | Y    | √    |
| 配置文件     | Y   | N   | Y    | N    | Y    | √    |
| 配置文件+命令行 | N   | N   | Y    | N    | Y    | √    |
| 只读配置文件   | N   | N   | Y    | N    | Y    | √    |
| 扫描配置文件   | Y   | Y   | Y    | Y    | Y    | √    |
| 扫描只读配置文件 | N   | N   | Y    | N    | Y    | √    |
| 下发配置文件   | Y   | Y   | N    | Y    | Y    | √    |

- [x] 扫描配置文件本地修改并启动网络后，web修改/停止时能够获取到最新配置
- [x] 运行时修改 .toml 文件为只读，web无法编辑/删除网络


#### 新core搭配旧web
> 对于不允许的操作返回错误（N）或无响应（N'）  
> FFI 未测试，行为应与命令行一致  
> 扫描配置文件：仅当 Web 数据库中存在时才可修改；启动时使用本地文件，修改后同步至 Web 数据库和核心配置文件  
> 扫描只读配置文件：修改和停止操作均被核心拒绝，但旧 Web 仍保存修改至数据库并显示成功，导致 Web 界面状态与实际不符（例如停止后 Web 显示已停止，但核心仍运行）

| 配置来源 | 修改 | 停止 | 本地文件 | 远程存储 | 状态展示 | 测试通过 |
| -------- | --- | --- | ---- | ---- | ---- | ---- |
| 命令行      | N   | N'  | N    | N    | Y    | √    |
| FFI      | N   | N'  | N    | N    | Y    | -    |
| 标准输入     | N   | N'  | N    | N    | Y    | √    |
| 配置文件     | N   | N'  | Y    | N    | Y    | √    |
| 配置文件+命令行 | N   | N'  | Y    | N    | Y    | √    |
| 只读配置文件   | N   | N'  | Y    | N    | Y    | √    |
| 扫描配置文件   | Y*  | Y   | Y    | Y    | Y    | √    |
| 扫描只读配置文件 | N*  | N*  | Y    | N    | Y    | √    |
| 下发配置文件   | Y   | Y   | N    | Y    | Y    | √    |

#### 旧core(v2.4.5)搭配新web

|          | 修改  | 停止  | 本地文件 | 远程存储 | 状态展示 | 测试通过 |
| -------- | --- | --- | ---- | ---- | ---- | ---- |
| 下发配置文件   | Y   | Y   | N    | Y    | Y    | √    |

#### GUI测试
- [x] 基本功能正常，未发现异常

### 兼容性总结

为了确保平滑升级，本次变更经过了严格的兼容性测试：

*   **新 Core + 新 Web UI**: 所有功能均按预期工作，UI 能够正确地根据权限禁用或隐藏操作按钮，提供了最佳的用户体验。
*   **新 Core + 旧 Web UI**: 系统保持稳定。对于旧客户端发出的不允许的操作（如修改一个只读配置），`core` 服务会拒绝执行并返回错误，有效防止了非法操作，保证了后端的健壮性。
*   **旧 Core + 新 Web UI**: 新的 Web UI 能够兼容旧版 `core` 服务。在无法获取到新的权限元数据时，它会回退到之前的行为模式，保证了基本的管理功能可用。

综上所述，本次 PR 通过建立清晰的权限模型、强化状态同步机制和优化服务生命周期管理，显著提升了 EasyTier 在复杂配置场景下的可靠性、一致性和稳定性。

### 附：操作时序图

#### 新web操作时序图
```mermaid
sequenceDiagram
    participant UI as UI前端<br/>(RemoteManagement.vue)
    participant WebBackend as Web后端<br/>(NetworkApi)
    participant DB as DB存储<br/>(SQLite)
    participant Core as Core<br/>(easytier-core)
    
    %% === 初始化阶段 ===
    Note over Core,UI: 1. Core 启动连接 Web 获取配置
    Core->>Core: 创建 WebClient 初始化 Controller<br/>注册 WebClientGuard 确保服务持续性
    
    loop Core 心跳循环 (每1秒)
        Core->>WebBackend: WebSocket: HeartbeatRequest<br/>{machine_id, user_token, running_network_instances}
        WebBackend->>WebBackend: Storage.update_client()<br/>更新客户端信息和在线状态
        WebBackend-->>Core: HeartbeatResponse {success}
    end
    
    Note over Core,WebBackend: Core 通过 RPC 接收 Web 后端的配置管理指令

    %% === UI 获取网络列表 ===
    Note over UI,Core: 1.5. UI 前端获取网络实例列表和元数据
    UI->>WebBackend: GET /api/v1/machines/{machine-id}/networks
    WebBackend->>Core: RPC: list_network_instance()
    Core-->>WebBackend: running_inst_ids
    WebBackend->>DB: 查询 user_running_network_configs (disabled=true)
    DB-->>WebBackend: disabled_inst_ids
    WebBackend-->>UI: {running_inst_ids, disabled_inst_ids}

    UI->>WebBackend: POST /api/v1/machines/{machine-id}/networks/metas<br/>{instance_ids: [...]}
    WebBackend->>Core: RPC: list_network_instance_meta(inst_ids)
    Core-->>WebBackend: NetworkMeta 列表 (来自 Core)
    WebBackend->>DB: 查询 user_running_network_configs (补充 Core 中没有的元数据)
    DB-->>WebBackend: NetworkConfig 列表
    WebBackend-->>UI: NetworkMeta 列表 (合并后)
    UI->>UI: 渲染网络下拉列表
    
    %% === 用户操作阶段 ===
    Note over UI,Core: 2. UI 前端点击编辑按钮获取配置
    UI->>UI: 用户点击编辑按钮 editNetwork()
    UI->>WebBackend: GET /api/v1/machines/{machine-id}/networks/config/{inst-id}
    
    WebBackend->>Core: RPC: get_network_instance_config(inst_id)
    Core->>Core: InstanceRpcService.get_config_service().get_config()
    
    alt Core 可访问且配置存在
        Core-->>WebBackend: NetworkConfig
        WebBackend-->>UI: NetworkConfig JSON
    else Core 不可访问或配置不存在
        WebBackend->>DB: 查询 user_running_network_configs<br/>WHERE user_id AND network_instance_id
        alt 配置存在于 DB
            DB-->>WebBackend: 返回 NetworkConfig JSON
        else 配置不存在
            Note over WebBackend: 直接返回 404 错误
        end
        WebBackend-->>UI: NetworkConfig JSON
    end
    
    UI->>UI: currentNetworkConfig = config<br/>isEditingNetwork = true
    UI->>UI: 渲染 Config 编辑界面
    
    %% === 保存配置阶段 ===
    Note over UI,Core: 3. UI 前端点击保存按钮保存配置
    UI->>UI: 用户点击保存按钮 saveNetworkConfig()
    UI->>WebBackend: PUT /api/v1/machines/{machine-id}/networks/config/{inst-id}<br/>{config: NetworkConfig}
    
    WebBackend->>DB: INSERT OR UPDATE user_running_network_configs
    Note over DB: 更新字段:<br/>- network_config (JSON)<br/>- update_time<br/>- disabled = false
    
    DB-->>WebBackend: 保存成功
    WebBackend-->>UI: HTTP 200 OK
    
    %% === 停止网络阶段 ===
    Note over UI,Core: 4. UI 前端点击停止网络按钮
    
    UI->>WebBackend: PUT /api/v1/machines/{machine-id}/networks/{inst-id}<br/>{disabled: true}
    
    WebBackend->>Core: RPC: get_network_instance_config(inst_id)
    Core-->>WebBackend: NetworkConfig
    
    WebBackend->>DB: INSERT OR UPDATE user_running_network_configs<br/>(保存当前配置)
    
    WebBackend->>Core: RPC: delete_network_instance(inst_id)
    Core->>Core: 检查 ConfigFileControl 权限<br/>过滤可删除实例
    Core->>Core: NetworkInstanceManager.remove_instance()
    Note over Core: 停止所有网络组件:<br/>- 关闭 VPN 隧道<br/>- 断开 Peer 连接<br/>- 清理路由表
    Core-->>WebBackend: 实例已停止
    
    WebBackend->>DB: UPDATE user_running_network_configs<br/>SET disabled = true
    DB-->>WebBackend: 更新成功
    WebBackend-->>UI: HTTP 200 OK
    
    %% === 运行网络阶段 ===
    Note over UI,Core: 5. UI 前端点击运行网络按钮
    UI->>UI: 用户点击运行按钮 saveAndRunNewNetwork()
    
    alt 如果网络已在运行
        Note over UI,Core: 引用停止网络逻辑 (同操作4)
    end
    
    UI->>WebBackend: POST /api/v1/machines/{machine-id}/networks<br/>{config: NetworkConfig, save: boolean}
    
    WebBackend->>Core: RPC: run_network_instance(NetworkConfig, save=true)
    Core->>Core: 检查 ConfigFileControl 权限<br/>验证是否可写
    Core->>Core: NetworkInstanceManager.add_instance()<br/>创建配置文件控制对象
    Note over Core: 根据配置来源确定权限:<br/>- conf.d目录: 可读写删<br/>- 单配置文件: 只读不可删<br/>- 远程创建: 可读写删
    Core->>Core: 写入配置文件 (如需要)
    Core->>Core: 创建 Instance<br/>启动 VPN 隧道<br/>连接 Peers
    Core-->>WebBackend: 返回执行结果 {inst_id}
    
    alt save 为 true
        WebBackend->>DB: INSERT OR UPDATE user_running_network_configs<br/>(保存配置，disabled=false)
        DB-->>WebBackend: 保存成功
    end
    
    WebBackend-->>UI: HTTP 200 OK
    
    %% === 删除网络阶段 ===
    Note over UI,Core: 6. UI 前端点击删除网络按钮
    
    UI->>WebBackend: DELETE /api/v1/machines/{machine-id}/networks/{inst-id}
    
    WebBackend->>Core: RPC: list_network_instance_meta([inst_id])
    Core->>Core: NetworkInstanceManager.get_instance_config_control()
    Core-->>WebBackend: NetworkMeta {config_permission}
    
    alt 如果网络正在运行且可删除
        WebBackend->>Core: RPC: delete_network_instance(inst_id)
        Core->>Core: 检查 ConfigFileControl 权限<br/>过滤可删除实例
        Core->>Core: NetworkInstanceManager.remove_instance()
        Note over Core: 停止所有网络组件:<br/>- 关闭 VPN 隧道<br/>- 断开 Peer 连接<br/>- 清理路由表
        Core->>Core: 删除配置文件 (如需要)
        Core-->>WebBackend: 实例已停止
    end
    
    WebBackend->>DB: DELETE FROM user_running_network_configs<br/>WHERE user_id = ? AND network_instance_id = ?
    DB-->>WebBackend: 删除成功
    
    WebBackend-->>UI: HTTP 200 OK
```

#### 旧web操作时序图
```mermaid
sequenceDiagram
    participant UI as UI前端<br/>(RemoteManagement.vue)
    participant WebBackend as Web后端<br/>(NetworkApi)
    participant DB as DB存储<br/>(SQLite)
    participant Core as Core<br/>(easytier-core)
    
    %% === 初始化阶段 ===
    Note over Core,UI: 1. Core 启动连接 Web 获取配置
    Core->>Core: 创建 WebClient 初始化 Controller
    
    loop Core 心跳循环 (每1秒)
        Core->>WebBackend: WebSocket: HeartbeatRequest<br/>{machine_id, user_token, running_network_instances}
        WebBackend->>WebBackend: Storage.update_client()<br/>更新客户端信息和在线状态
        WebBackend-->>Core: HeartbeatResponse {success}
    end
    
    Note over Core,WebBackend: Core 通过 RPC 接收 Web 后端的配置管理指令
    
    %% === 用户操作阶段 ===
    Note over UI,Core: 2. UI 前端点击编辑按钮获取配置
    UI->>UI: 用户点击编辑按钮 editNetwork()
    UI->>WebBackend: GET /api/v1/machines/{machine-id}/networks/config/{inst-id}
    
    WebBackend->>DB: 查询 user_running_network_configs<br/>WHERE user_id AND network_instance_id
    
    alt 配置存在于 DB
        DB-->>WebBackend: 返回 NetworkConfig JSON
    else 配置不存在
        Note over WebBackend: 直接返回 404 错误<br/>不会从 Core 获取配置
    end
    
    WebBackend-->>UI: NetworkConfig JSON
    UI->>UI: currentNetworkConfig = config<br/>isEditingNetwork = true
    UI->>UI: 渲染 Config 编辑界面
    
    %% === 保存配置阶段 ===
    Note over UI,Core: 3. UI 前端点击保存按钮保存配置
    UI->>UI: 用户点击保存按钮 saveNetworkConfig()
    UI->>WebBackend: PUT /api/v1/machines/{machine-id}/networks/config/{inst-id}<br/>{config: NetworkConfig}
    
    WebBackend->>DB: INSERT OR UPDATE user_running_network_configs
    Note over DB: 更新字段:<br/>- network_config (JSON)<br/>- update_time<br/>- disabled = false
    
    DB-->>WebBackend: 保存成功
    WebBackend-->>UI: HTTP 200 OK
    
    %% === 停止网络阶段 ===
    Note over UI,Core: 4. UI 前端点击停止网络按钮
    
    UI->>WebBackend: PUT /api/v1/machines/{machine-id}/networks/{inst-id}<br/>{disabled: true}
    
    WebBackend->>DB: UPDATE user_running_network_configs<br/>SET disabled = true
    DB-->>WebBackend: 更新成功
    
    WebBackend->>Core: RPC: delete_network_instance(inst_id)
    Core->>Core: NetworkInstanceManager.remove_instance()
    Note over Core: 停止所有网络组件:<br/>- 关闭 VPN 隧道<br/>- 断开 Peer 连接<br/>- 清理路由表
    Core-->>WebBackend: 实例已停止
    
    WebBackend-->>UI: HTTP 200 OK
    
    %% === 运行网络阶段 ===
    Note over UI,Core: 5. UI 前端点击运行网络按钮
    UI->>UI: 用户点击运行按钮 saveAndRunNewNetwork()
    
    alt 如果网络已在运行
        Note over UI,Core: 引用删除网络逻辑 (同操作6)
    end
    
    UI->>WebBackend: POST /api/v1/machines/{machine-id}/networks<br/>{config: NetworkConfig}
    
    Note over WebBackend,Core: 引用保存配置逻辑 (同操作3)
    
    WebBackend->>Core: RPC: run_network_instance(NetworkConfig)
    Core->>Core: NetworkInstanceManager.add_instance()
    Core->>Core: 创建 Instance<br/>启动 VPN 隧道<br/>连接 Peers
    Core-->>WebBackend: 返回执行结果
    
    WebBackend-->>UI: HTTP 200 OK
    
    %% === 删除网络阶段 ===
    Note over UI,Core: 6. UI 前端点击删除网络按钮
    
    UI->>WebBackend: DELETE /api/v1/machines/{machine-id}/networks/{inst-id}
    
    alt 如果网络正在运行
        WebBackend->>Core: RPC: remove_network_instance(inst_id)
        Core->>Core: NetworkInstanceManager.remove_instance()
        Note over Core: 停止所有网络组件:<br/>- 关闭 VPN 隧道<br/>- 断开 Peer 连接<br/>- 清理路由表
        Core-->>WebBackend: 实例已停止
    end
    
    WebBackend->>DB: DELETE FROM user_running_network_configs<br/>WHERE user_id = ? AND network_instance_id = ?
    DB-->>WebBackend: 删除成功
    
    WebBackend-->>UI: HTTP 200 OK
```
