### PR TITLE
feat(gui): persist and restore last used network instance ID

### DIFF
--- a/easytier-gui/src/auto-imports.d.ts
+++ b/easytier-gui/src/auto-imports.d.ts
@@ -43,6 +43,7 @@ declare global {
   const isWebClientConnected: typeof import('./composables/backend')['isWebClientConnected']
   const listNetworkInstanceIds: typeof import('./composables/backend')['listNetworkInstanceIds']
   const listenGlobalEvents: typeof import('./composables/event')['listenGlobalEvents']
+  const loadLastNetworkInstanceId: typeof import('./composables/config')['loadLastNetworkInstanceId']
   const loadMode: typeof import('./composables/mode')['loadMode']
   const mapActions: typeof import('pinia')['mapActions']
   const mapGetters: typeof import('pinia')['mapGetters']
@@ -76,6 +77,7 @@ declare global {
   const ref: typeof import('vue')['ref']
   const resolveComponent: typeof import('vue')['resolveComponent']
   const runNetworkInstance: typeof import('./composables/backend')['runNetworkInstance']
+  const saveLastNetworkInstanceId: typeof import('./composables/config')['saveLastNetworkInstanceId']
   const saveMode: typeof import('./composables/mode')['saveMode']
   const saveNetworkConfig: typeof import('./composables/backend')['saveNetworkConfig']
   const sendConfigs: typeof import('./composables/backend')['sendConfigs']
@@ -165,6 +167,7 @@ declare module 'vue' {
     readonly isWebClientConnected: UnwrapRef<typeof import('./composables/backend')['isWebClientConnected']>
     readonly listNetworkInstanceIds: UnwrapRef<typeof import('./composables/backend')['listNetworkInstanceIds']>
     readonly listenGlobalEvents: UnwrapRef<typeof import('./composables/event')['listenGlobalEvents']>
+    readonly loadLastNetworkInstanceId: UnwrapRef<typeof import('./composables/config')['loadLastNetworkInstanceId']>
     readonly loadMode: UnwrapRef<typeof import('./composables/mode')['loadMode']>
     readonly mapActions: UnwrapRef<typeof import('pinia')['mapActions']>
     readonly mapGetters: UnwrapRef<typeof import('pinia')['mapGetters']>
@@ -198,6 +201,7 @@ declare module 'vue' {
     readonly ref: UnwrapRef<typeof import('vue')['ref']>
     readonly resolveComponent: UnwrapRef<typeof import('vue')['resolveComponent']>
     readonly runNetworkInstance: UnwrapRef<typeof import('./composables/backend')['runNetworkInstance']>
+    readonly saveLastNetworkInstanceId: UnwrapRef<typeof import('./composables/config')['saveLastNetworkInstanceId']>
     readonly saveMode: UnwrapRef<typeof import('./composables/mode')['saveMode']>
     readonly saveNetworkConfig: UnwrapRef<typeof import('./composables/backend')['saveNetworkConfig']>
     readonly sendConfigs: UnwrapRef<typeof import('./composables/backend')['sendConfigs']>

--- a/easytier-gui/src/composables/config.ts
+++ b/easytier-gui/src/composables/config.ts
@@ -1,0 +1,20 @@
+/**
+ * 配置持久化相关的函数
+ * 用于保存和加载应用程序的各种配置状态
+ */
+
+/**
+ * 保存上次使用的网络实例 ID
+ * @param instanceId 网络实例 ID
+ */
+export function saveLastNetworkInstanceId(instanceId: string) {
+    localStorage.setItem('last_network_instance_id', instanceId)
+}
+
+/**
+ * 加载上次使用的网络实例 ID
+ * @returns 上次使用的网络实例 ID，如果没有则返回 null
+ */
+export function loadLastNetworkInstanceId(): string | null {
+    return localStorage.getItem('last_network_instance_id')
+}

--- a/easytier-gui/src/pages/index.vue
+++ b/easytier-gui/src/pages/index.vue
@@ -13,6 +13,7 @@ import { GUIRemoteClient } from '~/modules/api'
 
 import { useToast, useConfirm } from 'primevue'
 import { loadMode, saveMode, WebClientConfig, type Mode } from '~/composables/mode'
+import { saveLastNetworkInstanceId, loadLastNetworkInstanceId } from '~/composables/config'
 import ModeSwitcher from '~/components/ModeSwitcher.vue'
 import { getServiceStatus } from '~/composables/backend'
 
@@ -190,6 +191,12 @@ const remoteClient = computed(() => new GUIRemoteClient());
 const instanceId = ref<string | undefined>(undefined);
 const clientRunning = ref(false);
 
+watch(instanceId, (newVal) => {
+  if (newVal) {
+    saveLastNetworkInstanceId(newVal);
+  }
+});
+
 watch(clientRunning, async (newVal, oldVal) => {
   if (!newVal && oldVal) {
     if (manualDisconnect.value) {
@@ -197,6 +204,11 @@ watch(clientRunning, async (newVal, oldVal) => {
       return
     }
     await reconnectClient()
+  } else if (newVal && !oldVal) {
+    const lastInstanceId = loadLastNetworkInstanceId();
+    if (lastInstanceId) {
+      instanceId.value = lastInstanceId;
+    }
   }
 })
 


### PR DESCRIPTION
## 变更摘要
本次 PR 解决了 GUI 在重启或客户端重新连接后无法记住上次选中的网络实例的问题。通过将上次使用的网络实例 ID 持久化到 `localStorage`，并在客户端就绪时自动恢复，提升了用户体验。

## 详细修改内容
- **新增配置持久化模块**：创建了 [easytier-gui/src/composables/config.ts](easytier-gui/src/composables/config.ts)，提供基于 `localStorage` 的 `instanceId` 保存和加载功能。
- **自动保存状态**：在 [easytier-gui/src/pages/index.vue](easytier-gui/src/pages/index.vue) 中添加了对 `instanceId` 的监听，每当用户切换实例时自动更新持久化记录。
- **自动恢复状态**：在客户端服务启动或重新连接成功后，自动从持久化记录中读取并设置 `instanceId`。
- **类型定义更新**：更新了 [easytier-gui/src/auto-imports.d.ts](easytier-gui/src/auto-imports.d.ts) 以支持新增函数的自动导入。

## 测试验证
- [x] 切换网络实例后重启 GUI，确认能够自动选中上次的实例。
- [x] 验证在无持久化记录（首次运行）时的默认行为是否正常。

## 关联 Issue
- close #1735