### PR TITLE
fix: Preserve disable_sym_hole_punching setting on edit

### DIFF
--- a/easytier/src/launcher.rs
+++ b/easytier/src/launcher.rs
@@ -882,6 +882,7 @@ impl NetworkConfig {
         result.proxy_forward_by_system = Some(flags.proxy_forward_by_system);
         result.disable_encryption = Some(!flags.enable_encryption);
         result.disable_udp_hole_punching = Some(flags.disable_udp_hole_punching);
+        result.disable_sym_hole_punching = Some(flags.disable_sym_hole_punching);
         result.enable_magic_dns = Some(flags.accept_dns);
         result.mtu = Some(flags.mtu as i32);
         result.enable_private_mode = Some(flags.private_mode);


### PR DESCRIPTION
修复编辑配置时丢失“禁用对称NAT打洞”设置。

close #1522