### PR TITLE
fix(gui): open_log_dir not working

### DIFF
--- a/easytier-gui/src/pages/index.vue
+++ b/easytier-gui/src/pages/index.vue
@@ -255,6 +255,7 @@ const log_menu_items_popup: Ref<MenuItem[]> = ref([
       // console.log('open log dir', await getLogDirPath())
       await open(await getLogDirPath())
     },
+    visible: () => type() !== 'android',
   },
   {
     label: () => t('logging_copy_dir'),


### PR DESCRIPTION
我使用日志的时候发现“打开日志目录”这个功能是失效的。
看了下代码发现是忘了导入 shell 插件的 open 函数了。所以就给添上了。

此外，“打开日志目录”这个功能在 Android 上是不起作用的。
据我所知 android 也并不具备打开文件管理器并跳转指定目录的功能。
tauri shell 插件的 open 函数在 Android 上只能打开 mailto: https: wx: 这类 url。
所以我就把这个按钮在 Android 上隐藏了。