### PR TITLE
fix: ensure proxy routes update correctly on NIC

### DIFF
--- a/easytier/src/instance/virtual_nic.rs
+++ b/easytier/src/instance/virtual_nic.rs
@@ -892,10 +892,10 @@ impl NicCtx {
             let mut cur_proxy_cidrs = BTreeSet::<cidr::Ipv4Cidr>::new();
 
             // Initial sync: get current proxy_cidrs state and apply routes
-            let (added, removed) = ProxyCidrsMonitor::diff_proxy_cidrs(
+            let (_, added, removed) = ProxyCidrsMonitor::diff_proxy_cidrs(
                 peer_mgr.as_ref(),
                 &global_ctx,
-                &mut cur_proxy_cidrs,
+                &cur_proxy_cidrs,
             )
             .await;
             Self::apply_route_changes(
@@ -921,10 +921,10 @@ impl NicCtx {
                         );
                         event_receiver = event_receiver.resubscribe();
                         // Full sync after lagged to recover consistent state
-                        let (added, removed) = ProxyCidrsMonitor::diff_proxy_cidrs(
+                        let (_, added, removed) = ProxyCidrsMonitor::diff_proxy_cidrs(
                             peer_mgr.as_ref(),
                             &global_ctx,
-                            &mut cur_proxy_cidrs,
+                            &cur_proxy_cidrs,
                         )
                         .await;
                         GlobalCtxEvent::ProxyCidrsUpdated(added, removed)


### PR DESCRIPTION
修复 #1717 中引入的在使用虚拟网卡（NIC）时，由于代理 CIDR 状态管理不当导致的路由未能成功更新的问题。

将函数`ProxyCidrsMonitor::diff_proxy_cidrs`从原地修改（in-place mutation）模式重构为纯函数模式。