### PR TITLE
call remove_peer instead of remove_network when peer id not match

### DIFF
--- a/easytier/src/peers/foreign_network_manager.rs
+++ b/easytier/src/peers/foreign_network_manager.rs
@@ -598,7 +598,7 @@ impl ForeignNetworkManager {
         {
             if new_added {
                 self.data
-                    .remove_network(&entry.network.network_name.clone());
+                    .remove_peer(peer_conn.get_peer_id(), &entry.network.network_name.clone());
             }
             let err = if entry.my_peer_id != peer_conn.get_my_peer_id() {
                 anyhow::anyhow!(


### PR DESCRIPTION
Old cold make server fail to handle foreign network create when huge number of clients connect simultaneously