### PR TITLE
feat(gui): add encryption algorithm selector to network config

### DIFF
--- a/easytier-web/frontend-lib/src/components/Config.vue
+++ b/easytier-web/frontend-lib/src/components/Config.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import InputGroup from 'primevue/inputgroup'
 import InputGroupAddon from 'primevue/inputgroupaddon'
-import { SelectButton, Checkbox, InputText, InputNumber, AutoComplete, Panel, Divider, ToggleButton, Button, Password, Dialog } from 'primevue'
+import { SelectButton, Checkbox, InputText, InputNumber, AutoComplete, Panel, Divider, ToggleButton, Button, Password, Dialog, Dropdown } from 'primevue'
 import {
   addRow,
   DEFAULT_NETWORK_CONFIG,
@@ -172,6 +172,16 @@ const bool_flags: BoolFlag[] = [
   { field: 'enable_private_mode', help: 'enable_private_mode_help' },
 ]
 
+const encryptionAlgorithmOptions = ref([
+  { label: 'AES-GCM', value: 'aes-gcm' },
+  { label: 'AES-256-GCM', value: 'aes-256-gcm' },
+  { label: 'XOR', value: 'xor' },
+  { label: 'ChaCha20', value: 'chacha20' },
+  { label: 'OpenSSL AES-GCM', value: 'openssl-aes-gcm' },
+  { label: 'OpenSSL ChaCha20', value: 'openssl-chacha20' },
+  { label: 'OpenSSL AES-256-GCM', value: 'openssl-aes-256-gcm' },
+])
+
 const portForwardProtocolOptions = ref(["tcp", "udp"]);
 
 const editingPortForward = ref(false);
@@ -297,6 +307,16 @@ onMounted(() => {
                     </div>
 
                   </div>
+                </div>
+              </div>
+
+              <div class="flex flex-row gap-x-9 flex-wrap">
+                <div class="flex flex-col gap-2 basis-5/12 grow">
+                  <label for="encryption_algorithm">{{ t('encryption_algorithm') }}</label>
+                  <Dropdown id="encryption_algorithm" v-model="curNetwork.encryption_algorithm"
+                    :options="encryptionAlgorithmOptions" option-label="label" option-value="value"
+                    :placeholder="t('encryption_algorithm_placeholder')" />
+                  <small class="p-text-secondary">{{ t('encryption_algorithm_help') }}</small>
                 </div>
               </div>
 

--- a/easytier-web/frontend-lib/src/locales/cn.yaml
+++ b/easytier-web/frontend-lib/src/locales/cn.yaml
@@ -132,6 +132,10 @@ proxy_forward_by_system_help: 通过系统内核转发子网代理数据包，�
 disable_encryption: 禁用加密
 disable_encryption_help: 禁用对等节点通信的加密，默认为false，必须与对等节点相同
 
+encryption_algorithm: 加密算法
+encryption_algorithm_placeholder: 选择加密算法
+encryption_algorithm_help: 为节点通信选择加密算法。空字符串表示默认值（aes-gcm）。必须与对等节点相同。
+
 disable_tcp_hole_punching: 禁用TCP打洞
 disable_tcp_hole_punching_help: 禁用TCP打洞功能
 

--- a/easytier-web/frontend-lib/src/locales/en.yaml
+++ b/easytier-web/frontend-lib/src/locales/en.yaml
@@ -131,6 +131,10 @@ proxy_forward_by_system_help: Forward packet to proxy networks via system kernel
 disable_encryption: Disable Encryption
 disable_encryption_help: Disable encryption for peers communication, default is false, must be same with peers
 
+encryption_algorithm: Encryption Algorithm
+encryption_algorithm_placeholder: Select encryption algorithm
+encryption_algorithm_help: Choose the encryption algorithm for peer communication. Empty string means default (aes-gcm). Must be the same as peers.
+
 disable_tcp_hole_punching: Disable TCP Hole Punching
 disable_tcp_hole_punching_help: Disable tcp hole punching
 

--- a/easytier-web/frontend-lib/src/types/network.ts
+++ b/easytier-web/frontend-lib/src/types/network.ts
@@ -50,6 +50,7 @@ export interface NetworkConfig {
   multi_thread?: boolean
   proxy_forward_by_system?: boolean
   disable_encryption?: boolean
+  encryption_algorithm?: string
   disable_tcp_hole_punching?: boolean
   disable_udp_hole_punching?: boolean
   disable_sym_hole_punching?: boolean
@@ -121,6 +122,7 @@ export function DEFAULT_NETWORK_CONFIG(): NetworkConfig {
     multi_thread: true,
     proxy_forward_by_system: false,
     disable_encryption: false,
+    encryption_algorithm: 'aes-gcm',
     disable_tcp_hole_punching: false,
     disable_udp_hole_punching: false,
     disable_sym_hole_punching: false,


### PR DESCRIPTION
feat(gui): add encryption algorithm selector to network config

- Add encryption_algorithm field to NetworkConfig interface
- Support all encryption algorithms: aes-gcm, aes-256-gcm, xor, chacha20, and openssl-* variants
- Add i18n translations (en/cn) for new fields
- Default algorithm: aes-gcm (backend default)