### PR TITLE
fix(core): Fix sleep-wake reconnect by resetting alive_conn_urls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4722,9 +4722,9 @@ dependencies = [
 
 [[package]]
 name = "multimap"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 dependencies = [
  "serde",
 ]

--- a/easytier/Cargo.toml
+++ b/easytier/Cargo.toml
@@ -213,7 +213,7 @@ hickory-client = "0.25.2"
 hickory-server = { version = "0.25.2", features = ["resolver"] }
 derive_builder = "0.20.2"
 humantime-serde = "1.1.1"
-multimap = "0.10.0"
+multimap = "0.10.1"
 version-compare = "0.2.0"
 hmac = "0.12.1"
 sha2 = "0.10.8"

--- a/easytier/src/instance/instance.rs
+++ b/easytier/src/instance/instance.rs
@@ -484,7 +484,7 @@ impl InstanceConfigPatcher {
             match ConfigPatchAction::try_from(connector.action) {
                 Ok(ConfigPatchAction::Add) => {
                     tracing::info!("Connector added: {}", url);
-                    conn_manager.add_connector_by_url(url.as_str()).await?;
+                    conn_manager.add_connector_by_url(url).await?;
                 }
                 Ok(ConfigPatchAction::Remove) => {
                     tracing::info!("Connector removed: {}", url);
@@ -620,7 +620,7 @@ impl Instance {
     async fn add_initial_peers(&mut self) -> Result<(), Error> {
         for peer in self.global_ctx.config.get_peers().iter() {
             self.get_conn_manager()
-                .add_connector_by_url(peer.uri.as_str())
+                .add_connector_by_url(peer.uri.clone())
                 .await?;
         }
         Ok(())


### PR DESCRIPTION
Fixes #1006

## About the issue

The issue appears after sleeping and waking a Windows PC with S0ix enabled, the `event_recv` in `ManualConnectorManager::conn_mgr_handle_event_routine` will occur error `RecvError::Lagged` after waking (for traditional S3 sleep, the program is properly paused, so it may due to some weird S0ix sleeping behaviour).

In the current processing procedure, `data.alive_conn_urls` will be rebuilt with connections from `peer_map.get_alive_conns()`, which in this case, hasn't been properly cleaned up by `maintain_alive_conns` (see logs below). And the `GlobalCtxEvent::PeerConnRemoved` events are also not handled properly to remove alive connection urls, due to events lagged and dropped, introducing race condition, and resulting in a broken `alive_conn_urls`, where dead connections may still be present in the set that should be alive.

---
Log part when the issue is present, here you can see most `peer_map` connection closed handling occurred after rebuilding `alive_conn_list`:
```
  2025-11-14T14:44:18.7667259+08:00 DEBUG easytier::peers::peer_map: peer conn is closed, current alive conns: 10, conn_id: 5468daf6-2ca9-4ffb-91df-e95f5b2f010f
    at easytier\src\peers\peer_map.rs:89

  2025-11-14T14:44:18.7707891+08:00  WARN easytier::connector::manual: event_recv lagged: 8, rebuild alive conn list
    at easytier\src\connector\manual.rs:190

  2025-11-14T14:44:18.7786571+08:00 DEBUG easytier::peers::peer_map: peer conn is closed, current alive conns: 9, conn_id: 832363d3-c824-4f3d-8335-bc5fd327e470
    at easytier\src\peers\peer_map.rs:89

  2025-11-14T14:44:18.7793121+08:00 DEBUG easytier::peers::peer_map: peer conn is closed, current alive conns: 8, conn_id: cb929f44-72d5-4be6-bd62-4a23a804e13a
    at easytier\src\peers\peer_map.rs:89

  2025-11-14T14:44:18.7838144+08:00 DEBUG easytier::peers::peer_map: peer conn is closed, current alive conns: 7, conn_id: 9928ce01-9f1e-45dd-ab69-296398fa3f00
    at easytier\src\peers\peer_map.rs:89

  2025-11-14T14:44:18.7872507+08:00 DEBUG easytier::peers::peer_map: peer conn is closed, current alive conns: 6, conn_id: 13bcd9bd-693e-4c41-b602-41da05b3b6e7
    at easytier\src\peers\peer_map.rs:89
```
---

This further impacts `ManualConnectionManager::collect_dead_conns` to return no dead connections, and let `ManualConnectionManager::conn_mgr_reconn_routine` to belive no connections need reconnecting, finally lead to lost connection to the whole easytier network.

## About the fix

This fix just dropped the part for rebuilding `alive_conn_urls`, i.e. only clear it and force reconnecting. Re-collecting all peers and corresponding connections for rebuilding may take long time, resulting in more race conditions or even lag again, due to the small capacity (8) of the busy event bus while waking up.

Force reconnecting is mandatory for this sleep-wake case, and for other very rare receiver lagged case, reconnecting won't cause damage, so I think this is a fair trade-off.

This pull request also removes `PeerMap::alive_conns` and the related `PeerMap::maintain_alive_conns`, as they were only used for rebuiding `alive_conn_urls`.

--- 

The analysis of the issue and the fix are mostly from static code review and log inspection, as debugging by breakpoints, or even adding some tracing logs will broke the race condition and prevent replicating the bug, while I'm not very familiar with the whole easytier code base. So please correct me if there are any mistakes.