### PR TITLE
feat: Update Cargo.toml for easytier-gui and android app to support  tls1.2

### DIFF
--- a/easytier-gui/src-tauri/Cargo.toml
+++ b/easytier-gui/src-tauri/Cargo.toml
@@ -35,6 +35,9 @@ serde_json = "1"
 
 easytier = { path = "../../easytier" }
 tokio = { version = "1", features = ["full"] }
+rustls = { version = "0.23.0", features = [
+    "ring",
+] }
 anyhow = "1.0"
 chrono = { version = "0.4.37", features = ["serde"] }
 


### PR DESCRIPTION
fix #1531。根据 @CrazyBoyFeng 在 #1691 和 #1531 中的分析，为easytier-gui仅支持tls1.3而不支持tls1.2导致。通过更改easytier-gui构建配置，添加rustls依赖（需要ring特性）即可解决该问题。在windows和android平台上均测试通过。  