### PR TITLE
feat(mobile): Enhance the Magic DNS support via VpnService on Android

### DIFF
--- a/easytier-gui/src/composables/mobile_vpn.ts
+++ b/easytier-gui/src/composables/mobile_vpn.ts
@@ -168,7 +168,7 @@ export async function onNetworkInstanceChange(instanceId: string) {
     }
 
     try {
-      await doStartVpn(virtual_ip, 24, routes, dns)
+      await doStartVpn(virtual_ip, network_length, routes, dns)
     }
     catch (e) {
       console.error('start vpn service failed, stop all other network insts.', e)


### PR DESCRIPTION
fix #1477 

之前的版本在 android 上没有实现 magic dns 功能。
经过查询日志可知 magic dns 实例已经跑起来了，只不过没有注册到 android 的 `VpnService` 的 tun 接口上。
这个 pr 主要做了两件事：
1. 把 `100.100.100.101/32` 路由注册到 `VpnService` 的 tun 接口上。
2. 把 `100.100.100.101` 写入 `VpnService` 的 tun 接口的 DNS 列表中。

经过实机测试，已在 android 端实现了魔法 dns 功能。