### PR TITLE
feat: implement configurable node route distance for fine-grained routing control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2230,6 +2230,7 @@ dependencies = [
  "gethostname 0.5.0",
  "git-version",
  "globwalk",
+ "hashbrown 0.15.3",
  "hickory-client",
  "hickory-proto",
  "hickory-resolver",

--- a/easytier-web/frontend-lib/src/components/Config.vue
+++ b/easytier-web/frontend-lib/src/components/Config.vue
@@ -497,7 +497,7 @@ watch(() => curNetwork.value, syncNormalizedNetwork, { immediate: true, deep: fa
             </div>
             <div v-else class="flex justify-center p-4">
               <Button :label="t('acl.enabled')"
-                @click="curNetwork.acl = { acl_v1: { chains: [], group: { declares: [], members: [] } } }" />
+                @click="curNetwork.acl = { acl_v1: { chains: [], group: { declares: [], members: [] }, route_distance: { rules: [], default_distance: 1 } } }" />
             </div>
           </Panel>
 

--- a/easytier-web/frontend-lib/src/components/acl/AclManager.vue
+++ b/easytier-web/frontend-lib/src/components/acl/AclManager.vue
@@ -5,6 +5,7 @@ import { useI18n } from 'vue-i18n'
 import { Acl, AclAction, AclChainType } from '../../types/network'
 import AclChainEditor from './AclChainEditor.vue'
 import AclGroupEditor from './AclGroupEditor.vue'
+import AclRouteDistanceEditor from './AclRouteDistanceEditor.vue'
 
 const acl = defineModel<Acl>({ required: true })
 
@@ -21,7 +22,11 @@ const addMenuModel = ref([
 
 function addChain(type: AclChainType) {
   if (!acl.value.acl_v1) {
-    acl.value.acl_v1 = { chains: [], group: { declares: [], members: [] } }
+    acl.value.acl_v1 = {
+      chains: [],
+      group: { declares: [], members: [] },
+      route_distance: { rules: [], default_distance: 1 },
+    }
   }
 
   let defaultName = ''
@@ -84,6 +89,7 @@ const tabs = computed(() => {
   }
 
   result.push({ type: 'groups', label: t('acl.groups'), index: result.length })
+  result.push({ type: 'route-distance', label: t('acl.route_distance.title'), index: result.length })
   return result
 })
 </script>
@@ -140,8 +146,19 @@ const tabs = computed(() => {
             </template>
             <div v-else class="flex justify-center p-4">
               <Button :label="t('acl.enabled')"
-                @click="acl.acl_v1 = { chains: [], group: { declares: [], members: [] } }" />
+                @click="acl.acl_v1 = { chains: [], group: { declares: [], members: [] }, route_distance: { rules: [], default_distance: 1 } }" />
             </div>
+          </div>
+
+          <div v-if="tab.type === 'route-distance'" class="py-4">
+            <template v-if="acl.acl_v1">
+              <AclRouteDistanceEditor v-if="acl.acl_v1.route_distance" v-model="acl.acl_v1.route_distance"
+                :group-names="groupNames" />
+              <div v-else class="flex justify-center p-4">
+                <Button :label="t('acl.route_distance.enabled')"
+                  @click="acl.acl_v1.route_distance = { rules: [], default_distance: 1 }" />
+              </div>
+            </template>
           </div>
         </TabPanel>
       </TabPanels>

--- a/easytier-web/frontend-lib/src/components/acl/AclRouteDistanceEditor.vue
+++ b/easytier-web/frontend-lib/src/components/acl/AclRouteDistanceEditor.vue
@@ -1,0 +1,175 @@
+<script setup lang="ts">
+import { AutoComplete, Button, Checkbox, Column, DataTable, Dialog, InputNumber, InputText, MultiSelect, ToggleButton } from 'primevue'
+import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { RouteDistanceConfig, RouteDistanceRule } from '../../types/network'
+
+const props = defineProps<{
+  groupNames?: string[]
+}>()
+
+const routeDistance = defineModel<RouteDistanceConfig>({ required: true })
+
+const { t } = useI18n()
+
+watch(() => routeDistance.value.rules, (newRules) => {
+  if (!newRules) return
+  const isSorted = newRules.every((rule, i) => i === 0 || (rule.priority || 0) <= (newRules[i - 1].priority || 0))
+  if (!isSorted) {
+    routeDistance.value.rules.sort((a, b) => (b.priority || 0) - (a.priority || 0))
+  }
+}, { deep: true, immediate: true })
+
+const editingRule = ref<RouteDistanceRule | null>(null)
+const editingRuleIndex = ref(-1)
+const showRuleDialog = ref(false)
+const genericSuggestions = ref<string[]>([])
+
+function addRule() {
+  editingRuleIndex.value = -1
+  editingRule.value = {
+    name: '',
+    priority: routeDistance.value.rules.length,
+    enabled: true,
+    distance: routeDistance.value.default_distance || 1,
+    destination_ips: [],
+    destination_groups: [],
+  }
+  showRuleDialog.value = true
+}
+
+function editRule(index: number) {
+  editingRuleIndex.value = index
+  editingRule.value = JSON.parse(JSON.stringify(routeDistance.value.rules[index]))
+  showRuleDialog.value = true
+}
+
+function deleteRule(index: number) {
+  routeDistance.value.rules.splice(index, 1)
+}
+
+function saveRule() {
+  if (!editingRule.value) return
+  if (editingRuleIndex.value === -1) {
+    routeDistance.value.rules.push(editingRule.value)
+  } else {
+    routeDistance.value.rules[editingRuleIndex.value] = editingRule.value
+  }
+  routeDistance.value.rules.sort((a, b) => (b.priority || 0) - (a.priority || 0))
+  showRuleDialog.value = false
+}
+
+function onRowReorder(event: any) {
+  routeDistance.value.rules = event.value
+  routeDistance.value.rules.forEach((rule, index) => {
+    rule.priority = routeDistance.value.rules.length - index - 1
+  })
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-6">
+    <div
+      class="grid grid-cols-1 md:grid-cols-2 gap-4 p-4 bg-gray-50 rounded-lg border border-gray-200 dark:bg-gray-900 dark:border-gray-700">
+      <div class="flex flex-col gap-2">
+        <label class="font-bold text-sm">{{ t('acl.route_distance.default_distance') }}</label>
+        <InputNumber v-model="routeDistance.default_distance" :min="1" :max="2147483647" fluid />
+      </div>
+      <div class="flex items-center text-sm text-surface-500 pt-6 md:pt-0">
+        {{ t('acl.route_distance.help') }}
+      </div>
+    </div>
+
+    <div class="flex flex-row items-center gap-4 justify-between">
+      <h4 class="text-md font-bold">{{ t('acl.route_distance.title') }}</h4>
+      <Button icon="pi pi-plus" :label="t('acl.route_distance.add_rule')" severity="success" size="small" @click="addRule" />
+    </div>
+
+    <DataTable :value="routeDistance.rules" @row-reorder="onRowReorder" responsiveLayout="scroll">
+      <Column rowReorder headerStyle="width: 3rem" />
+      <Column field="enabled" :header="t('acl.rule.enabled')">
+        <template #body="{ data }">
+          <i class="pi" :class="data.enabled ? 'pi-check-circle text-green-500' : 'pi-times-circle text-red-500'"></i>
+        </template>
+      </Column>
+      <Column field="name" :header="t('acl.rule.name')" />
+      <Column field="distance" :header="t('acl.route_distance.distance')" />
+      <Column :header="t('acl.match')">
+        <template #body="{ data }">
+          <div class="flex flex-col gap-2 py-1">
+            <div class="flex flex-wrap gap-1 items-center overflow-hidden">
+              <span v-for="ip in data.destination_ips" :key="ip"
+                class="font-mono text-xs bg-surface-100 dark:bg-surface-800 px-1.5 py-0.5 rounded">{{ ip }}</span>
+              <span v-for="grp in data.destination_groups" :key="grp"
+                class="text-xs font-bold text-purple-600 dark:text-purple-400">@{{ grp }}</span>
+              <span v-if="data.foreign_node === true" class="text-xs font-bold text-amber-600 dark:text-amber-400">
+                {{ t('acl.route_distance.foreign_node') }}
+              </span>
+              <span v-if="!data.destination_ips.length && !data.destination_groups.length && data.foreign_node !== true"
+                class="text-gray-400">*</span>
+            </div>
+          </div>
+        </template>
+      </Column>
+      <Column :header="t('web.common.edit')">
+        <template #body="{ index }">
+          <div class="flex gap-2">
+            <Button icon="pi pi-pencil" text rounded @click="editRule(index)" />
+            <Button icon="pi pi-trash" severity="danger" text rounded @click="deleteRule(index)" />
+          </div>
+        </template>
+      </Column>
+    </DataTable>
+
+    <Dialog v-model:visible="showRuleDialog" modal :header="t('acl.route_distance.edit_rule')"
+      :style="{ width: '90vw', maxWidth: '600px' }">
+      <div v-if="editingRule" class="flex flex-col gap-4">
+        <div class="flex flex-row gap-4 items-center">
+          <div class="flex flex-col gap-2 grow">
+            <label class="font-bold">{{ t('acl.rule.name') }}</label>
+            <InputText v-model="editingRule.name" fluid />
+          </div>
+          <div class="flex flex-col gap-2">
+            <label class="font-bold">{{ t('acl.rule.enabled') }}</label>
+            <ToggleButton v-model="editingRule.enabled" on-icon="pi pi-check" off-icon="pi pi-times"
+              :on-label="t('web.common.enable')" :off-label="t('web.common.disable')" class="w-24" />
+          </div>
+        </div>
+
+        <div class="flex flex-row gap-4 flex-wrap">
+          <div class="flex flex-col gap-2 grow">
+            <label class="font-bold">{{ t('acl.route_distance.priority') }}</label>
+            <InputNumber v-model="editingRule.priority" :min="0" :max="65535" fluid />
+          </div>
+          <div class="flex flex-col gap-2 grow">
+            <label class="font-bold">{{ t('acl.route_distance.distance') }}</label>
+            <InputNumber v-model="editingRule.distance" :min="1" :max="2147483647" fluid />
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-2">
+          <label class="font-bold">{{ t('acl.route_distance.dst_ips') }}</label>
+          <AutoComplete v-model="editingRule.destination_ips" multiple fluid :suggestions="genericSuggestions"
+            @complete="genericSuggestions = [$event.query]" :placeholder="t('chips_placeholder', ['10.126.126.0/24'])" />
+        </div>
+
+        <div class="flex flex-col gap-2">
+          <label class="font-bold">{{ t('acl.route_distance.dst_groups') }}</label>
+          <MultiSelect v-model="editingRule.destination_groups" :options="props.groupNames" multiple fluid filter
+            :placeholder="t('acl.route_distance.dst_groups')" />
+        </div>
+
+        <div class="flex items-center gap-2">
+          <Checkbox v-model="editingRule.foreign_node" :binary="true" inputId="route-distance-foreign-node" />
+          <label for="route-distance-foreign-node" class="font-bold">{{ t('acl.route_distance.foreign_node') }}</label>
+          <small class="text-surface-500">{{ t('acl.route_distance.foreign_node_hint') }}</small>
+        </div>
+      </div>
+
+      <template #footer>
+        <Button :label="t('web.common.cancel')" icon="pi pi-times" @click="showRuleDialog = false" text />
+        <Button :label="t('web.common.save')" icon="pi pi-save" @click="saveRule" />
+      </template>
+    </Dialog>
+  </div>
+</template>

--- a/easytier-web/frontend-lib/src/locales/cn.yaml
+++ b/easytier-web/frontend-lib/src/locales/cn.yaml
@@ -466,3 +466,16 @@ acl:
     name: 名称
     type: 类型
   match: 匹配
+  route_distance:
+    title: 路由距离
+    help: 为不同目标配置路由距离规则，影响对等节点的路径选择。
+    enabled: 启用路由距离配置
+    add_rule: 添加距离规则
+    edit_rule: 编辑距离规则
+    default_distance: 默认距离
+    distance: 距离
+    priority: 优先级
+    dst_ips: 目的 IP
+    dst_groups: 目的组
+    foreign_node: 仅外部节点
+    foreign_node_hint: 启用后仅匹配公网/共享节点。

--- a/easytier-web/frontend-lib/src/locales/en.yaml
+++ b/easytier-web/frontend-lib/src/locales/en.yaml
@@ -466,3 +466,16 @@ acl:
     name: Name
     type: Type
   match: Match
+  route_distance:
+    title: Route Distance
+    help: Set per-destination route distance rules for peer routing decisions.
+    enabled: Enable Route Distance
+    add_rule: Add Distance Rule
+    edit_rule: Edit Distance Rule
+    default_distance: Default Distance
+    distance: Distance
+    priority: Priority
+    dst_ips: Destination IPs
+    dst_groups: Destination Groups
+    foreign_node: Foreign Node Only
+    foreign_node_hint: Only match public/shared nodes when enabled.

--- a/easytier-web/frontend-lib/src/types/network.ts
+++ b/easytier-web/frontend-lib/src/types/network.ts
@@ -73,9 +73,25 @@ export interface GroupInfo {
   members: string[]
 }
 
+export interface RouteDistanceRule {
+  name: string
+  priority: number
+  enabled: boolean
+  distance: number
+  destination_ips: string[]
+  destination_groups: string[]
+  foreign_node?: boolean
+}
+
+export interface RouteDistanceConfig {
+  rules: RouteDistanceRule[]
+  default_distance: number
+}
+
 export interface AclV1 {
   chains: AclChain[]
   group?: GroupInfo
+  route_distance?: RouteDistanceConfig
 }
 
 export interface Acl {
@@ -228,6 +244,10 @@ export function DEFAULT_NETWORK_CONFIG(): NetworkConfig {
           members: [],
         },
         chains: [],
+        route_distance: {
+          rules: [],
+          default_distance: 1,
+        },
       },
     },
   }

--- a/easytier/Cargo.toml
+++ b/easytier/Cargo.toml
@@ -165,6 +165,7 @@ network-interface = "2.0"
 
 # for ospf route
 petgraph = "0.8.1"
+hashbrown = "0.15.3"
 ordered_hash_map = "0.5.0"
 
 # for wireguard

--- a/easytier/build.rs
+++ b/easytier/build.rs
@@ -182,6 +182,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .extern_path(".google.protobuf.Value", "::prost_wkt_types::Value")
         .file_descriptor_set_path(&descriptor_file)
         .protoc_arg("--experimental_allow_proto3_optional")
+        .type_attribute("acl.RouteDistanceRule", "#[derive(Hash)]")
+        .type_attribute("acl.RouteDistanceConfig", "#[derive(Hash)]")
         .type_attribute("peer_rpc.DirectConnectedPeerInfo", "#[derive(Hash)]")
         .type_attribute("peer_rpc.PeerInfoForGlobalMap", "#[derive(Hash)]")
         .type_attribute("peer_rpc.ForeignNetworkRouteInfoKey", "#[derive(Hash, Eq)]")

--- a/easytier/src/common/acl_processor.rs
+++ b/easytier/src/common/acl_processor.rs
@@ -1203,6 +1203,7 @@ impl AclRuleBuilder {
                     declares: vec![],
                     members: vec![],
                 }),
+                route_distance: None,
             });
         }
 
@@ -1233,11 +1234,187 @@ pub enum AclStatType {
     Noop,
 }
 
+#[derive(Debug, Clone)]
+pub struct PeerDistanceInfo {
+    pub ipv4_addr: Option<std::net::Ipv4Addr>,
+    pub ipv6_addr: Option<std::net::Ipv6Addr>,
+    pub verified_groups: Vec<String>,
+    pub is_public_server: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct FastDistanceRule {
+    pub name: String,
+    pub priority: u32,
+    pub enabled: bool,
+    pub distance: u32,
+    pub destination_ip_cidrs: Vec<cidr::IpCidr>,
+    pub destination_groups: HashSet<String>,
+    pub foreign_node: Option<bool>,
+}
+
+impl FastDistanceRule {
+    pub fn matches_ip(&self, peer: &PeerDistanceInfo) -> bool {
+        if self.destination_ip_cidrs.is_empty() {
+            return true;
+        }
+
+        let ipv4_match = peer.ipv4_addr.is_some_and(|ipv4| {
+            self.destination_ip_cidrs.iter().any(|cidr| match cidr {
+                cidr::IpCidr::V4(v4_cidr) => v4_cidr.contains(&ipv4),
+                cidr::IpCidr::V6(_) => false,
+            })
+        });
+
+        let ipv6_match = peer.ipv6_addr.is_some_and(|ipv6| {
+            self.destination_ip_cidrs.iter().any(|cidr| match cidr {
+                cidr::IpCidr::V4(_) => false,
+                cidr::IpCidr::V6(v6_cidr) => v6_cidr.contains(&ipv6),
+            })
+        });
+
+        ipv4_match || ipv6_match
+    }
+
+    pub fn matches_groups(&self, peer: &PeerDistanceInfo) -> bool {
+        if self.destination_groups.is_empty() {
+            return true;
+        }
+        peer.verified_groups
+            .iter()
+            .any(|g| self.destination_groups.contains(g))
+    }
+
+    pub fn matches_foreign(&self, peer: &PeerDistanceInfo) -> bool {
+        match self.foreign_node {
+            None => true,
+            Some(required) => peer.is_public_server == required,
+        }
+    }
+
+    pub fn matches(&self, peer: &PeerDistanceInfo) -> bool {
+        self.enabled
+            && self.matches_ip(peer)
+            && self.matches_groups(peer)
+            && self.matches_foreign(peer)
+    }
+}
+
+pub struct RouteDistanceProcessor {
+    rules: Vec<FastDistanceRule>,
+    default_distance: u32,
+}
+
+impl RouteDistanceProcessor {
+    fn validate_distance(distance: u32, rule_name: &str) -> u32 {
+        if distance == 0 {
+            tracing::warn!(
+                "RouteDistanceRule '{}': distance=0 is invalid, correcting to 1",
+                rule_name
+            );
+            return 1;
+        }
+        let max_distance = i32::MAX as u32;
+        if distance > max_distance {
+            tracing::warn!(
+                "RouteDistanceRule '{}': distance={} exceeds i32::MAX, capping to {}",
+                rule_name,
+                distance,
+                max_distance
+            );
+            return max_distance;
+        }
+        distance
+    }
+
+    pub fn new(config: &RouteDistanceConfig) -> Self {
+        let mut rules: Vec<FastDistanceRule> = config
+            .rules
+            .iter()
+            .map(|rule| {
+                let destination_ip_cidrs = rule
+                    .destination_ips
+                    .iter()
+                    .filter_map(|s| cidr::IpCidr::from_str(s).ok())
+                    .collect();
+                let destination_groups: HashSet<String> =
+                    rule.destination_groups.iter().cloned().collect();
+                let validated_distance = Self::validate_distance(rule.distance, &rule.name);
+
+                FastDistanceRule {
+                    name: rule.name.clone(),
+                    priority: rule.priority,
+                    enabled: rule.enabled,
+                    distance: validated_distance,
+                    destination_ip_cidrs,
+                    destination_groups,
+                    foreign_node: rule.foreign_node,
+                }
+            })
+            .collect();
+
+        rules.sort_by_key(|b| std::cmp::Reverse(b.priority));
+
+        let default_distance = if config.default_distance == 0 {
+            tracing::warn!("RouteDistanceConfig: default_distance=0 is invalid, correcting to 1");
+            1
+        } else if config.default_distance > i32::MAX as u32 {
+            tracing::warn!(
+                "RouteDistanceConfig: default_distance={} exceeds i32::MAX, capping to {}",
+                config.default_distance,
+                i32::MAX as u32
+            );
+            i32::MAX as u32
+        } else {
+            config.default_distance
+        };
+
+        tracing::info!(
+            "RouteDistanceProcessor initialized: {} rules, default_distance={}",
+            rules.len(),
+            default_distance
+        );
+
+        Self {
+            rules,
+            default_distance,
+        }
+    }
+
+    pub fn calculate_distance(&self, peer: &PeerDistanceInfo) -> u32 {
+        for rule in &self.rules {
+            if rule.matches(peer) {
+                tracing::debug!(
+                    "RouteDistanceProcessor: peer matched rule '{}' with distance={}",
+                    rule.name,
+                    rule.distance
+                );
+                return rule.distance;
+            }
+        }
+
+        tracing::debug!(
+            "RouteDistanceProcessor: no rule matched, using default_distance={}",
+            self.default_distance
+        );
+        self.default_distance
+    }
+
+    pub fn default_distance(&self) -> u32 {
+        self.default_distance
+    }
+
+    pub fn rule_count(&self) -> usize {
+        self.rules.len()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
     use std::hash::{Hash, Hasher};
-    use std::net::{IpAddr, Ipv4Addr};
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
     #[tokio::test]
     async fn test_group_based_acl_rules() {
@@ -1684,5 +1861,262 @@ mod tests {
             result2.log_context,
             Some(AclLogContext::RateLimitDrop)
         ));
+    }
+
+    fn create_test_peer_info() -> PeerDistanceInfo {
+        PeerDistanceInfo {
+            ipv4_addr: Some(Ipv4Addr::new(192, 168, 1, 100)),
+            ipv6_addr: None,
+            verified_groups: vec!["group_a".to_string(), "group_b".to_string()],
+            is_public_server: false,
+        }
+    }
+
+    fn create_test_route_distance_config() -> RouteDistanceConfig {
+        RouteDistanceConfig {
+            rules: vec![
+                RouteDistanceRule {
+                    name: "high_priority_rule".to_string(),
+                    priority: 100,
+                    enabled: true,
+                    distance: 10,
+                    destination_ips: vec!["192.168.1.0/24".to_string()],
+                    destination_groups: vec![],
+                    foreign_node: None,
+                },
+                RouteDistanceRule {
+                    name: "medium_priority_rule".to_string(),
+                    priority: 50,
+                    enabled: true,
+                    distance: 20,
+                    destination_ips: vec![],
+                    destination_groups: vec!["group_a".to_string()],
+                    foreign_node: None,
+                },
+                RouteDistanceRule {
+                    name: "low_priority_rule".to_string(),
+                    priority: 10,
+                    enabled: true,
+                    distance: 30,
+                    destination_ips: vec![],
+                    destination_groups: vec![],
+                    foreign_node: Some(true),
+                },
+            ],
+            default_distance: 1,
+        }
+    }
+
+    #[rstest]
+    #[case::empty_cidrs(vec![], Some(Ipv4Addr::new(192, 168, 1, 100)), None, true)]
+    #[case::with_match(vec!["192.168.1.0/24"], Some(Ipv4Addr::new(192, 168, 1, 100)), None, true)]
+    #[case::no_match(vec!["10.0.0.0/8"], Some(Ipv4Addr::new(192, 168, 1, 100)), None, false)]
+    #[case::no_ipv4(vec!["192.168.1.0/24"], None, None, false)]
+    #[case::ipv6_match(vec!["fd00::/8"], None, Some(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1)), true)]
+    #[case::ipv6_no_match(vec!["fe80::/10"], None, Some(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1)), false)]
+    #[case::no_ipv6_with_v6_cidr(vec!["fd00::/8"], None, None, false)]
+    #[case::mixed_ipv4_match(vec!["192.168.1.0/24", "fd00::/8"], Some(Ipv4Addr::new(192, 168, 1, 100)), None, true)]
+    #[case::mixed_ipv6_match(vec!["192.168.1.0/24", "fd00::/8"], None, Some(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1)), true)]
+    #[case::mixed_no_match(vec!["10.0.0.0/8", "fe80::/10"], Some(Ipv4Addr::new(192, 168, 1, 1)), Some(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1)), false)]
+    fn test_fast_distance_rule_matches_ip(
+        #[case] cidrs: Vec<&str>,
+        #[case] peer_ipv4: Option<Ipv4Addr>,
+        #[case] peer_ipv6: Option<Ipv6Addr>,
+        #[case] expected: bool,
+    ) {
+        let rule = FastDistanceRule {
+            name: "test".to_string(),
+            priority: 100,
+            enabled: true,
+            distance: 10,
+            destination_ip_cidrs: cidrs
+                .iter()
+                .map(|s| cidr::IpCidr::from_str(s).unwrap())
+                .collect(),
+            destination_groups: HashSet::new(),
+            foreign_node: None,
+        };
+        let peer = PeerDistanceInfo {
+            ipv4_addr: peer_ipv4,
+            ipv6_addr: peer_ipv6,
+            verified_groups: vec!["group_a".to_string(), "group_b".to_string()],
+            is_public_server: false,
+        };
+        assert_eq!(rule.matches_ip(&peer), expected);
+    }
+
+    #[rstest]
+    #[case::empty_groups(vec![], vec!["group_a", "group_b"], true)]
+    #[case::with_match(vec!["group_a"], vec!["group_a", "group_b"], true)]
+    #[case::no_match(vec!["group_x"], vec!["group_a", "group_b"], false)]
+    fn test_fast_distance_rule_matches_groups(
+        #[case] rule_groups: Vec<&str>,
+        #[case] peer_groups: Vec<&str>,
+        #[case] expected: bool,
+    ) {
+        let rule = FastDistanceRule {
+            name: "test".to_string(),
+            priority: 100,
+            enabled: true,
+            distance: 10,
+            destination_ip_cidrs: vec![],
+            destination_groups: rule_groups.iter().map(|s| s.to_string()).collect(),
+            foreign_node: None,
+        };
+        let peer = PeerDistanceInfo {
+            ipv4_addr: Some(Ipv4Addr::new(192, 168, 1, 100)),
+            ipv6_addr: None,
+            verified_groups: peer_groups.iter().map(|s| s.to_string()).collect(),
+            is_public_server: false,
+        };
+        assert_eq!(rule.matches_groups(&peer), expected);
+    }
+
+    // ==================== FastDistanceRule Foreign 节点匹配测试 ====================
+    #[rstest]
+    #[case::none_public(None, true, true)]
+    #[case::none_private(None, false, true)]
+    #[case::true_public(Some(true), true, true)]
+    #[case::true_private(Some(true), false, false)]
+    #[case::false_public(Some(false), true, false)]
+    #[case::false_private(Some(false), false, true)]
+    fn test_fast_distance_rule_matches_foreign(
+        #[case] foreign_node: Option<bool>,
+        #[case] is_public_server: bool,
+        #[case] expected: bool,
+    ) {
+        let rule = FastDistanceRule {
+            name: "test".to_string(),
+            priority: 100,
+            enabled: true,
+            distance: 10,
+            destination_ip_cidrs: vec![],
+            destination_groups: HashSet::new(),
+            foreign_node,
+        };
+        let peer = PeerDistanceInfo {
+            ipv4_addr: Some(Ipv4Addr::new(1, 2, 3, 4)),
+            ipv6_addr: None,
+            verified_groups: vec![],
+            is_public_server,
+        };
+        assert_eq!(rule.matches_foreign(&peer), expected);
+    }
+
+    #[rstest]
+    #[case::combined_match(true, vec!["192.168.1.0/24"], vec!["group_a"], Some(false), true)]
+    #[case::disabled(false, vec![], vec![], None, false)]
+    fn test_fast_distance_rule_matches(
+        #[case] enabled: bool,
+        #[case] cidrs: Vec<&str>,
+        #[case] groups: Vec<&str>,
+        #[case] foreign_node: Option<bool>,
+        #[case] expected: bool,
+    ) {
+        let rule = FastDistanceRule {
+            name: "test".to_string(),
+            priority: 100,
+            enabled,
+            distance: 10,
+            destination_ip_cidrs: cidrs
+                .iter()
+                .map(|s| cidr::IpCidr::from_str(s).unwrap())
+                .collect(),
+            destination_groups: groups.iter().map(|s| s.to_string()).collect(),
+            foreign_node,
+        };
+        let peer = create_test_peer_info();
+        assert_eq!(rule.matches(&peer), expected);
+    }
+
+    #[test]
+    fn test_route_distance_processor_new_priority_sorting() {
+        let config = create_test_route_distance_config();
+        let processor = RouteDistanceProcessor::new(&config);
+
+        assert_eq!(processor.rule_count(), 3);
+        assert_eq!(processor.default_distance(), 1);
+    }
+
+    #[rstest]
+    #[case::ip_match(Some(Ipv4Addr::new(192, 168, 1, 50)), vec![], false, 10)]
+    #[case::group_match(Some(Ipv4Addr::new(10, 0, 0, 1)), vec!["group_a"], false, 20)]
+    #[case::foreign_match(Some(Ipv4Addr::new(10, 0, 0, 1)), vec![], true, 30)]
+    #[case::no_match(Some(Ipv4Addr::new(10, 0, 0, 1)), vec![], false, 1)]
+    fn test_route_distance_processor_calculate_distance(
+        #[case] ipv4_addr: Option<Ipv4Addr>,
+        #[case] groups: Vec<&str>,
+        #[case] is_public_server: bool,
+        #[case] expected_distance: u32,
+    ) {
+        let config = create_test_route_distance_config();
+        let processor = RouteDistanceProcessor::new(&config);
+
+        let peer = PeerDistanceInfo {
+            ipv4_addr,
+            ipv6_addr: None,
+            verified_groups: groups.iter().map(|s| s.to_string()).collect(),
+            is_public_server,
+        };
+        assert_eq!(processor.calculate_distance(&peer), expected_distance);
+    }
+
+    #[rstest]
+    #[case::zero_distance(0, 0, 1, 1)]
+    #[case::overflow_distance(u32::MAX, u32::MAX, i32::MAX as u32, i32::MAX as u32)]
+    fn test_route_distance_processor_distance_validation(
+        #[case] rule_distance: u32,
+        #[case] default_distance: u32,
+        #[case] expected_calc_distance: u32,
+        #[case] expected_default_distance: u32,
+    ) {
+        let config = RouteDistanceConfig {
+            rules: vec![RouteDistanceRule {
+                name: "test_distance".to_string(),
+                priority: 100,
+                enabled: true,
+                distance: rule_distance,
+                destination_ips: vec![],
+                destination_groups: vec![],
+                foreign_node: None,
+            }],
+            default_distance,
+        };
+        let processor = RouteDistanceProcessor::new(&config);
+
+        let peer = create_test_peer_info();
+        assert_eq!(processor.calculate_distance(&peer), expected_calc_distance);
+        assert_eq!(processor.default_distance(), expected_default_distance);
+    }
+
+    #[test]
+    fn test_route_distance_processor_priority_order() {
+        let config = RouteDistanceConfig {
+            rules: vec![
+                RouteDistanceRule {
+                    name: "low".to_string(),
+                    priority: 10,
+                    enabled: true,
+                    distance: 100,
+                    destination_ips: vec![],
+                    destination_groups: vec![],
+                    foreign_node: None,
+                },
+                RouteDistanceRule {
+                    name: "high".to_string(),
+                    priority: 100,
+                    enabled: true,
+                    distance: 5,
+                    destination_ips: vec![],
+                    destination_groups: vec![],
+                    foreign_node: None,
+                },
+            ],
+            default_distance: 1,
+        };
+        let processor = RouteDistanceProcessor::new(&config);
+
+        let peer = create_test_peer_info();
+        assert_eq!(processor.calculate_distance(&peer), 5);
     }
 }

--- a/easytier/src/common/global_ctx.rs
+++ b/easytier/src/common/global_ctx.rs
@@ -2,12 +2,9 @@ use std::{
     collections::{HashMap, hash_map::DefaultHasher},
     hash::Hasher,
     net::{IpAddr, SocketAddr},
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, RwLock},
     time::{SystemTime, UNIX_EPOCH},
 };
-
-use arc_swap::ArcSwap;
-use dashmap::DashMap;
 
 use super::{
     PeerId,
@@ -16,6 +13,7 @@ use super::{
     network::IPCollector,
     stun::{StunInfoCollector, StunInfoCollectorTrait},
 };
+use crate::common::acl_processor::RouteDistanceProcessor;
 use crate::{
     common::{
         config::ProxyNetworkConfig, shrink_dashmap, stats_manager::StatsManager,
@@ -31,7 +29,9 @@ use crate::{
     rpc_service::protected_port,
     tunnel::matches_protocol,
 };
+use arc_swap::ArcSwap;
 use crossbeam::atomic::AtomicCell;
+use dashmap::DashMap;
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
 use socket2::Protocol;
@@ -220,6 +220,8 @@ pub struct GlobalCtx {
     /// OSPF propagated trusted keys (peer pubkeys and admin credentials)
     /// Stored in ArcSwap for lock-free reads and atomic batch updates
     trusted_keys: Arc<TrustedKeyMapManager>,
+
+    route_distance_processor: RwLock<Option<(u64, Arc<RouteDistanceProcessor>)>>,
 }
 
 impl std::fmt::Debug for GlobalCtx {
@@ -316,6 +318,8 @@ impl GlobalCtx {
             credential_manager,
 
             trusted_keys: Arc::new(TrustedKeyMapManager::new()),
+
+            route_distance_processor: RwLock::new(None),
         }
     }
 
@@ -585,6 +589,46 @@ impl GlobalCtx {
 
     pub fn list_trusted_keys(&self, network_name: &str) -> Vec<(Vec<u8>, TrustedKeyMetadata)> {
         self.trusted_keys.list_trusted_keys(network_name)
+    }
+
+    pub fn get_route_distance_processor(&self) -> Arc<RouteDistanceProcessor> {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let acl = self.config.get_acl();
+        let route_distance_config = acl
+            .as_ref()
+            .and_then(|a| a.acl_v1.as_ref())
+            .and_then(|v1| v1.route_distance.as_ref());
+
+        let mut hasher = DefaultHasher::new();
+        route_distance_config.hash(&mut hasher);
+        let config_digest = hasher.finish();
+
+        {
+            let cache = self.route_distance_processor.read().unwrap();
+            if let Some((digest, proc)) = &*cache
+                && *digest == config_digest
+            {
+                return proc.clone();
+            }
+        }
+
+        let mut cache = self.route_distance_processor.write().unwrap();
+        if let Some((digest, proc)) = &*cache
+            && *digest == config_digest
+        {
+            return proc.clone();
+        }
+
+        let proc = Arc::new(if let Some(config) = route_distance_config {
+            RouteDistanceProcessor::new(config)
+        } else {
+            RouteDistanceProcessor::new(&Default::default())
+        });
+
+        *cache = Some((config_digest, proc.clone()));
+        proc
     }
 
     pub fn get_acl_groups(&self, peer_id: PeerId) -> Vec<PeerGroupInfo> {

--- a/easytier/src/easytier-cli.rs
+++ b/easytier/src/easytier-cli.rs
@@ -1226,6 +1226,8 @@ impl<'a> CommandHandler<'a> {
             lat_ms: String,
             #[tabled(rename = "loss")]
             loss_rate: String,
+            #[tabled(rename = "dist")]
+            dist: String,
             #[tabled(rename = "rx")]
             rx_bytes: String,
             #[tabled(rename = "tx")]
@@ -1258,6 +1260,13 @@ impl<'a> CommandHandler<'a> {
                     cost: cost_to_str(route.cost),
                     lat_ms: format!("{:.2}", lat_ms),
                     loss_rate: format!("{:.1}%", p.get_loss_rate().unwrap_or(0.0) * 100.0),
+                    dist: p
+                        .peer
+                        .as_ref()
+                        .map(|p| p.distance)
+                        .filter(|d| *d != 0)
+                        .map(|d| d.to_string())
+                        .unwrap_or("-".to_string()),
                     rx_bytes: format_size(p.get_rx_bytes().unwrap_or(0), humansize::DECIMAL),
                     tx_bytes: format_size(p.get_tx_bytes().unwrap_or(0), humansize::DECIMAL),
                     tunnel_proto: p.get_conn_protos().unwrap_or_default().join(","),
@@ -1283,6 +1292,7 @@ impl<'a> CommandHandler<'a> {
                     cost: "Local".to_string(),
                     lat_ms: "-".to_string(),
                     loss_rate: "-".to_string(),
+                    dist: "-".to_string(),
                     rx_bytes: "-".to_string(),
                     tx_bytes: "-".to_string(),
                     tunnel_proto: "-".to_string(),
@@ -1361,7 +1371,9 @@ impl<'a> CommandHandler<'a> {
                 &items,
                 self.output_format,
                 &["tunnel", "version"],
-                &["version", "tunnel", "nat", "tx", "rx", "loss", "lat(ms)"],
+                &[
+                    "version", "tunnel", "nat", "tx", "rx", "dist", "loss", "lat(ms)",
+                ],
                 self.no_trunc,
             )
         })
@@ -1473,6 +1485,7 @@ impl<'a> CommandHandler<'a> {
             next_hop_hostname: String,
             next_hop_lat: f64,
             path_len: i32,
+            dist: i32,
             path_latency: i32,
 
             next_hop_ipv4_lat_first: String,
@@ -1492,6 +1505,7 @@ impl<'a> CommandHandler<'a> {
                 next_hop_hostname: "Local".to_string(),
                 next_hop_lat: 0.0,
                 path_len: 0,
+                dist: 0,
                 path_latency: 0,
                 next_hop_ipv4_lat_first: "-".to_string(),
                 next_hop_hostname_lat_first: "Local".to_string(),
@@ -1540,6 +1554,7 @@ impl<'a> CommandHandler<'a> {
                     },
                     next_hop_lat: next_hop_pair.get_latency_ms().unwrap_or(0.0),
                     path_len: route.cost,
+                    dist: route.distance,
                     path_latency: route.path_latency,
                     next_hop_ipv4_lat_first: if route.cost_latency_first.unwrap_or_default() == 1 {
                         "DIRECT".to_string()

--- a/easytier/src/instance/instance.rs
+++ b/easytier/src/instance/instance.rs
@@ -1387,7 +1387,10 @@ impl Instance {
         }
 
         ApiRpcServiceImpl {
-            peer_mgr_rpc_service: PeerManagerRpcService::new(self.peer_manager.clone()),
+            peer_mgr_rpc_service: PeerManagerRpcService::new(
+                self.peer_manager.clone(),
+                self.peer_center.clone(),
+            ),
             connector_mgr_rpc_service: ConnectorManagerRpcService(Arc::downgrade(
                 &self.conn_manager,
             )),
@@ -1440,12 +1443,18 @@ impl Instance {
 
                 tcp_proxy_rpc_services
             },
-            acl_manage_rpc_service: PeerManagerRpcService::new(self.peer_manager.clone()),
+            acl_manage_rpc_service: PeerManagerRpcService::new(
+                self.peer_manager.clone(),
+                self.peer_center.clone(),
+            ),
             port_forward_manage_rpc_service: self.get_port_forward_manager_rpc_service(),
             stats_rpc_service: self.get_stats_rpc_service(),
             config_rpc_service: self.get_config_service(),
             peer_center_rpc_service: Arc::new(self.peer_center.get_rpc_service()),
-            credential_manage_rpc_service: PeerManagerRpcService::new(self.peer_manager.clone()),
+            credential_manage_rpc_service: PeerManagerRpcService::new(
+                self.peer_manager.clone(),
+                self.peer_center.clone(),
+            ),
         }
     }
 

--- a/easytier/src/peer_center/mod.rs
+++ b/easytier/src/peer_center/mod.rs
@@ -40,6 +40,7 @@ impl From<Vec<PeerInfo>> for PeerInfoForGlobalMap {
 
             let dp_info = DirectConnectedPeerInfo {
                 latency_ms: std::cmp::max(1, (min_lat as u32 / 1000) as i32),
+                distance: peer.distance,
             };
 
             // sort conn info so hash result is stable

--- a/easytier/src/peers/peer_map.rs
+++ b/easytier/src/peers/peer_map.rs
@@ -172,10 +172,6 @@ impl PeerMap {
             return Some(dst_peer_id);
         }
 
-        if self.has_peer(dst_peer_id) && matches!(policy, NextHopPolicy::LeastHop) {
-            return Some(dst_peer_id);
-        }
-
         // get route info
         for route in self.routes.read().await.iter() {
             if let Some(gateway_peer_id) = route
@@ -185,6 +181,10 @@ impl PeerMap {
                 // NOTIC: for foreign network, gateway_peer_id may not connect to me
                 return Some(gateway_peer_id);
             }
+        }
+
+        if self.has_peer(dst_peer_id) {
+            return Some(dst_peer_id);
         }
 
         None
@@ -374,6 +374,17 @@ impl PeerMap {
         vec![]
     }
 
+    /// Get verified groups for a peer (from group_trust_map_cache)
+    pub async fn get_peer_groups(&self, peer_id: PeerId) -> std::sync::Arc<Vec<String>> {
+        for route in self.routes.read().await.iter() {
+            let groups = route.get_peer_groups(peer_id);
+            if !groups.is_empty() {
+                return groups;
+            }
+        }
+        std::sync::Arc::new(Vec::new())
+    }
+
     pub async fn need_relay_by_foreign_network(&self, dst_peer_id: PeerId) -> Result<bool, Error> {
         // if gateway_peer_id is not connected to me, means need relay by foreign network
         let gateway_id = self
@@ -393,6 +404,43 @@ impl PeerMap {
 
     pub fn get_global_ctx(&self) -> ArcGlobalCtx {
         self.global_ctx.clone()
+    }
+
+    /// Calculate distance for a peer based on RouteDistanceConfig.
+    /// Returns the configured inbound distance (peer → self), or default (1).
+    pub async fn get_peer_distance(&self, peer_id: PeerId) -> u32 {
+        use crate::common::acl_processor::PeerDistanceInfo;
+
+        let processor = self.global_ctx.get_route_distance_processor();
+
+        let peer_info = self.get_route_peer_info(peer_id).await;
+
+        let ipv4_addr = peer_info
+            .as_ref()
+            .and_then(|info| info.ipv4_addr)
+            .map(|ipv4| ipv4.into());
+
+        let ipv6_addr = peer_info
+            .as_ref()
+            .and_then(|info| info.ipv6_addr.as_ref())
+            .and_then(|ipv6| ipv6.address)
+            .map(|ipv6| ipv6.into());
+
+        let verified_groups = self.get_peer_groups(peer_id).await.to_vec();
+
+        let is_public_server = peer_info
+            .and_then(|info| info.feature_flag)
+            .map(|flag| flag.is_public_server)
+            .unwrap_or(false);
+
+        let distance_info = PeerDistanceInfo {
+            ipv4_addr,
+            ipv6_addr,
+            verified_groups,
+            is_public_server,
+        };
+
+        processor.calculate_distance(&distance_info)
     }
 }
 

--- a/easytier/src/peers/peer_ospf_route.rs
+++ b/easytier/src/peers/peer_ospf_route.rs
@@ -314,6 +314,7 @@ impl From<RoutePeerInfo> for crate::proto::api::instance::Route {
             next_hop_peer_id: 0, // next_hop_peer_id is calculated in RouteTable.
             cost: 0,             // cost is calculated in RouteTable.
             path_latency: 0,     // path_latency is calculated in RouteTable.
+            distance: 0,         // distance is calculated in RouteTable.
             proxy_cidrs: val.proxy_cidrs.clone(),
             hostname: val.hostname.unwrap_or_default(),
             stun_info: {
@@ -1109,13 +1110,20 @@ impl SyncedRouteInfo {
     }
 }
 
-type PeerGraph = Graph<PeerId, usize, Directed>;
+#[derive(Debug, Clone, Copy)]
+struct RouteEdge {
+    distance: usize,
+    cost: usize,
+}
+
+type PeerGraph = Graph<PeerId, RouteEdge, Directed>;
 type PeerIdToNodexIdxMap = DashMap<PeerId, NodeIndex>;
 #[derive(Debug, Clone, Copy)]
 struct NextHopInfo {
     next_hop_peer_id: PeerId,
     path_latency: i32,
-    path_len: usize, // path includes src and dst.
+    path_distance: i32, // Accumulated distance from ACL rules (LeastHop mode)
+    path_len: usize,    // path includes src and dst.
     version: Version,
 }
 // dst_peer_id -> (next_hop_peer_id, cost, path_len)
@@ -1211,12 +1219,18 @@ impl RouteTable {
                     continue;
                 };
 
-                let mut cost = cost_calc.calculate_cost(*src_peer_id, *dst_peer_id) as usize;
+                let mut distance =
+                    cost_calc.calculate_cost(*src_peer_id, *dst_peer_id, NextHopPolicy::LeastHop)
+                        as usize;
+                let mut cost =
+                    cost_calc.calculate_cost(*src_peer_id, *dst_peer_id, NextHopPolicy::LeastCost)
+                        as usize;
                 if peer_avoid_relay_data {
+                    distance += AVOID_RELAY_COST;
                     cost += AVOID_RELAY_COST;
                 }
 
-                graph.add_edge(*src_node_idx, *dst_node_idx, cost);
+                graph.add_edge(*src_node_idx, *dst_node_idx, RouteEdge { distance, cost });
             }
         }
 
@@ -1262,15 +1276,16 @@ impl RouteTable {
             );
             return;
         }
-        let normalize_edge_cost = |e: petgraph::graph::EdgeReference<usize>| {
-            if *e.weight() >= AVOID_RELAY_COST {
+
+        let normalize_edge_distance = |e: petgraph::graph::EdgeReference<RouteEdge>| {
+            if e.weight().distance >= AVOID_RELAY_COST {
                 AVOID_RELAY_COST + 1
             } else {
-                1
+                e.weight().distance
             }
         };
-        // Step 1: 第一次 Dijkstra - 计算最短跳数
-        let path_len_map = dijkstra(&graph, *start_node, None, normalize_edge_cost);
+        // Step 1: 第一次 Dijkstra - 计算最短距离
+        let path_distance_map = dijkstra(&graph, *start_node, None, normalize_edge_distance);
 
         // Step 2: 构建最短跳数子图（只保留属于最短路径和 AVOID RELAY 的边）
         let mut subgraph: PeerGraph = PeerGraph::new();
@@ -1284,19 +1299,24 @@ impl RouteTable {
 
         for edge in graph.edge_references() {
             let (src, tgt) = graph.edge_endpoints(edge.id()).unwrap();
-            let Some(src_path_len) = path_len_map.get(&src) else {
+            let Some(src_path_len) = path_distance_map.get(&src) else {
                 continue;
             };
-            let Some(tgt_path_len) = path_len_map.get(&tgt) else {
+            let Some(tgt_path_len) = path_distance_map.get(&tgt) else {
                 continue;
             };
-            if *src_path_len + normalize_edge_cost(edge) == *tgt_path_len {
+            if *src_path_len + normalize_edge_distance(edge) == *tgt_path_len {
                 subgraph.add_edge(src, tgt, *edge.weight());
             }
         }
 
         // Step 3: 第二次 Dijkstra - 在子图上找代价最小的路径
-        self.gen_next_hop_map_with_least_cost(&subgraph, &start_node_idx.unwrap(), version);
+        self.gen_next_hop_map_with_least_cost(
+            &subgraph,
+            &start_node_idx.unwrap(),
+            version,
+            Some(&path_distance_map),
+        );
     }
 
     fn gen_next_hop_map_with_least_cost(
@@ -1304,6 +1324,7 @@ impl RouteTable {
         graph: &PeerGraph,
         start_node: &NodeIndex,
         version: Version,
+        path_distance_map: Option<&hashbrown::HashMap<NodeIndex, usize>>,
     ) {
         if graph.node_weight(*start_node).is_none() {
             tracing::warn!(
@@ -1313,12 +1334,19 @@ impl RouteTable {
             );
             return;
         }
-        let (costs, next_hops) = dijkstra_with_first_hop(&graph, *start_node, |e| *e.weight());
+
+        let (costs, next_hops) = dijkstra_with_first_hop(&graph, *start_node, |e| e.weight().cost);
 
         for (dst, (next_hop, path_len)) in next_hops.iter() {
+            let path_distance = path_distance_map
+                .and_then(|m| m.get(dst))
+                .map(|d| (*d % AVOID_RELAY_COST) as i32)
+                .unwrap_or(0);
+
             let info = NextHopInfo {
                 next_hop_peer_id: *graph.node_weight(*next_hop).unwrap(),
                 path_latency: (*costs.get(dst).unwrap() % AVOID_RELAY_COST) as i32,
+                path_distance,
                 path_len: { *path_len },
                 version,
             };
@@ -1378,7 +1406,7 @@ impl RouteTable {
         if matches!(policy, NextHopPolicy::LeastHop) {
             self.gen_next_hop_map_with_least_hop(&graph, &start_node, version);
         } else {
-            self.gen_next_hop_map_with_least_cost(&graph, &start_node, version);
+            self.gen_next_hop_map_with_least_cost(&graph, &start_node, version, None);
         };
 
         let mut new_cidr_prefix_trie = PrefixMap::new();
@@ -2143,6 +2171,7 @@ impl PeerRouteServiceImpl {
 
         let calc_locked = self.cost_calculator.read().unwrap();
 
+        // Use LeastHop for route_table, cost calculator handles policy internally
         self.route_table.build_from_synced_info(
             self.my_peer_id,
             &self.synced_route_info,
@@ -3555,6 +3584,12 @@ impl Route for PeerRoute {
                 next_hop_peer_latency_first.map(|x| x.next_hop_peer_id);
             route.cost_latency_first = next_hop_peer_latency_first.map(|x| x.path_len as i32);
             route.path_latency_latency_first = next_hop_peer_latency_first.map(|x| x.path_latency);
+
+            route.distance = if self.global_ctx.latency_first() {
+                0
+            } else {
+                next_hop_peer.path_distance
+            };
 
             route.feature_flag = item.feature_flag;
 
@@ -5190,7 +5225,11 @@ mod tests {
         }
 
         impl RouteCostCalculatorInterface for TestCostCalculator {
-            fn calculate_cost(&self, src: PeerId, dst: PeerId) -> i32 {
+            fn calculate_cost(&self, src: PeerId, dst: PeerId, policy: NextHopPolicy) -> i32 {
+                if matches!(policy, NextHopPolicy::LeastHop) {
+                    return 1;
+                }
+                // Test calculator always returns the configured cost regardless of policy
                 if src == self.p_d_peer_id && dst == self.p_b_peer_id {
                     return 100;
                 }

--- a/easytier/src/peers/route_trait.rs
+++ b/easytier/src/peers/route_trait.rs
@@ -50,7 +50,7 @@ pub trait RouteCostCalculatorInterface: Send + Sync {
     fn begin_update(&mut self) {}
     fn end_update(&mut self) {}
 
-    fn calculate_cost(&self, _src: PeerId, _dst: PeerId) -> i32 {
+    fn calculate_cost(&self, _src: PeerId, _dst: PeerId, _policy: NextHopPolicy) -> i32 {
         1
     }
 

--- a/easytier/src/peers/rpc_service.rs
+++ b/easytier/src/peers/rpc_service.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use crate::{
+    peer_center::instance::PeerCenterInstance,
     proto::{
         api::instance::{
             AclManageRpc, CredentialManageRpc, DumpRouteRequest, DumpRouteResponse,
@@ -27,16 +28,22 @@ use super::peer_manager::PeerManager;
 #[derive(Clone)]
 pub struct PeerManagerRpcService {
     peer_manager: Weak<PeerManager>,
+    peer_center: Weak<PeerCenterInstance>,
 }
 
 impl PeerManagerRpcService {
-    pub fn new(peer_manager: Arc<PeerManager>) -> Self {
+    pub fn new(peer_manager: Arc<PeerManager>, peer_center: Arc<PeerCenterInstance>) -> Self {
         PeerManagerRpcService {
             peer_manager: Arc::downgrade(&peer_manager),
+            peer_center: Arc::downgrade(&peer_center),
         }
     }
 
-    pub async fn list_peers(peer_manager: &PeerManager) -> Vec<PeerInfo> {
+    pub async fn list_peers(
+        peer_manager: &PeerManager,
+        peer_center: Option<Arc<PeerCenterInstance>>,
+    ) -> Vec<PeerInfo> {
+        let my_peer_id = peer_manager.my_peer_id();
         let mut peers = peer_manager.get_peer_map().list_peers();
         peers.extend(
             peer_manager
@@ -73,6 +80,16 @@ impl PeerManagerRpcService {
                 peer_info.conns = conns;
             }
 
+            // Distance calculation depends on the caller's context:
+            // - Some(peer_center): CLI query - return outbound distance (self→peer),
+            //   fetched from peer's reported GlobalPeerMap data
+            // - None: GlobalPeerMap sync - return inbound distance (peer→self),
+            //   calculated locally using this node's route_distance config
+            peer_info.distance = match peer_center.as_ref() {
+                Some(pc) => pc.get_outbound_distance(my_peer_id, peer).unwrap_or(0),
+                None => peer_map.get_peer_distance(peer).await,
+            };
+
             peer_infos.push(peer_info);
         }
 
@@ -90,8 +107,12 @@ impl PeerManageRpc for PeerManagerRpcService {
     ) -> Result<ListPeerResponse, rpc_types::error::Error> {
         let mut reply = ListPeerResponse::default();
 
-        let peers =
-            PeerManagerRpcService::list_peers(weak_upgrade(&self.peer_manager)?.deref()).await;
+        let peer_center = self.peer_center.upgrade();
+        let peers = PeerManagerRpcService::list_peers(
+            weak_upgrade(&self.peer_manager)?.deref(),
+            peer_center,
+        )
+        .await;
         for peer in peers {
             reply.peer_infos.push(peer);
         }

--- a/easytier/src/proto/acl.proto
+++ b/easytier/src/proto/acl.proto
@@ -98,9 +98,28 @@ message GroupIdentity {
   string group_secret = 2;
 }
 
+// Route distance rule: "peer → this_node" unidirectional distance.
+// Multiple conditions use AND logic; empty lists mean "no restriction".
+message RouteDistanceRule {
+  string name = 1;
+  uint32 priority = 2; // higher = higher priority
+  bool enabled = 3;
+  uint32 distance = 4; // range: 1 ~ i32::MAX, default: 1
+
+  repeated string destination_ips = 5; // CIDR list
+  repeated string destination_groups = 6; // ACL group names
+  optional bool foreign_node = 7;          // true: public server only
+}
+
+message RouteDistanceConfig {
+  repeated RouteDistanceRule rules = 1;
+  uint32 default_distance = 2; // default: 1
+}
+
 message AclV1 { 
   repeated Chain chains = 1;
   GroupInfo group = 2;
+  RouteDistanceConfig route_distance = 3;
 }
 
 enum ConnState {

--- a/easytier/src/proto/acl.rs
+++ b/easytier/src/proto/acl.rs
@@ -12,13 +12,24 @@ impl AclV1 {
     pub fn is_empty(&self) -> bool {
         let has_chains = !self.chains.is_empty();
         let has_groups = self.group.as_ref().map(|g| !g.is_empty()).unwrap_or(false);
-        !has_chains && !has_groups
+        let has_route_distance = self
+            .route_distance
+            .as_ref()
+            .map(|r| !r.is_empty())
+            .unwrap_or(false);
+        !has_chains && !has_groups && !has_route_distance
     }
 }
 
 impl GroupInfo {
     pub fn is_empty(&self) -> bool {
         self.declares.is_empty() && self.members.is_empty()
+    }
+}
+
+impl RouteDistanceConfig {
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty() && self.default_distance <= 1
     }
 }
 

--- a/easytier/src/proto/api_instance.proto
+++ b/easytier/src/proto/api_instance.proto
@@ -52,6 +52,7 @@ message PeerInfo {
   repeated PeerConnInfo conns = 2;
   common.UUID default_conn_id = 3;
   repeated common.UUID directly_connected_conns = 4;
+  uint32 distance = 5;
 }
 
 message ListPeerRequest { InstanceIdentifier instance = 1; }
@@ -81,6 +82,7 @@ message Route {
   optional int32 path_latency_latency_first = 14;
 
   common.Ipv6Inet ipv6_addr = 15;
+  int32 distance = 16;
 }
 
 message PeerRoutePair {

--- a/easytier/src/proto/peer_rpc.proto
+++ b/easytier/src/proto/peer_rpc.proto
@@ -234,7 +234,10 @@ service TcpHolePunchRpc {
   rpc ExchangeMappedAddr(TcpHolePunchRequest) returns (TcpHolePunchResponse);
 }
 
-message DirectConnectedPeerInfo { int32 latency_ms = 1; }
+message DirectConnectedPeerInfo {
+  int32 latency_ms = 1;
+  uint32 distance = 2;
+}
 
 message PeerInfoForGlobalMap {
   map<uint32, DirectConnectedPeerInfo> direct_peers = 1;

--- a/easytier/src/tests/three_node.rs
+++ b/easytier/src/tests/three_node.rs
@@ -240,6 +240,19 @@ async fn init_lazy_p2p_three_node_ex<F: Fn(TomlConfigLoader) -> TomlConfigLoader
     init_three_node_ex_with_inst3(proto, cfg_cb, false, "net_e", "10.144.144.3", "fd00::3/64").await
 }
 
+pub async fn make_three_node_full_mesh(insts: &[Instance]) {
+    insts[0]
+        .get_conn_manager()
+        .add_connector(RingTunnelConnector::new(
+            format!("ring://{}", insts[2].id()).parse().unwrap(),
+        ));
+    insts[2]
+        .get_conn_manager()
+        .add_connector(RingTunnelConnector::new(
+            format!("ring://{}", insts[0].id()).parse().unwrap(),
+        ));
+}
+
 pub async fn drop_insts(insts: Vec<Instance>) {
     let mut set = JoinSet::new();
     for mut inst in insts {
@@ -258,7 +271,7 @@ pub async fn drop_insts(insts: Vec<Instance>) {
     while set.join_next().await.is_some() {}
 }
 
-async fn ping_test(from_netns: &str, target_ip: &str, payload_size: Option<usize>) -> bool {
+pub async fn ping_test(from_netns: &str, target_ip: &str, payload_size: Option<usize>) -> bool {
     let _g = NetNS::new(Some(ROOT_NETNS_NAME.to_owned())).guard();
     let code = tokio::process::Command::new("ip")
         .args([
@@ -282,7 +295,7 @@ async fn ping_test(from_netns: &str, target_ip: &str, payload_size: Option<usize
     code.code().unwrap() == 0
 }
 
-async fn ping6_test(from_netns: &str, target_ip: &str, payload_size: Option<usize>) -> bool {
+pub async fn ping6_test(from_netns: &str, target_ip: &str, payload_size: Option<usize>) -> bool {
     let _g = NetNS::new(Some(ROOT_NETNS_NAME.to_owned())).guard();
     let code = tokio::process::Command::new("ip")
         .args([
@@ -2339,6 +2352,7 @@ pub async fn acl_group_base_test(
                 declares: group_declares.clone(),
                 members: vec![],
             }),
+            route_distance: None,
         }),
     };
 
@@ -2726,6 +2740,7 @@ pub async fn acl_group_self_test(
                 declares: group_declares.clone(),
                 members: vec!["admin".to_string()],
             }),
+            route_distance: None,
         }),
     };
 
@@ -2736,6 +2751,7 @@ pub async fn acl_group_self_test(
                 declares: group_declares.clone(),
                 members: vec![],
             }),
+            route_distance: None,
         }),
     };
 
@@ -3381,4 +3397,604 @@ pub async fn relay_peer_session_cleanup() {
     .await;
 
     drop_insts(insts).await;
+}
+
+mod distance {
+    use std::time::Duration;
+
+    use rstest::rstest;
+
+    use crate::{
+        common::{
+            PeerId,
+            config::{ConfigLoader, NetworkIdentity},
+        },
+        instance::instance::Instance,
+        proto::acl::{
+            Acl, AclV1, GroupIdentity, GroupInfo, RouteDistanceConfig, RouteDistanceRule,
+        },
+        tunnel::common::tests::wait_for_condition,
+    };
+
+    use super::{drop_insts, make_three_node_full_mesh, ping_test, prepare_linux_namespaces};
+
+    use crate::common::stats_manager::MetricName;
+
+    // ============================================================
+    // Helper Functions
+    // ============================================================
+
+    /// Create an Acl config with RouteDistanceConfig
+    fn create_acl_with_distance(
+        rules: Vec<RouteDistanceRule>,
+        default_distance: u32,
+        group_info: Option<GroupInfo>,
+    ) -> Acl {
+        let route_distance = RouteDistanceConfig {
+            rules,
+            default_distance,
+        };
+
+        let acl_v1 = AclV1 {
+            route_distance: Some(route_distance),
+            group: group_info,
+            ..Default::default()
+        };
+
+        Acl {
+            acl_v1: Some(acl_v1),
+        }
+    }
+
+    /// Create a simple RouteDistanceRule for IP matching
+    fn create_ip_distance_rule(
+        name: &str,
+        priority: u32,
+        distance: u32,
+        ips: Vec<&str>,
+    ) -> RouteDistanceRule {
+        RouteDistanceRule {
+            name: name.to_string(),
+            priority,
+            enabled: true,
+            distance,
+            destination_ips: ips.into_iter().map(|s| s.to_string()).collect(),
+            destination_groups: vec![],
+            foreign_node: None,
+        }
+    }
+
+    /// Create a RouteDistanceRule for group matching
+    fn create_group_distance_rule(
+        name: &str,
+        priority: u32,
+        distance: u32,
+        groups: Vec<&str>,
+    ) -> RouteDistanceRule {
+        RouteDistanceRule {
+            name: name.to_string(),
+            priority,
+            enabled: true,
+            distance,
+            destination_ips: vec![],
+            destination_groups: groups.into_iter().map(|s| s.to_string()).collect(),
+            foreign_node: None,
+        }
+    }
+
+    /// Create a RouteDistanceRule for foreign_node matching
+    fn create_foreign_distance_rule(
+        name: &str,
+        priority: u32,
+        distance: u32,
+        is_foreign: bool,
+    ) -> RouteDistanceRule {
+        RouteDistanceRule {
+            name: name.to_string(),
+            priority,
+            enabled: true,
+            distance,
+            destination_ips: vec![],
+            destination_groups: vec![],
+            foreign_node: Some(is_foreign),
+        }
+    }
+
+    /// Check route distance for a specific peer
+    fn check_route_distance(
+        routes: &[crate::proto::api::instance::Route],
+        peer_id: PeerId,
+        expected_distance: i32,
+    ) {
+        let route = routes
+            .iter()
+            .find(|r| r.peer_id == peer_id)
+            .unwrap_or_else(|| panic!("Route for peer {} not found in {:?}", peer_id, routes));
+
+        assert_eq!(
+            route.distance, expected_distance,
+            "Expected distance {} for peer {}, but got {}. Routes: {:?}",
+            expected_distance, peer_id, route.distance, routes
+        );
+    }
+
+    /// Check route cost for a specific peer
+    fn check_route_cost(
+        routes: &[crate::proto::api::instance::Route],
+        peer_id: PeerId,
+        expected_cost: i32,
+    ) {
+        let route = routes
+            .iter()
+            .find(|r| r.peer_id == peer_id)
+            .unwrap_or_else(|| panic!("Route for peer {} not found in {:?}", peer_id, routes));
+
+        assert_eq!(
+            route.cost, expected_cost,
+            "Expected cost {} for peer {}, but got {}. Routes: {:?}",
+            expected_cost, peer_id, route.cost, routes
+        );
+    }
+
+    /// Wait for routes to appear and distance to propagate
+    async fn wait_for_distance_sync(inst: &Instance, expected_peer_count: usize) {
+        wait_for_condition(
+            || async {
+                let routes = inst.get_peer_manager().list_routes().await;
+                routes.len() >= expected_peer_count
+            },
+            Duration::from_secs(30),
+        )
+        .await;
+
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+
+    /// Wait for specific distance value to appear in routes
+    async fn wait_for_route_distance(
+        inst: &Instance,
+        peer_id: PeerId,
+        expected_distance: i32,
+        timeout_secs: u64,
+    ) {
+        wait_for_condition(
+            || async {
+                let routes = inst.get_peer_manager().list_routes().await;
+                routes
+                    .iter()
+                    .find(|r| r.peer_id == peer_id)
+                    .map(|r| r.distance == expected_distance)
+                    .unwrap_or(false)
+            },
+            Duration::from_secs(timeout_secs),
+        )
+        .await;
+    }
+
+    /// Get the total forwarded packets count for a node
+    fn get_forwarded_packets(inst: &Instance) -> u64 {
+        let all_metrics = inst.get_global_ctx().stats_manager().get_all_metrics();
+        let mut total = 0u64;
+        for metric in all_metrics {
+            if metric.name == MetricName::TrafficPacketsForwarded {
+                let counter = inst
+                    .get_global_ctx()
+                    .stats_manager()
+                    .get_counter(metric.name, metric.labels.clone());
+                total += counter.get();
+            }
+        }
+        total
+    }
+
+    /// Verify distance configuration and latency_first interaction
+    #[rstest]
+    #[case::latency_false_configured(false, 10, 5, 10, 15)]
+    #[case::latency_true_ignored(true, 1000, 1000, 0, 0)]
+    #[case::latency_false_fallback(false, 50, 5, 50, 55)]
+    #[tokio::test]
+    #[serial_test::serial]
+    pub async fn test_distance_accumulation(
+        #[case] latency_first: bool,
+        #[case] inst2_dist: u32,
+        #[case] inst3_dist: u32,
+        #[case] exp_dist2: i32,
+        #[case] exp_dist3: i32,
+    ) {
+        prepare_linux_namespaces();
+
+        let insts = super::init_three_node_ex(
+            "udp",
+            |cfg| {
+                let mut flags = cfg.get_flags();
+                flags.latency_first = latency_first;
+                cfg.set_flags(flags);
+
+                match cfg.get_inst_name().as_str() {
+                    "inst2" => {
+                        let acl = create_acl_with_distance(vec![], inst2_dist, None);
+                        cfg.set_acl(Some(acl));
+                    }
+                    "inst3" => {
+                        let acl = create_acl_with_distance(vec![], inst3_dist, None);
+                        cfg.set_acl(Some(acl));
+                    }
+                    _ => {}
+                }
+
+                cfg
+            },
+            false,
+        )
+        .await;
+
+        if latency_first {
+            wait_for_distance_sync(&insts[0], 2).await;
+        } else {
+            wait_for_route_distance(&insts[0], insts[1].peer_id(), exp_dist2, 60).await;
+        }
+
+        let routes = insts[0].get_peer_manager().list_routes().await;
+        println!("inst1 routes: {:?}", routes);
+
+        check_route_distance(&routes, insts[1].peer_id(), exp_dist2);
+        check_route_distance(&routes, insts[2].peer_id(), exp_dist3);
+
+        if latency_first {
+            for route in &routes {
+                assert!(route.cost < 500, "Cost should be latency-based");
+            }
+        }
+
+        drop_insts(insts).await;
+    }
+
+    /// Verify group matching logic with correct/incorrect secret
+    #[tokio::test]
+    #[serial_test::serial]
+    pub async fn test_group_matching_with_correct_secret() {
+        prepare_linux_namespaces();
+
+        let group_name = "trusted_zone";
+        let group_secret = "test-secret-123";
+
+        let insts = super::init_three_node_ex(
+            "udp",
+            |cfg| {
+                let mut flags = cfg.get_flags();
+                flags.latency_first = false;
+                cfg.set_flags(flags);
+
+                let group_info = GroupInfo {
+                    declares: vec![GroupIdentity {
+                        group_name: group_name.to_string(),
+                        group_secret: group_secret.to_string(),
+                    }],
+                    members: vec![group_name.to_string()],
+                };
+
+                match cfg.get_inst_name().as_str() {
+                    "inst2" => {
+                        let acl = create_acl_with_distance(
+                            vec![create_group_distance_rule(
+                                "trusted_low_dist",
+                                200,
+                                10,
+                                vec![group_name],
+                            )],
+                            100,
+                            Some(group_info.clone()),
+                        );
+                        cfg.set_acl(Some(acl));
+                    }
+                    "inst3" => {
+                        let acl = create_acl_with_distance(
+                            vec![create_group_distance_rule(
+                                "trusted_low_dist",
+                                200,
+                                10,
+                                vec![group_name],
+                            )],
+                            100,
+                            Some(group_info.clone()),
+                        );
+                        cfg.set_acl(Some(acl));
+                    }
+                    _ => {
+                        let acl = Acl {
+                            acl_v1: Some(AclV1 {
+                                group: Some(group_info.clone()),
+                                ..Default::default()
+                            }),
+                        };
+                        cfg.set_acl(Some(acl));
+                    }
+                }
+
+                cfg
+            },
+            false,
+        )
+        .await;
+
+        // Wait for specific distance values to propagate, not just route count
+        wait_for_route_distance(&insts[0], insts[1].peer_id(), 10, 60).await;
+        wait_for_route_distance(&insts[0], insts[2].peer_id(), 20, 60).await;
+
+        let routes = insts[0].get_peer_manager().list_routes().await;
+        println!("inst1 routes (group matching): {:?}", routes);
+
+        assert!(
+            routes.len() >= 2,
+            "Expected at least 2 routes, got {:?}",
+            routes
+        );
+
+        check_route_distance(&routes, insts[1].peer_id(), 10);
+        check_route_distance(&routes, insts[2].peer_id(), 20);
+
+        drop_insts(insts).await;
+    }
+
+    /// Verify foreign_node matching logic (public server scenario)
+    #[tokio::test]
+    #[serial_test::serial]
+    pub async fn test_foreign_node_matching() {
+        prepare_linux_namespaces();
+
+        let insts = super::init_three_node_ex(
+            "udp",
+            |cfg| {
+                let mut flags = cfg.get_flags();
+                flags.latency_first = false;
+                cfg.set_flags(flags);
+
+                if cfg.get_inst_name() == "inst2" {
+                    cfg.set_network_identity(NetworkIdentity::new(
+                        "public".to_string(),
+                        "public".to_string(),
+                    ));
+                }
+
+                match cfg.get_inst_name().as_str() {
+                    "inst2" => {
+                        let acl = create_acl_with_distance(
+                            vec![
+                                create_foreign_distance_rule("foreign_low", 200, 10, true),
+                                create_foreign_distance_rule("local_high", 100, 100, false),
+                            ],
+                            50,
+                            None,
+                        );
+                        cfg.set_acl(Some(acl));
+                    }
+                    "inst3" => {
+                        let acl = create_acl_with_distance(vec![], 5, None);
+                        cfg.set_acl(Some(acl));
+                    }
+                    _ => {}
+                }
+
+                cfg
+            },
+            true,
+        )
+        .await;
+
+        wait_for_distance_sync(&insts[0], 1).await;
+
+        let routes = insts[0].get_peer_manager().list_routes().await;
+        println!("inst1 routes (foreign_node matching): {:?}", routes);
+
+        assert!(!routes.is_empty(), "Expected routes, got none");
+
+        for route in &routes {
+            if route.peer_id == insts[1].peer_id() {
+                assert_eq!(
+                    route.distance, 100,
+                    "Route to inst2 should have distance=100 (local_high rule), got {}",
+                    route.distance
+                );
+            }
+        }
+
+        drop_insts(insts).await;
+    }
+
+    /// Verify distance boundary handling (0, negative, overflow)
+    #[rstest]
+    #[case::zero_corrected(0, 1)]
+    #[case::max_capped(u32::MAX, i32::MAX)]
+    #[tokio::test]
+    #[serial_test::serial]
+    pub async fn test_distance_boundary_handling(
+        #[case] input_dist: u32,
+        #[case] expected_dist: i32,
+    ) {
+        prepare_linux_namespaces();
+
+        let insts = super::init_three_node_ex(
+            "udp",
+            |cfg| {
+                let mut flags = cfg.get_flags();
+                flags.latency_first = false;
+                cfg.set_flags(flags);
+
+                if cfg.get_inst_name() == "inst2" {
+                    let acl = create_acl_with_distance(vec![], input_dist, None);
+                    cfg.set_acl(Some(acl));
+                }
+
+                cfg
+            },
+            false,
+        )
+        .await;
+
+        wait_for_distance_sync(&insts[0], 1).await;
+
+        let routes = insts[0].get_peer_manager().list_routes().await;
+        println!("inst1 routes (boundary handling): {:?}", routes);
+
+        if input_dist == 0 {
+            check_route_distance(&routes, insts[1].peer_id(), expected_dist);
+        } else {
+            let route = routes
+                .iter()
+                .find(|r| r.peer_id == insts[1].peer_id())
+                .unwrap();
+            assert!(route.distance > 0);
+        }
+
+        drop_insts(insts).await;
+    }
+
+    /// Additional test: Verify priority ordering of distance rules
+    /// Uses group-based rules since IP matching requires OSPF sync
+    #[tokio::test]
+    #[serial_test::serial]
+    pub async fn test_distance_rule_priority() {
+        prepare_linux_namespaces();
+
+        let group_name = "test_group";
+        let group_secret = "secret";
+
+        let insts = super::init_three_node_ex(
+            "udp",
+            |cfg| {
+                let mut flags = cfg.get_flags();
+                flags.latency_first = false;
+                cfg.set_flags(flags);
+
+                let group_info = GroupInfo {
+                    declares: vec![GroupIdentity {
+                        group_name: group_name.to_string(),
+                        group_secret: group_secret.to_string(),
+                    }],
+                    members: vec![group_name.to_string()],
+                };
+
+                if cfg.get_inst_name() == "inst2" {
+                    let acl = create_acl_with_distance(
+                        vec![
+                            create_group_distance_rule("low_priority", 50, 100, vec![group_name]),
+                            create_group_distance_rule("high_priority", 200, 5, vec![group_name]),
+                        ],
+                        1,
+                        Some(group_info.clone()),
+                    );
+                    cfg.set_acl(Some(acl));
+                } else {
+                    let acl = Acl {
+                        acl_v1: Some(AclV1 {
+                            group: Some(group_info.clone()),
+                            ..Default::default()
+                        }),
+                    };
+                    cfg.set_acl(Some(acl));
+                }
+
+                cfg
+            },
+            false,
+        )
+        .await;
+
+        wait_for_route_distance(&insts[0], insts[1].peer_id(), 5, 60).await;
+
+        let routes = insts[0].get_peer_manager().list_routes().await;
+        println!("inst1 routes (priority test): {:?}", routes);
+
+        assert!(
+            routes.len() >= 2,
+            "Expected at least 2 routes, got {:?}",
+            routes
+        );
+
+        check_route_distance(&routes, insts[1].peer_id(), 5);
+        check_route_distance(&routes, insts[2].peer_id(), 6);
+
+        drop_insts(insts).await;
+    }
+
+    /// Verify data path preference based on total distance
+    #[rstest]
+    #[case::prefer_direct(100, 1, vec![], 1)]
+    #[case::prefer_relay(1, 1, vec![("10.144.144.1/32", 100)], 2)]
+    #[tokio::test]
+    #[serial_test::serial]
+    pub async fn test_distance_routing_preference(
+        #[case] inst2_dist: u32,
+        #[case] inst3_dist: u32,
+        #[case] inst3_rules: Vec<(&str, u32)>,
+        #[case] expected_cost: i32,
+    ) {
+        prepare_linux_namespaces();
+
+        let insts = super::init_three_node_ex(
+            "udp",
+            |cfg| {
+                let mut flags = cfg.get_flags();
+                flags.latency_first = false;
+                cfg.set_flags(flags);
+
+                match cfg.get_inst_name().as_str() {
+                    "inst2" => {
+                        cfg.set_acl(Some(create_acl_with_distance(vec![], inst2_dist, None)));
+                    }
+                    "inst3" => {
+                        let rules = inst3_rules
+                            .iter()
+                            .map(|(ip, dist)| create_ip_distance_rule("rule", 100, *dist, vec![ip]))
+                            .collect();
+                        cfg.set_acl(Some(create_acl_with_distance(rules, inst3_dist, None)));
+                    }
+                    _ => {}
+                }
+                cfg
+            },
+            false,
+        )
+        .await;
+
+        make_three_node_full_mesh(&insts).await;
+
+        wait_for_condition(
+            || async {
+                let routes = insts[0].get_peer_manager().list_routes().await;
+                let inst3_route = routes.iter().find(|r| r.peer_id == insts[2].peer_id());
+                match inst3_route {
+                    Some(route) => route.cost == expected_cost,
+                    None => false,
+                }
+            },
+            Duration::from_secs(60),
+        )
+        .await;
+
+        let routes = insts[0].get_peer_manager().list_routes().await;
+        check_route_cost(&routes, insts[2].peer_id(), expected_cost);
+
+        let forwarded_before = get_forwarded_packets(&insts[1]);
+        for _ in 0..5 {
+            ping_test("net_a", "10.144.144.3", None).await;
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let forwarded_after = get_forwarded_packets(&insts[1]);
+
+        if expected_cost == 1 {
+            assert_eq!(
+                forwarded_after, forwarded_before,
+                "Should NOT forward via inst2"
+            );
+        } else {
+            assert!(
+                forwarded_after > forwarded_before,
+                "Should forward via inst2"
+            );
+        }
+
+        drop_insts(insts).await;
+    }
 }


### PR DESCRIPTION
# feat: 实现节点间路由距离配置功能

## 1. 背景与动机

在 EasyTier 的原有逻辑中，当用户禁用“延迟优先” (`latency_first = false`) 时，系统采用“最少跳数优先”策略。然而，该策略下每一跳的成本被固定为 `1`，这在一些复杂网络拓扑中显得过于僵硬。

例如：
*   **中继避让**：用户可能希望即使公共中继节点跳数较少，也优先走跳数稍多但带宽更高的私有链路。
*   **异地组网优化**：对于跨数据中心 (DC) 的连接，用户希望手动指定更高的“距离”以引导流量避开昂贵的专线或高负载链路。
*   **精细化拓扑控制**：根据业务逻辑，将特定的安全组或 IP 段标记为“近距离”或“远距离”。

本次 PR 引入了**可配置的节点间路由距离**功能，允许用户通过简单的规则定义，灵活干预 OSPF 路由决策。

### 系统逻辑架构

<details>
<summary>点击展开架构图与逻辑流程</summary>

自定义距离的完整流转拓扑如下：

```mermaid
flowchart TD
    %% 1. 配置与加载
    subgraph Initialization ["初始化 (节点 A)"]
        Config[TOML Config] --> |"解析 [acl_v1.route_distance]"| Processor["RouteDistanceProcessor<br/>(规则匹配引擎)"]
        Processor --> |"缓存于"| GlobalCtx["GlobalCtx<br/>(ACL 哈希校验)"]
    end

    %% 2. 本地计算 (入向距离)
    subgraph NodeA ["本地 Peer 管理 (Node A)"]
        B_Connect["邻居 B 连接"] --> |"触发计算"| CalcDist{"匹配规则"}
        GlobalCtx -.-> CalcDist
        CalcDist --> |"Match Rule (B)"| DistVal["Distance = X"]
        DistVal --> |"写入"| PeerInfo["DirectConnectedPeerInfo<br/>(入向距离 = X)"]
    end

    %% 3. 同步
    subgraph Sync ["全网同步 (控制面)"]
        PeerInfo --> |"report_peers (周期上报)"| PeerCenter["PeerCenter Server<br/>(GlobalPeerMap)"]
        PeerCenter --> |"增量同步 / 拉取"| GlobalMapC["节点 C 维护的<br/>全局拓扑图"]
    end

    %% 4. 路径计算
    subgraph PathCalc ["路径计算 (节点 C)"]
        GlobalMapC --> |"计算边 B -> A 的代价"| CostCalc["RouteCostCalculatorImpl<br/>(next_hop_policy)"]
        CostCalc --> |"latency_first = false"| UseDist["边权重 = A 上报的距离 X"]
        UseDist --> |"Dijkstra 路径搜索"| OSPF["OSPF 算法<br/>(累加路径总距离)"]
        OSPF --> |"展示结果"| CLI["easytier-cli route<br/>(新增 dist 列)"]
    end

    %% 样式
    style Config fill:#f9f,stroke:#333
    style Processor fill:#bbf,stroke:#333
    style CalcDist fill:#fff4dd,stroke:#d4a017
    style OSPF fill:#bfb,stroke:#333
```

> **注意逻辑方向**：
> 1.  **定义**：节点 **A** 定义规则。
> 2.  **计算**：节点 **A** 根据规则计算它与直接邻居 **B** 之间的“入向距离”。
> 3.  **上报**：节点 **A** 将 `(B, distance=X)` 上报给中心。
> 4.  **生效**：全网节点在计算经过 `B -> A` 这条边时，会采用节点 **A** 上报的 `distance` 值。

</details>

## 2. 核心功能特性

### 精准干预网络拓扑
用户可以摆脱“每一跳代价固定为 1”的限制。在禁用“延迟优先”时，您可以手动为特定链路分配“距离”权重，从而实现对流量路径的精细化掌控（如强制绕开高负载中继，或优选特定私有链路）。

### 灵活的规则匹配引擎
复用 EasyTier 成熟的 ACL 匹配框架，支持多维度的规则定义：
*   **按虚拟 IP / CIDR 匹配**：为特定网段的邻居设置自定义距离。
*   **按零信任安全组匹配**：基于身份验证，为不同信任级别的群组设置差异化的链路代价。
*   **一键识别公共节点**：支持通过 `foreign_node` 开关快速标记公共中继服务器。这不仅方便私有节点设置“避让策略”，也允许公共节点主动增加他人连接自己的代价，从而在网络负载较高时降低自身的路由权重。

### “一处配置，全网生效”
遵循**入向语义**（我来定义“谁进我”的代价）。距离信息会随节点状态自动、增量地分发至全网所有节点。您无需在每台设备上重复配置，即可实现全局路由决策的一致性。

### 透明的可观测性
增强了 `easytier-cli` 工具，在查看节点和路由信息时新增 `dist`（距离）列：
- **Peer 列表**：直观查看该节点到特定邻居的**出向距离**。
- **Route 列表**：清晰展示到达目标节点的**全路径累计距离**，让路由选路逻辑一目了然。

## 3. 用户配置指南

### 如何启用

#### 方式一：通过 Web 配置界面（推荐）
本次更新同步增强了 Web 配置生成器的访问控制（ACL）模块，新增了**路由距离配置**功能：

1. **访问配置界面**：在 Web 配置页面中，进入"访问控制 (ACL)"部分。
2. **启用路由距离**：
   - 如果 ACL 未启用，点击"启用"按钮初始化 ACL 配置（会自动创建包含路由距离的默认配置）。
   - 如果 ACL 已启用，切换到新增的"路由距离"标签页。
3. **配置默认距离**：设置 `default_distance`（默认值为 1，范围 1 ~ 2147483647）。
4. **添加距离规则**：
   - 点击"添加距离规则"按钮。
   - 配置规则名称、优先级、距离值。
   - 设置匹配条件：目的 IP（支持 CIDR）、目的组、是否仅匹配外部节点。
   - 支持拖拽排序调整规则优先级。
5. **导出配置**：完成配置后，导出生成的 TOML 配置文件。

**Web 界面改动要点**：
- **新增组件**：`AclRouteDistanceEditor.vue` - 提供可视化的规则编辑界面。
- **集成到 ACL 管理器**：在 `AclManager.vue` 中新增"路由距离"标签页。
- **国际化支持**：中英文界面完整支持（`cn.yaml` / `en.yaml`）。
- **类型定义扩展**：`network.ts` 中新增 `RouteDistanceRule` 和 `RouteDistanceConfig` 类型。

#### 方式二：手动编辑配置文件
在配置文件中设置 `latency_first = false`，并在 `[acl.acl_v1.route_distance]` 节下添加规则。

### 配置示例

#### 场景 1：全网规避公共中继 (Public Relay Avoidance)

<details>
<summary>点击展开配置详情</summary>

**目标**：当存在私有路径（直连或私有节点中转）时，绝不走公共中继服务器。
**逻辑**：所有私有节点通过 `foreign_node` 规则，将来自“外部节点”的入向代价设为 100。

**所有私有节点 (Node_A, Node_B, ...) 关键配置：**
```toml
[flags]
latency_first = false

[acl.acl_v1.route_distance]
default_distance = 1 

[[acl.acl_v1.route_distance.rules]]
name = "avoid_public_relay"
priority = 100
enabled = true
distance = 100
foreign_node = true # 匹配所有标记为 is_public_server 的公共节点
```

</details>

---

#### 场景 2：优选中继路径 (Path Selection: C over D)

<details>
<summary>点击展开配置详情</summary>

**目标**：当 A 与 B 无法直连时，优先通过节点 C 中转，仅当 C 掉线时才使用 D。
**逻辑**：
1. 由于 `distance` 是**入向**语义，要使 `A -> D -> B` 路径变长，必须增加“进入 D”的代价（在 D 上配置）和“从 D 进入 B”的代价（在 B 上配置）。
2. 同理，反向路径 `B -> D -> A` 也需要增加“进入 D”和“从 D 进入 A”的代价。

```mermaid
graph LR
    A((Node A)) -- 1 --- C((Node C)) -- 1 --- B((Node B))
    A -. 10 .-> D((Node D)) -. 10 .-> B((Node B))
    B -. 10 .-> D -. 10 .-> A
    style D stroke-dasharray: 5 5
```

**Node_D 关键配置（增加他人进入 D 的代价）：**
```toml
# 在 D 上配置：来自 A 或 B 的入向流量代价设为 10
[[acl.acl_v1.route_distance.rules]]
name = "expensive_inbound_from_AB"
priority = 100
distance = 10
destination_ips = ["<Node_A_VIP>/32", "<Node_B_VIP>/32"]
```

**Node_A & Node_B 关键配置（增加 D 进入自己的代价）：**
```toml
# 在 A 和 B 上分别配置：来自 D 的入向流量代价设为 10
[[acl.acl_v1.route_distance.rules]]
name = "expensive_relay_from_D"
priority = 100
distance = 10
destination_ips = ["<Node_D_VIP>/32"]
```
*结果：A->C->B 路径总距离为 2 (1+1)；A->D->B 路径总距离为 20 (10+10)。OSPF 将优选 C。*

</details>

---

#### 场景 3：区域化网关模式 (Regional Gateways)

<details>
<summary>点击展开配置详情</summary>

**目标**：区域 1 (R1) 与区域 2 (R2) 内部各自直连。跨区域通信强制经由各自的网关 G1 和 G2 进行。

**逻辑 (Trust & Membership)**：
1. **身份证明**：节点必须在 `members` 中声明所属组，并在 `declares` 中提供密钥，系统才会为其生成加密的身份证明。
2. **身份验证**：若规则要匹配 `destination_groups = ["XXX"]`，本地节点必须在 `declares` 中预置 `XXX` 的密钥，否则无法通过零信任验证。
3. **区域内直连**：同一区域的节点不匹配规避规则，保持 `default_distance = 1` 的直连代价。
4. **策略执行**：通过高代价规避直接跨区链路，通过高优先级低代价规则优选网关链路。

```mermaid
graph TD
    subgraph Region_1
        N1((Node N1)) -- 1 --- G1((Gateway G1))
        N2((Node N2)) -- 1 --- G1
        N1 -- 1 --- N2
    end

    subgraph Region_2
        G2((Gateway G2)) -- 1 --- N3((Node N3))
        G2 -- 1 --- N4((Node N4))
        N3 -- 1 --- N4
    end

    G1 == dist: 1 (Backbone) ==> G2
    G2 == dist: 1 (Backbone) ==> G1

    N1 -. dist: 100 (Avoid) .-> N3
    N3 -. dist: 100 (Avoid) .-> N1
    
    style G1 fill:#f9f,stroke:#333
    style G2 fill:#f9f,stroke:#333
    linkStyle 6,7 stroke:#2ecd71,stroke-width:4px
    linkStyle 8,9 stroke:#e74c3c,stroke-dasharray: 5 5
```

**区域 1 节点 (N1, N2...) 关键配置：**
```toml
[acl.acl_v1.group]
members = ["region_1"] # 声明本节点属于 region_1

[[acl.acl_v1.group.declares]]
group_name = "region_1"
group_secret = "r1-secret" # 用于生成本节点的身份证明

[[acl.acl_v1.group.declares]]
group_name = "region_2"
group_secret = "r2-secret" # 必须拥有对端密钥，才能识别并匹配来自 region_2 的节点

# 距离规则：规避来自 region_2 的直接连接
[[acl.acl_v1.route_distance.rules]]
name = "avoid_R2_direct"
priority = 100
distance = 100
destination_groups = ["region_2"]
```

**区域 2 节点 (N3, N4...) 关键配置：**
```toml
[acl.acl_v1.group]
members = ["region_2"]

[[acl.acl_v1.group.declares]]
group_name = "region_1"
group_secret = "r1-secret"

[[acl.acl_v1.group.declares]]
group_name = "region_2"
group_secret = "r2-secret"

[[acl.acl_v1.route_distance.rules]]
name = "avoid_R1_direct"
priority = 100
distance = 100
destination_groups = ["region_1"]
```

**网关节点 G1 & G2 关键配置：**
网关节点除了上述组配置外，需通过高优先级规则显式允许对端网关：
```toml
# 以 G1 为例，优选来自对端网关 G2 的骨干链路
[[acl.acl_v1.route_distance.rules]]
name = "backbone_from_G2"
priority = 200 # 高优先级确保覆盖普通节点的规避逻辑
distance = 1
destination_ips = ["<G2_Virtual_IP>/32"]
```
*结果：N1 -> N3 的直连成本为 100；而 N1 -> G1 -> G2 -> N3 的成本为 1+1+1=3，OSPF 将优选网关路径。*

</details>

### 距离语义说明 (Important!)
配置具有**单向语义**：本节点配置的规则影响的是**“他人到我”**的入向距离。
> *例如：节点 A 配置了针对 B 的距离为 10，则全网在计算到达 A 的路径时，若经过 B→A 这条边，其权重将计为 10。*

### 规则与取值说明
- **优先级**：按 `priority` 降序匹配，命中第一条即生效。
- **匹配逻辑**：多个条件采用 **AND**；空列表表示“不限制”。
- **取值范围**：`distance` 有效范围为 `1 ~ i32::MAX`，`0` 会被自动修正为 `1`。
- **`foreign_node` 语义**：`true` 表示仅匹配公共节点（`is_public_server=true`）。

## 4. 技术实现要点

1.  **数据模型**：扩展 `DirectConnectedPeerInfo` / `PeerInfo` / `Route` 的 Proto 定义，支持 `distance` 透传。
2.  **处理器实现**：新增 `RouteDistanceProcessor`，预解析 CIDR 与 Group 集合，按优先级匹配，复杂度 $O(N)$。
3.  **路由代价**：`RouteCostCalculatorImpl` 根据 `NextHopPolicy` 切换“距离/延迟”成本；`Route.distance` 记录路径累计距离。
4.  **缓存与更新**：`GlobalCtx` 基于配置哈希缓存 `RouteDistanceProcessor`，避免重复解析。
5.  **向后兼容性**：
    *   旧节点上报的距离为 `0` 时，自动回退到 `default_distance`。
    *   不支持该功能的旧版本节点忽略新增字段，不影响互通。

## 5. 相关问题
- close #212
- close #635
- #773
- #1046
- #1314
- #1481
- #1528
