### PR TITLE
feat: replace with 0 when ws/wss use standard port explicitly

### DIFF
--- a/easytier/src/common/dns.rs
+++ b/easytier/src/common/dns.rs
@@ -74,6 +74,7 @@ pub async fn socket_addrs(
         .or_else(default_port_number)
         .ok_or(Error::InvalidUrl(url.to_string()))?;
     // See https://github.com/EasyTier/EasyTier/pull/947
+    // here is for compatibility with old version
     let port = match port {
         0 => match url.scheme() {
             "ws" => 80,

--- a/easytier/src/tunnel/mod.rs
+++ b/easytier/src/tunnel/mod.rs
@@ -207,8 +207,8 @@ fn default_port(scheme: &str) -> Option<u16> {
     match scheme {
         "tcp" => Some(11010),
         "udp" => Some(11010),
-        "ws" => Some(11011),
-        "wss" => Some(11012),
+        "ws" => Some(80),
+        "wss" => Some(443),
         "faketcp" => Some(11013),
         "quic" => Some(11012),
         "wg" => Some(11011),


### PR DESCRIPTION
## 简介
经过 #947 改善后，目前如果要使用 ws/wss 协议的标准端口，需要将 url 写成 `ws(s)://address:0` 的方式。
但是这种写法不常为人所知，往往是发生连接异常然后来 issue 搜索才知道这个写法。
而且目前使用 `ws://address:80` 这种写法仍然会被转换为 `ws://address:11011`，这样非常反直觉。
所以我写个这个改善方案：将用户输入的 `ws(s)://address:80(443)` 在被 `url.parse()` 修剪前先转换为 `ws(s)://address:0`。然后在实际连接/监听时再从 `socket_addrs()` 里还原成标准端口。

目前的处理逻辑（wss 对应的 443 同理）：
| url | parse() | listen or connect |
| --- | --- | --- |
| ws://addr | ws://addr | ws://addr:11011 |
| ws://addr:80 | ws://addr | ws://addr:11011 |
| ws://addr:0 | ws://addr:0 | ws://addr:80 |
| ws://addr:8080 | ws://addr:8080 | ws://addr:8080 |

改善后的处理逻辑（wss 对应的 443 同理）：
| url | process_url_port() | parse() | listen or connect |
| --- | --- | --- | --- |
| ws://addr | ws://addr | ws://addr | ws://addr:11011 |
| ws://addr:80 | ws://addr:0 | ws://addr:0 | ws://addr:80 |
| ws://addr:0 | ws://addr:0 | ws://addr:0 | ws://addr:80 |
| ws://addr:8080 | ws://addr:8080 | ws://addr:8080 | ws://addr:8080 |

这样修改向后兼容：没有端口使用默认端口，0 端口用标准端口，指定端口就用指定端口。
唯一的区别就是指定使用标准端口时，以前是用默认端口，修改后使用标准端口。
只不过这个修改还不完美：输入 `ws://addr:80` 时，输出配置和日志仍然是 `ws://addr:0`。

我本来想通过给 url 设置包装类，重写序列化和反序列化函数来实现完美的替换。但后来发现牵动的地方太多，几乎整个代码用到 url 的地方都要替换，所以就采用了当前这个方案。

functionally resolve #1401 

## 代码实现细节
* utls.rs
添加了一个新函数 `process_url_port()`
作用是对输入字符串判断：如果是协议 `ws://` 且端口为 `:80`，或协议 `wss://` 端口 `:443` 就将端口替换为 0
* core.rs 和 launcher.rs
读取/转换用户输入的 peer、node、server、listener 的 url 原本调用 `url.parse()` 的地方都替换成了 `process_url_port()`