### PR TITLE
ui: clarify encryption checkbox description in locales

### DIFF
--- a/easytier-web/frontend-lib/src/locales/cn.yaml
+++ b/easytier-web/frontend-lib/src/locales/cn.yaml
@@ -130,7 +130,7 @@ proxy_forward_by_system: 系统转发
 proxy_forward_by_system_help: 通过系统内核转发子网代理数据包，禁用内置NAT
 
 disable_encryption: 禁用加密
-disable_encryption_help: 禁用对等节点通信的加密，默认为false，必须与对等节点相同
+disable_encryption_help: 禁用对等节点通信的加密。注意：默认启用加密，若勾选此项则关闭，必须与对等节点设置一致。
 
 disable_tcp_hole_punching: 禁用TCP打洞
 disable_tcp_hole_punching_help: 禁用TCP打洞功能

--- a/easytier-web/frontend-lib/src/locales/en.yaml
+++ b/easytier-web/frontend-lib/src/locales/en.yaml
@@ -129,7 +129,7 @@ proxy_forward_by_system: System Forward
 proxy_forward_by_system_help: Forward packet to proxy networks via system kernel, disable internal nat for network proxy
 
 disable_encryption: Disable Encryption
-disable_encryption_help: Disable encryption for peers communication, default is false, must be same with peers
+disable_encryption_help: Disable encryption for peers communication. Encryption is enabled by default, this option must be same with peers.
 
 disable_tcp_hole_punching: Disable TCP Hole Punching
 disable_tcp_hole_punching_help: Disable tcp hole punching


### PR DESCRIPTION
## 主要目的
修复 Issue #1837 中提到的“禁用加密”复选框描述歧义问题。通过优化国际化文案，明确“默认启用加密”以及“勾选即关闭”的业务逻辑，使 UI 描述更符合用户直觉。

## 关联 Issue
- Fixes #1837