### PR TITLE
feat(web): add --disable-registration flag to disable user registration

### DIFF
--- a/easytier-web/locales/app.yml
+++ b/easytier-web/locales/app.yml
@@ -34,3 +34,6 @@ cli:
   geoip_db:
     en: "The path to the GeoIP2 database file, used to lookup the location of the client, default is the embedded file (only country information) , recommend https://github.com/P3TERX/GeoLite.mmdb"
     zh-CN: "GeoIP2 数据库文件路径，用于查找客户端的位置，默认为嵌入文件（仅国家信息），推荐 https://github.com/P3TERX/GeoLite.mmdb"
+  disable_registration:
+    en: "Disable user registration"
+    zh-CN: "禁用用户注册"

--- a/easytier-web/src/main.rs
+++ b/easytier-web/src/main.rs
@@ -109,6 +109,13 @@ struct Cli {
         help = t!("cli.api_host").to_string()
     )]
     api_host: Option<url::Url>,
+
+    #[arg(
+        long,
+        default_value = "false",
+        help = t!("cli.disable_registration").to_string(),
+    )]
+    disable_registration: bool,
 }
 
 impl LoggingConfigLoader for &Cli {
@@ -212,6 +219,7 @@ async fn main() {
         mgr.clone(),
         db,
         web_router_restful,
+        cli.disable_registration,
     )
     .await
     .unwrap()


### PR DESCRIPTION
# feat(web): 新增禁用用户注册功能

## 概述

本 PR 为 `easytier-web` 添加了 `--disable-registration` 命令行参数，允许管理员禁用用户注册功能。当启用此选项时，注册 API 端点将返回 `403 Forbidden` 错误。

## 动机

在某些部署场景下，管理员可能希望禁止新用户自行注册，例如：
- 私有部署环境，仅允许管理员手动创建用户
- 安全考虑，防止未授权用户注册

## 变更内容

### 新增文件/功能

| 文件 | 变更 |
|------|------|
| `easytier-web/locales/app.yml` | 添加 `disable_registration` 的国际化文本 (en/zh-CN) |
| `easytier-web/src/main.rs` | 添加 `--disable-registration` CLI 参数 |
| `easytier-web/src/restful/auth.rs` | 新增 `FeatureFlags` 结构体，实现注册禁用检查逻辑 |
| `easytier-web/src/restful/mod.rs` | 存储配置并通过 `Extension` 层传递给路由 |

### 使用方式

```bash
# 启动时禁用用户注册
easytier-web --disable-registration

# 或显式设置
easytier-web --disable-registration=true
```

### API 行为变化

当 `--disable-registration` 启用时：

- **端点**: `POST /api/v1/auth/register`
- **响应**: `403 Forbidden`
- **响应体**: `{"message": "Registration is disabled"}`

## 技术实现

1. **CLI 参数**: 使用 `clap` 定义 `--disable-registration` 参数，默认值为 `false`
2. **配置传递**: 通过 `RestfulServer` 构造函数传递配置
3. **路由层注入**: 使用 Axum 的 `Extension` 层将 `FeatureFlags` 注入到 `auth::router()`
4. **请求处理**: 在 `register` handler 中检查 `feature_flags.disable_registration`

## 兼容性

- ✅ 向后兼容：默认值为 `false`，不影响现有部署
- ✅ 无破坏性变更
