### PR TITLE
fix(mobile): Add DHCP polling to fix Android VPN startup failure

### DIFF
--- a/easytier-gui/src/composables/event.ts
+++ b/easytier-gui/src/composables/event.ts
@@ -7,6 +7,7 @@ const EVENTS = Object.freeze({
     PRE_RUN_NETWORK_INSTANCE: 'pre_run_network_instance',
     POST_RUN_NETWORK_INSTANCE: 'post_run_network_instance',
     VPN_SERVICE_STOP: 'vpn_service_stop',
+    DHCP_IP_CHANGED: 'dhcp_ip_changed',
 });
 
 function onSaveConfigs(event: Event<NetworkTypes.NetworkConfig[]>) {
@@ -30,12 +31,20 @@ async function onVpnServiceStop(event: Event<string>) {
     await onNetworkInstanceChange(event.payload);
 }
 
+async function onDhcpIpChanged(event: Event<string>) {
+    console.log(`Received event '${EVENTS.DHCP_IP_CHANGED}' for instance: ${event.payload}`);
+    if (type() === 'android') {
+        await onNetworkInstanceChange(event.payload);
+    }
+}
+
 export async function listenGlobalEvents() {
     const unlisteners = [
         await listen(EVENTS.SAVE_CONFIGS, onSaveConfigs),
         await listen(EVENTS.PRE_RUN_NETWORK_INSTANCE, onPreRunNetworkInstance),
         await listen(EVENTS.POST_RUN_NETWORK_INSTANCE, onPostRunNetworkInstance),
         await listen(EVENTS.VPN_SERVICE_STOP, onVpnServiceStop),
+        await listen(EVENTS.DHCP_IP_CHANGED, onDhcpIpChanged),
     ];
 
     return () => {


### PR DESCRIPTION
# fix(gui): 修复 Android DHCP 网络中 VPN 服务无法启动的问题

## 概述

本 PR 修复了一个由 #1489 重构引入的严重问题：在 Android 平台上，当使用 DHCP 自动获取 IP 地址时，VPN 服务无法正确启动。

采用**双重保障机制**：
1. **定时轮询**：解决初始化阶段 IP 获取延迟问题
2. **事件监听**：解决运行时 IP 变化的实时响应

## 问题描述

### 现象
在 Android 设备上使用 DHCP 模式时：
1. 网络实例成功启动
2. `post_run_network_instance` 事件被触发
3. `onNetworkInstanceChange` 函数被调用，此时 `virtual_ipv4` 尚未通过 DHCP 获取到
4. 函数检测到 IP 为空，调用 `doStopVpn()` 并返回
5. 后续即使 DHCP 成功分配了 IP，也不会再次触发 VPN 初始化

### 根本原因

1. **初始 IP 获取延迟**
   - #1489 的重构将事件触发时机提前到网络实例启动后立即发送
   - DHCP 的 IP 获取是异步过程，存在时间差
   - 原有代码没有处理这种竞态条件

2. **缺少运行时 IP 变化监听**
   - EasyTier 内部 DHCP 可能在运行时因冲突或网络拓扑变化而改变 IP
   - 没有机制监听和响应这些变化

## 解决方案

### 整体架构

```
初始化阶段（定时轮询）
    ↓
获取到 IP → 停止轮询 → 启动 VPN
    ↓
运行时阶段（事件监听）
    ↓
监听 DhcpIpv4Changed → 更新 VPN 配置
```

### 1. 定时轮询机制（处理初始 IP 获取）

**文件**：`easytier-gui/src/composables/mobile_vpn.ts`

**实现逻辑**：
- 在 `onNetworkInstanceChange` 函数入口处清除旧的轮询定时器
- 检测到 DHCP 已启用但 IP 为空时，不立即停止 VPN
- 设置 2 秒后的定时器，递归调用自身重新检查
- 一旦获取到 IP，退出轮询，继续正常的 VPN 初始化流程

**设计考量**：
- 使用 `setTimeout` 而非 `setInterval`，确保灵活性和清理简单性
- 单例定时器设计，避免资源浪费
- 2 秒重试间隔在用户体验和系统资源之间取得平衡

### 2. 事件监听机制（处理运行时 IP 变化）

**文件**：`easytier-gui/src-tauri/src/lib.rs`

**实现逻辑**：
- 在 `run_network_instance` 函数中订阅实例的 GlobalCtx 事件
- 监听 `DhcpIpv4Changed` 事件（首次分配或 IP 变化）
- 将事件转发到前端作为 Tauri 事件 `dhcp_ip_changed`
- 正确处理 channel 关闭和消息积压情况

**文件**：`easytier-gui/src/composables/event.ts`

**实现逻辑**：
- 注册 `dhcp_ip_changed` 事件监听器
- Android 平台下收到事件时触发 `onNetworkInstanceChange`

## 技术细节

### 架构决策

**为什么需要双重保障？**
1. **竞态条件**：事件监听器注册可能晚于首次 IP 分配，导致事件丢失
2. **可靠性**：定时轮询作为兜底机制，确保启动阶段的稳定性
3. **实时性**：事件监听保证运行时 IP 变化的即时响应

**为什么不修改后端事件触发时机？**
- 影响范围最小化：前端修复仅影响 Android VPN 场景
- 向后兼容：不影响其他平台和模式的现有行为
- 职责分离：DHCP 是前端 VPN 初始化关心的问题，在前端处理更合理

**架构原则遵守**
- ✅ 不侵入 easytier-core：所有 GUI 逻辑保持在 GUI 层
- ✅ 核心层只负责发出事件，GUI 层订阅并处理
- ✅ 通过 `subscribe_event()` 接口实现松耦合

### 边界情况处理

1. **网络实例切换**：旧定时器被立即清除，避免资源泄漏
2. **用户手动停止**：instanceId 为空时直接停止 VPN，终止轮询
3. **DHCP 失败**：轮询会持续进行，直到用户干预
4. **静态 IP 配置**：不启用 DHCP 时，轮询逻辑完全不会触发
5. **Event Receiver 生命周期**：instance 停止时，broadcast channel 自动关闭，receiver 正确退出
6. **消息积压**：使用 resubscribe() 重新订阅，避免因消息积压导致丢失事件

## 影响范围

### 变更文件
- `easytier-gui/src/composables/mobile_vpn.ts`
- `easytier-gui/src-tauri/src/lib.rs`
- `easytier-gui/src/composables/event.ts`

### 影响平台
- ✅ **Android（主要受益）**：完全修复 DHCP 场景
- ✅ **其他平台**：无影响

### 影响场景
- ✅ **DHCP 模式**：从完全不可用变为完全正常
- ✅ **静态 IP 模式**：无影响，轮询逻辑不会触发
- ✅ **远程/服务模式**：无影响

## 测试验证

### 手动测试清单
- [x] DHCP 模式下启动网络实例，VPN 成功获取 IP 并启动
- [x] 静态 IP 模式下功能正常，未触发轮询
- [x] 快速切换网络实例，无定时器泄漏
- [x] 网络实例停止时轮询正确终止
- [x] 查看控制台日志，轮询过程清晰可见
- [x] 模拟运行时 IP 冲突，验证事件监听机制
- [x] 验证 event_receiver 在实例停止时正确释放
- [x] 切换运行带 TUN 的网络实例，不会导致应用卡死或死锁

## 附带修复：修复 Android 切换网络时的死锁问题

### 问题描述
在 Android 平台上，当切换启动的网络实例时，`disable_instances_with_tun` 函数在遍历 `enabled_networks` 集合的同时，会调用 `handle_update_network_state` 来修改该集合，这会导致 `dashmap` 的死锁。

### 解决方案
在 `easytier-gui/src-tauri/src/lib.rs` 的 `disable_instances_with_tun` 函数中，将迭代和修改操作分离：
1. 首先，遍历 `enabled_networks` 集合，将所有需要禁用的实例 ID 收集到一个临时的 `Vec<uuid::Uuid>` 中。
2. 然后，遍历这个临时的 `Vec`，对每个实例 ID 调用 `handle_update_network_state` 进行禁用操作。

通过这种方式，避免了在迭代一个 `dashmap` 集合的同时对其进行修改，从而解决了死锁问题。

## 已知限制

**无超时保护**：
- 如果 DHCP 服务器永不响应，轮询会持续进行
- 依赖用户手动停止网络实例来终止
