### PR TITLE
修改 api_host 默认值为打开的域名而非固定域名

### DIFF
--- a/easytier-web/frontend/public/api_meta.js
+++ b/easytier-web/frontend/public/api_meta.js
@@ -1,3 +1,7 @@
 window.apiMeta = {
-    api_host: "https://config-server.easytier.cn"
+    api_host: location.origin //使用 location.origin 代替原本固定域名
+    // 备用选项，使用默认的80端口建立面板导致连接失败时取消注释以下内容
+    // const defaultPort = location.protocol === 'https:' ? '443' : '80';
+    // const baseUrl = location.protocol + '//' + location.hostname + ':' + (location.port || defaultPort);
+    // api_host: baseUrl
 }


### PR DESCRIPTION
修改文件 `EasyTier/easytier-web/frontend/public/api_meta.js`
把 `api_host` 后面的默认链接换成 `location.origin`
在后面添加备用选项以面对特殊情况，大部分情况下 `location.origin` 足以胜任