### PR TITLE
feat(core): Support environment variable parsing in config files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2163,6 +2163,7 @@ dependencies = [
  "serial_test",
  "service-manager",
  "sha2",
+ "shellexpand",
  "smoltcp",
  "socket2 0.5.10",
  "stun_codec",
@@ -7752,6 +7753,15 @@ checksum = "09fa9338aed9a1df411814a5b2252f7cd206c55ae9bf2fa763f8de84603aa60c"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+dependencies = [
+ "dirs 6.0.0",
 ]
 
 [[package]]

--- a/easytier-contrib/easytier-ohrs/Cargo.lock
+++ b/easytier-contrib/easytier-ohrs/Cargo.lock
@@ -1071,6 +1071,7 @@ dependencies = [
  "serde_json",
  "service-manager",
  "sha2",
+ "shellexpand",
  "smoltcp",
  "socket2 0.5.10",
  "stun_codec",
@@ -3923,6 +3924,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]

--- a/easytier-gui/src-tauri/src/elevate/linux.rs
+++ b/easytier-gui/src-tauri/src/elevate/linux.rs
@@ -7,9 +7,7 @@ use super::Command;
 use anyhow::{anyhow, Result};
 use std::env;
 use std::ffi::OsStr;
-use std::path::PathBuf;
 use std::process::{Command as StdCommand, Output};
-use std::str::FromStr;
 
 /// The implementation of state check and elevated executing varies on each platform
 impl Command {

--- a/easytier/Cargo.toml
+++ b/easytier/Cargo.toml
@@ -217,6 +217,7 @@ multimap = "0.10.0"
 version-compare = "0.2.0"
 hmac = "0.12.1"
 sha2 = "0.10.8"
+shellexpand = "3.1.1"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows", target_os = "freebsd"))'.dependencies]
 machine-uid = "0.5.3"

--- a/easytier/locales/app.yml
+++ b/easytier/locales/app.yml
@@ -21,6 +21,9 @@ core_clap:
   config_dir:
     en: "Load all .toml files in the directory to start network instances, and store the received configurations in this directory."
     zh-CN: "加载目录中的所有 .toml 文件以启动网络实例，并将下发的配置保存在此目录中。"
+  disable_env_parsing:
+    en: "disable environment variable parsing in config file"
+    zh-CN: "禁用配置文件中的环境变量解析"
   generate_completions:
     en: "generate shell completions"
     zh-CN: "生成 shell 补全脚本"

--- a/easytier/src/common/env_parser.rs
+++ b/easytier/src/common/env_parser.rs
@@ -1,0 +1,247 @@
+//! 环境变量解析模块
+//!
+//! 提供配置文件中环境变量占位符的解析功能
+//! 支持 Shell 风格的语法：${VAR}、$VAR、${VAR:-default} 等
+
+use std::borrow::Cow;
+
+/// 解析字符串中的环境变量占位符
+///
+/// 支持的语法：
+/// - `${VAR_NAME}`          - 标准格式（推荐）
+/// - `$VAR_NAME`            - 简写格式
+/// - `${VAR_NAME:-default}` - 带默认值（bash 标准语法）
+///
+/// # 参数
+/// - `text`: 待解析的字符串
+///
+/// # 返回值
+/// - `String`: 替换后的字符串
+/// - `bool`: 是否检测到并替换了环境变量
+pub fn expand_env_vars(text: &str) -> (String, bool) {
+    // 使用 shellexpand::env() 解析环境变量
+    // 该函数仅处理环境变量，不处理 tilde (~) 扩展，适合配置文件场景
+    match shellexpand::env(text) {
+        Ok(expanded) => {
+            // 通过比较原始字符串和扩展后的字符串判断是否发生了替换
+            let changed = match &expanded {
+                Cow::Borrowed(_) => false, // 未发生变化，仍是借用
+                Cow::Owned(_) => true,     // 发生了变化，产生了新字符串
+            };
+
+            (expanded.into_owned(), changed)
+        }
+        Err(e) => {
+            // 如果解析失败（例如变量引用语法错误），记录警告并返回原字符串
+            tracing::warn!("Failed to expand environment variables in config: {}", e);
+            (text.to_string(), false)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_expand_standard_syntax() {
+        std::env::set_var("TEST_VAR_STANDARD", "test_value");
+        let (result, changed) = expand_env_vars("secret=${TEST_VAR_STANDARD}");
+        assert_eq!(result, "secret=test_value");
+        assert!(changed);
+    }
+
+    #[test]
+    fn test_expand_short_syntax() {
+        std::env::set_var("TEST_VAR_SHORT", "short_value");
+        let (result, changed) = expand_env_vars("key=$TEST_VAR_SHORT");
+        assert_eq!(result, "key=short_value");
+        assert!(changed);
+    }
+
+    #[test]
+    fn test_expand_with_default() {
+        // 确保变量未定义
+        std::env::remove_var("UNDEFINED_VAR_WITH_DEFAULT");
+        let (result, changed) = expand_env_vars("port=${UNDEFINED_VAR_WITH_DEFAULT:-8080}");
+        assert_eq!(result, "port=8080");
+        assert!(changed);
+    }
+
+    #[test]
+    fn test_no_env_vars() {
+        let (result, changed) = expand_env_vars("plain text without variables");
+        assert_eq!(result, "plain text without variables");
+        assert!(!changed);
+    }
+
+    #[test]
+    fn test_empty_string() {
+        let (result, changed) = expand_env_vars("");
+        assert_eq!(result, "");
+        assert!(!changed);
+    }
+
+    #[test]
+    fn test_multiple_vars() {
+        std::env::set_var("VAR1", "value1");
+        std::env::set_var("VAR2", "value2");
+        let (result, changed) = expand_env_vars("${VAR1} and ${VAR2}");
+        assert_eq!(result, "value1 and value2");
+        assert!(changed);
+    }
+
+    #[test]
+    fn test_undefined_var_without_default() {
+        // 确保变量未定义
+        std::env::remove_var("COMPLETELY_UNDEFINED_VAR");
+        let (result, changed) = expand_env_vars("value=${COMPLETELY_UNDEFINED_VAR}");
+        // shellexpand::env 对未定义的变量会保持原样
+        assert_eq!(result, "value=${COMPLETELY_UNDEFINED_VAR}");
+        assert!(!changed);
+    }
+
+    #[test]
+    fn test_complex_toml_config() {
+        std::env::set_var("ET_SECRET", "my-secret-key");
+        std::env::set_var("ET_PORT", "11010");
+
+        let config = r#"
+[network_identity]
+network_name = "test-network"
+network_secret = "${ET_SECRET}"
+
+[[peer]]
+uri = "tcp://127.0.0.1:${ET_PORT}"
+"#;
+
+        let (result, changed) = expand_env_vars(config);
+        assert!(changed);
+        assert!(result.contains(r#"network_secret = "my-secret-key""#));
+        assert!(result.contains(r#"uri = "tcp://127.0.0.1:11010""#));
+    }
+
+    #[test]
+    fn test_escape_syntax_double_dollar() {
+        std::env::set_var("ESCAPED_VAR", "should_not_expand");
+        // shellexpand 使用 $$ 作为转义序列，表示字面量的单个 $
+        // $$ 会被转义为单个 $，不会触发变量扩展
+        let (result, changed) = expand_env_vars("value=$${ESCAPED_VAR}");
+        assert_eq!(result, "value=${ESCAPED_VAR}");
+        assert!(changed); // $$ -> $ 被视为一次变换
+    }
+
+    #[test]
+    fn test_escape_syntax_backslash() {
+        std::env::set_var("ESCAPED_VAR", "should_not_expand");
+        // shellexpand 中反斜杠转义的行为：\$ 会展开为 \<变量值>
+        // 这不是推荐的转义方式，此测试仅为记录实际行为
+        let (result, changed) = expand_env_vars(r"value=\${ESCAPED_VAR}");
+        assert_eq!(result, r"value=\should_not_expand");
+        assert!(changed);
+    }
+
+    #[test]
+    fn test_multiple_dollar_signs() {
+        std::env::set_var("TEST_VAR", "value");
+        // 测试多个连续的 $ 符号
+        let (result1, changed1) = expand_env_vars("$$");
+        assert_eq!(result1, "$");
+        assert!(changed1);
+
+        let (result2, changed2) = expand_env_vars("$$$$");
+        assert_eq!(result2, "$$");
+        assert!(changed2);
+
+        // $$ 后跟变量扩展
+        let (result3, changed3) = expand_env_vars("$$$TEST_VAR");
+        assert_eq!(result3, "$value");
+        assert!(changed3);
+    }
+
+    #[test]
+    fn test_empty_var_value() {
+        std::env::set_var("EMPTY_VAR", "");
+        let (result, changed) = expand_env_vars("value=${EMPTY_VAR}");
+        // 变量存在但值为空
+        assert_eq!(result, "value=");
+        assert!(changed);
+    }
+
+    #[test]
+    fn test_default_with_special_chars() {
+        std::env::remove_var("UNDEFINED_SPECIAL");
+        // 测试默认值包含冒号、等号、空格等特殊字符
+        let (result, changed) = expand_env_vars("url=${UNDEFINED_SPECIAL:-http://localhost:8080}");
+        assert_eq!(result, "url=http://localhost:8080");
+        assert!(changed);
+
+        let (result2, changed2) = expand_env_vars("key=${UNDEFINED_SPECIAL:-name=value}");
+        assert_eq!(result2, "key=name=value");
+        assert!(changed2);
+
+        let (result3, changed3) = expand_env_vars("msg=${UNDEFINED_SPECIAL:-hello world}");
+        assert_eq!(result3, "msg=hello world");
+        assert!(changed3);
+    }
+
+    #[test]
+    fn test_var_name_with_numbers_underscores() {
+        std::env::set_var("VAR_123", "num_value");
+        std::env::set_var("_VAR", "underscore_prefix");
+        std::env::set_var("VAR_", "underscore_suffix");
+
+        let (result1, changed1) = expand_env_vars("${VAR_123}");
+        assert_eq!(result1, "num_value");
+        assert!(changed1);
+
+        let (result2, changed2) = expand_env_vars("${_VAR}");
+        assert_eq!(result2, "underscore_prefix");
+        assert!(changed2);
+
+        let (result3, changed3) = expand_env_vars("${VAR_}");
+        assert_eq!(result3, "underscore_suffix");
+        assert!(changed3);
+    }
+
+    #[test]
+    fn test_invalid_syntax() {
+        // 测试无效语法的处理
+        let (result1, changed1) = expand_env_vars("${}");
+        // shellexpand 会保留无效语法原样
+        assert_eq!(result1, "${}");
+        assert!(!changed1);
+
+        // 注意：未闭合的 ${VAR 实际上 shellexpand 会当作普通文本处理
+        // 它会尝试查找名为 "VAR" 的环境变量（到字符串末尾）
+        std::env::remove_var("VAR");
+        let (result2, _changed2) = expand_env_vars("incomplete ${VAR");
+        // 如果 VAR 未定义，shellexpand 会返回错误或保持原样
+        assert_eq!(result2, "incomplete ${VAR");
+        // 注意：changed2 的值取决于 shellexpand 是否认为这是有效语法
+        // 因此不对 changed2 做断言
+    }
+
+    #[test]
+    fn test_mixed_defined_undefined_vars() {
+        std::env::set_var("DEFINED_VAR", "defined");
+        std::env::remove_var("UNDEFINED_VAR");
+
+        // 混合已定义和未定义的变量
+        // shellexpand::env 在遇到未定义变量时会返回错误（默认行为）
+        // 因此整个字符串会保持不变
+        let (result, changed) = expand_env_vars("${DEFINED_VAR} and ${UNDEFINED_VAR}");
+        assert_eq!(result, "${DEFINED_VAR} and ${UNDEFINED_VAR}");
+        assert!(!changed);
+    }
+
+    #[test]
+    fn test_nested_braces() {
+        std::env::set_var("OUTER", "outer_value");
+        // 嵌套的大括号是无效语法，shellexpand::env 会返回错误
+        let (result, changed) = expand_env_vars("${OUTER} and ${{INNER}}");
+        // 由于语法错误，整个字符串保持不变
+        assert_eq!(result, "${OUTER} and ${{INNER}}");
+        assert!(!changed);
+    }
+}

--- a/easytier/src/common/mod.rs
+++ b/easytier/src/common/mod.rs
@@ -16,6 +16,7 @@ pub mod config;
 pub mod constants;
 pub mod defer;
 pub mod dns;
+pub mod env_parser;
 pub mod error;
 pub mod global_ctx;
 pub mod idn;

--- a/easytier/src/core.rs
+++ b/easytier/src/core.rs
@@ -133,6 +133,9 @@ struct Cli {
 
     #[clap(long, help = t!("core_clap.daemon").to_string())]
     daemon: bool,
+
+    #[clap(long, help = t!("core_clap.disable_env_parsing").to_string())]
+    disable_env_parsing: bool,
 }
 
 #[derive(Parser, Debug, Default, PartialEq, Eq)]
@@ -1209,8 +1212,12 @@ async fn run_main(cli: Cli) -> anyhow::Result<()> {
         }
     };
     for config_file in config_files {
-        let (mut cfg, mut control) =
-            load_config_from_file(&config_file, cli.config_dir.as_ref()).await?;
+        let (mut cfg, mut control) = load_config_from_file(
+            &config_file,
+            cli.config_dir.as_ref(),
+            cli.disable_env_parsing,
+        )
+        .await?;
 
         if cli.network_options.can_merge(&cfg, config_file_count) {
             cli.network_options

--- a/easytier/src/rpc_service/instance_manage.rs
+++ b/easytier/src/rpc_service/instance_manage.rs
@@ -213,6 +213,21 @@ impl WebClientService for InstanceManageRpcService {
             .inst_id
             .ok_or_else(|| anyhow::anyhow!("instance id is required"))?
             .into();
+
+        let control = self
+            .manager
+            .get_instance_config_control(&inst_id)
+            .ok_or_else(|| anyhow::anyhow!("instance config control not found"))?;
+
+        if control.is_read_only() {
+            return Err(anyhow::anyhow!(
+                "Configuration for instance {} is read-only (uses environment variables) and cannot be retrieved via API. \
+                 Please access the configuration file directly on the file system.",
+                inst_id
+            )
+            .into());
+        }
+
         let config = self
             .manager
             .get_instance_service(&inst_id)


### PR DESCRIPTION
# 支持配置文件中的环境变量解析

## 功能概述

实现了在 EasyTier 配置文件（TOML 格式）中解析环境变量占位符的功能，解决配置与密钥分离的问题，使配置文件可以安全地提交到版本控制系统。

### 核心特性

- ✅ 支持 Shell 风格的环境变量语法：`${VAR}`、`$VAR`、`${VAR:-default}`
- ✅ 使用环境变量的配置自动标记为只读（READ_ONLY|NO_DELETE）
- ✅ 提供 `--disable-env-parsing` CLI 开关以禁用此功能
- ✅ 加固 RPC API 安全性，防止只读配置通过 API 泄露
- ✅ 仅适用于本地文件系统加载的配置，不影响 Web/GUI 远程下发的配置

## 实现细节

### 1. 新增依赖

在 `easytier/Cargo.toml` 文件中，为了支持标准的 Shell 语法，新增了 `shellexpand = "3.1.1"` 依赖来处理环境变量的扩展。

### 2. 核心模块：环境变量解析器

新增了 `easytier/src/common/env_parser.rs` 模块，其核心函数 `expand_env_vars` 负责解析字符串中的环境变量，并返回解析后的结果以及一个布尔值，用于标识是否发生了替换。该模块能够处理标准、简写及带默认值的语法，并对无效语法进行容错处理。

### 3. 配置加载逻辑修改

在 `easytier/src/common/config.rs` 中，修改了配置加载逻辑。在读取并解析 TOML 文件之前，会先进行环境变量的替换。如果检测到配置中使用了环境变量，该配置的权限会被自动设置为只读（`READ_ONLY`）和不可删除（`NO_DELETE`）。

### 4. CLI 集成

在 `easytier/src/core.rs` 中，为命令行工具添加了 `--disable-env-parsing` 参数，允许用户在启动时禁用环境变量解析功能。这个参数的设置会被传递到配置加载函数中。

### 5. RPC 安全加固

在 `easytier/src/rpc_service/instance_manage.rs` 的 `get_instance_config` 方法中增加了安全检查。如果一个配置实例因为使用了环境变量而被标记为只读，那么通过 RPC API 获取该配置的请求将被拒绝，并返回明确的错误信息，以防止敏感信息通过 API 泄露。

### 6. 国际化支持

在 `easytier/locales/app.yml` 文件中，为新的 `--disable-env-parsing` CLI 参数添加了对应的中英文帮助文本。

## 使用示例

### 基础用法

**配置文件 (`config.toml`):**
```toml
[network_identity]
network_name = "my-network"
network_secret = "${ET_SECRET}"

[[peer]]
uri = "tcp://1.1.1.1:${ET_PORT:-11010}"
```

**运行:**
```bash
export ET_SECRET="my-secret-key"
export ET_PORT="12345"
easytier-core -c config.toml
```

**实际生效的配置:**
```toml
[network_identity]
network_name = "my-network"
network_secret = "my-secret-key"  # 从环境变量替换

[[peer]]
uri = "tcp://1.1.1.1:12345"  # 从环境变量替换
```

### 多实例场景

在同一台机器上运行两个实例：

**work.toml:**
```toml
network_secret = "${ET_SECRET_WORK}"
```

**home.toml:**
```toml
network_secret = "${ET_SECRET_HOME}"
```

```bash
export ET_SECRET_WORK="company-secret"
export ET_SECRET_HOME="home-secret"
easytier-core -c work.toml -c home.toml
```

### 禁用环境变量解析

如果配置中包含类似 `$` 的字面值，有两种处理方式：

#### 方式 1：使用转义机制（推荐）

推荐使用 `$$` 作为转义序列来保留字面量的 `$` 符号：

```toml
# 转义单个 $ 符号
description = "Pay $100 for the service"
literal_var = "$${VAR}"  # 保持 ${VAR} 字面量

# 多个 $ 符号
double_dollar = "$$$$"  # 结果：$$
```

#### 方式 2：全局禁用解析

如果配置中需要大量字面量 `$` 符号，可以全局禁用环境变量解析：

```bash
easytier-core -c config.toml --disable-env-parsing
```

**注意**：使用转义机制 `$$` 时，配置仍然可以进行环境变量解析，只是对特定字符进行转义处理。

## 安全考虑

### 1. 自动只读标记

使用环境变量的配置会自动标记为 `READ_ONLY|NO_DELETE`：
- 防止 Web/GUI 意外覆盖配置文件
- 避免环境变量引用丢失
- 与 CLI 参数覆盖的行为保持一致

### 2. RPC API 保护

只读配置无法通过 `get_instance_config` API 获取：
- 防止攻击者通过 API 获取配置内容
- 即使是管理员也需要直接访问文件系统
- 返回清晰的错误信息指导用户

### 3. 适用范围限制

环境变量解析**仅限本地文件**：
- 从文件系统加载：✅ 解析
- Web Console 下发：❌ 不解析
- GUI 远程配置：❌ 不解析

### 4. 错误处理

- **未定义的变量（无默认值）**：保留原占位符，不替换
- **未定义的变量（有默认值）**：使用默认值
- **混合未定义变量**：若字符串包含任一未定义变量（无默认值），整个字符串保持不变
- **语法错误**：记录警告日志，返回原文本
- **配置校验**：由现有逻辑负责（如必填字段检查）

### 5. 转义机制

**shellexpand 使用 `$$` 作为转义序列**（这是 shellexpand crate 的实现行为）：

- **推荐方式**：使用 `$$` 转义为单个 `$` 字符
  - `$$` → `$`
  - `$${VAR}` → `${VAR}`（字面量，不会展开）
  - `$$$$` → `$$`

- **不推荐**：`\${VAR}` 不会保留字面量，而是展开为 `\变量值`

- **备选方案**：如果配置中需要大量字面量 `$` 符号，可以使用 `--disable-env-parsing` 禁用整个解析功能

**注意**：在标准 POSIX shell 中，`$$` 表示当前进程的 PID，而非转义序列。shellexpand 的这种行为是其库的特定实现。

已在单元测试中完整验证该行为。

## 人工手动集成测试

### 1. 基础功能验证
- [x] **场景 A：基本环境变量替换**
    - 操作：创建一个 `config.toml`，其中 `network_secret` 使用 `${ET_SECRET}`。
    - 步骤：
        1. `export ET_SECRET="my-secret-key"`
        2. 运行 `easytier-core -c config.toml`
    - 预期：EasyTier 成功启动，且网络密钥被正确解析为 "my-secret-key"。
- [x] **场景 B：默认值回退**
    - 操作：在 `config.toml` 中使用 `${ET_PORT:-11010}`，且**不**设置 `ET_PORT` 环境变量。
    - 步骤：运行 `easytier-core -c config.toml`
    - 预期：EasyTier 成功启动，监听端口为 11010。
- [x] **场景 C：禁用解析开关**
    - 操作：在 `config.toml` 中包含字面量 `${VAR}`（非环境变量意图）。
    - 步骤：运行 `easytier-core -c config.toml --disable-env-parsing`
    - 预期：EasyTier 启动，配置中的 `${VAR}` 保持原样，未被尝试解析。

### 2. 安全性验证 (RPC/API)
- [x] **场景 D：只读配置保护**
    - 操作：启动一个使用了环境变量的实例。
    - 步骤：使用 `easytier-cli` 或 Web Console 尝试获取该实例的配置（`get_network_instance_config`）。
    - 预期：操作失败，返回错误信息提示配置为只读，无法通过 API 获取。
- [x] **场景 E：防止配置覆写**
    - 操作：启动一个使用了环境变量的实例。
    - 步骤：尝试通过 GUI 或 CLI 修改该实例的配置并保存。
    - 预期：保存失败或提示只读，文件系统上的 `config.toml` 未被修改（特别是未被展开后的值覆盖）。

### 3. 多实例与隔离
- [x] **场景 F：多实例不同环境**
    - 操作：准备两个配置文件 `work.toml` (`${WORK_SECRET}`) 和 `home.toml` (`${HOME_SECRET}`)。
    - 步骤：
        1. `export WORK_SECRET="company-key"`
        2. `export HOME_SECRET="family-key"`
        3. 同时启动两个实例。
    - 预期：两个实例同时运行，且分别使用了正确的、不同的密钥。

### 4. 容器与编排环境 (模拟)
- [x] **场景 G：Docker 模拟**
    - 操作：模拟 Docker 传参。
    - 步骤：`ET_SECRET="docker-key" easytier-core -c config.toml`
    - 预期：配置正确加载。这验证了通过进程环境传递变量的有效性。

### 5. GUI/Web Console 交互
- [x] **场景 I：GUI/Web 配置下发**
    - 操作：通过 Web Console 或 GUI 客户端向实例下发配置（例如修改网络名称或密钥）。
    - 步骤：在配置字段中输入 `${VAR}` 或 `$VAR` 形式的字符串。
    - 预期：
        - **Web Console**：下发的配置**不应**发生环境变量解析。保存后再次查看，应仍显示为 `${VAR}` 字面量。
        - **GUI**：同上，远程配置不进行解析。
    - 备注：这是为了确保环境变量解析仅作为本地文件系统加载的特性，避免远程下发意外引用了运行环境的变量。
- [x] 验证只读配置无法通过 GUI/Web 修改或删除

### 6. 错误处理
- [x] **场景 H：未定义变量**
    - 操作：配置文件引用 `${UNDEFINED_VAR}`，且未设置该环境变量。
    - 步骤：运行 `easytier-core`。
    - 预期：程序启动，配置项保留原字符串 `${UNDEFINED_VAR}`。如果该字段有格式要求（如 IP 地址），程序可能会因配置解析错误而启动失败；如果是字符串字段（如密钥），则会使用字面量 `${UNDEFINED_VAR}` 启动。


## 解决的问题

### 1. GitOps/DevOps 场景

**问题**：配置文件需要纳入版本控制，但包含敏感密钥

**解决**：
- 配置文件只包含占位符，可安全提交到 Git
- 实际密钥通过环境变量在运行时注入
- 完美支持 Infrastructure as Code

### 2. NixOS 场景

**问题**：NixOS 用户的系统配置托管在 GitHub，密钥暴露风险

**解决**：
- 无需加密整个配置文件
- 配置模板可公开分享
- 密钥通过 NixOS 的 secrets 管理注入

### 3. Kubernetes 场景

**问题**：无法有效结合 ConfigMap 和 Secret

**解决**：
- 配置模板存储在 ConfigMap
- 敏感密钥存储在 Secret 并注入为环境变量
- 符合云原生最佳实践

### 4. 单机多实例场景

**问题**：难以为每个实例配置不同的密钥

**解决**：
- 每个配置文件可引用不同的环境变量
- 通过环境变量名实现配置隔离
- 支持灵活的多租户部署
