### PR TITLE
fix: magic dns tld_dns_zone were not working properly

### DIFF
--- a/easytier/src/instance/dns_server/server_instance.rs
+++ b/easytier/src/instance/dns_server/server_instance.rs
@@ -527,11 +527,11 @@ impl MagicDnsServerInstance {
         // Use configured tld_dns_zone or fall back to DEFAULT_ET_DNS_ZONE if empty
         let flags = peer_mgr.get_global_ctx().config.get_flags();
         let tld_dns_zone_clone = flags.tld_dns_zone.clone();
-        
+
         data.update_dns_records(std::iter::empty(), &tld_dns_zone_clone)
             .await
             .context("Failed to initialize DNS zone")?;
-        
+
         let data_clone = data.clone();
         tokio::task::spawn_blocking(move || data_clone.do_system_config(&tld_dns_zone_clone))
             .await


### PR DESCRIPTION
The DNS server was only registering zones when routes were updated via RPC calls from clients. Since routes were added after peer link established, the demanded zone was never initialized, causing queries to be forwarded to upstream DNS servers instead of being handled authoritatively by the 100.100.100.101 MagicDNS server.

A example previous version was posted here:

> config.toml

```toml
# ....
[flags]
accept_dns = true
tld_dns_zone = "abc.xyz."
# ....
```

```shell
root@rv-router-01:~# nslookup rv-router-01.et.net 100.100.100.101
Server:         100.100.100.101
Address:        100.100.100.101:53


Name:   rv-router-01.et.net
Address: 192.168.20.1

root@rv-router-01:~# nslookup rv-router-01.abc.xyz 100.100.100.101
Server:         100.100.100.101
Address:        100.100.100.101:53

Non-authoritative answer:
Name:   rv-router-01.abc.xyz
Address: 104.21.2.57
Name:   rv-router-01.abc.xyz
Address: 172.67.128.207

Non-authoritative answer:
Name:   rv-router-01.abc.xyz
Address: 2606:4700:3031::ac43:80cf
Name:   rv-router-01.abc.xyz
Address: 2606:4700:3031::6815:239

```



I have modified easytier/src/instance/dns_server/server_instance.rs to initialize DNS zone as soon as easytir-core starts. This makes the DNS server authoritative for the configured zone from the beginning.