### PR TITLE
ci: use shared key for build workflow

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -160,6 +160,7 @@ jobs:
           # The prefix cache key, this can be changed to start a new cache manually.
           # default: "v0-rust"
           prefix-key: ""
+          shared-key: "core-registry"
           cache-targets: "false"
 
       - name: Setup protoc


### PR DESCRIPTION
`cache-targets: "false"` 表明这个 cache 只保存 Cargo registry，这部分都是源代码， 可以被所有 target 共享，因此应该使用同一个 cache