### PR TITLE
feat: easytier-web supports custom listening addresses

### DIFF
--- a/easytier-web/locales/app.yml
+++ b/easytier-web/locales/app.yml
@@ -19,12 +19,24 @@ cli:
   config_server_protocol:
     en: "The protocol to listen for the config server, used by the easytier-core to connect to, possible values: udp, tcp, ws"
     zh-CN: "配置服务器的监听协议，用于被 easytier-core 连接, 可能的值：udp, tcp, ws"
+  config_server_addr_v4:
+    en: "IPv4 address to bind for the config server, default is 0.0.0.0"
+    zh-CN: "配置服务器绑定的 IPv4 地址，默认为 0.0.0.0"
+  config_server_addr_v6:
+    en: "IPv6 address to bind for the config server, default is ::"
+    zh-CN: "配置服务器绑定的 IPv6 地址，默认为 ::"
   api_server_port:
     en: "The port to listen for the restful server, acting as ApiHost and used by the web frontend"
     zh-CN: "restful 服务器的监听端口，作为 ApiHost 并被 web 前端使用"
+  api_server_addr:
+    en: "The address to bind the API server, default is 0.0.0.0"
+    zh-CN: "API 服务器绑定的地址，默认为 0.0.0.0"
   web_server_port:
     en: "The port to listen for the web dashboard server, default is same as the api server port"
     zh-CN: "web dashboard 服务器的监听端口, 默认为与 api 服务器端口相同"
+  web_server_addr:
+    en: "The address to bind the web dashboard server. Defaults to the API server address if not provided."
+    zh-CN: "web dashboard 服务器绑定的地址。若未提供则默认与 API 服务器地址相同。"
   no_web:
     en: "Do not run the web dashboard server"
     zh-CN: "不运行 web dashboard 服务器"


### PR DESCRIPTION
This patch introduces new CLI options to specify custom IPv4 and IPv6 addresses for config server, API server, and web server, allowing more flexible network binding instead of defaulting to all interfaces.

------
此补丁引入新的 CLI 选项，用于指定配置服务器、API 服务器和 Web 服务器的自定义 IPv4 和 IPv6 地址，从而允许更灵活的网络绑定，而非默认绑定到所有接口。