### PR TITLE
fix: avoid panic for quic peer urls using port 0

### DIFF
--- a/easytier/src/tunnel/quic.rs
+++ b/easytier/src/tunnel/quic.rs
@@ -247,7 +247,7 @@ impl TunnelConnector for QUICTunnelConnector {
                 .await?;
         if addr.port() == 0 {
             return Err(TunnelError::InvalidAddr(format!(
-                "invalid remote quic port 0 in url: {} (port 0 placeholder is only supported for ws/wss)",
+                "invalid remote QUIC port 0 in url: {} (port 0 is not a valid QUIC port)",
                 self.addr
             )));
         }


### PR DESCRIPTION
## Summary
- reject `quic://...:0` as an invalid remote target and return a regular `InvalidAddr` error
- replace a `unwrap()` in QUIC connect setup with error propagation so invalid targets do not abort the process
- add a regression test to ensure QUIC port 0 fails gracefully instead of panicking