### PR TITLE
ci: aes-gcm is no longer required in check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Check features
         if: ${{ !cancelled() }}
-        run: cargo hack check --package easytier --each-feature --features aes-gcm --exclude-features macos-ne --verbose
+        run: cargo hack check --package easytier --each-feature --exclude-features macos-ne --verbose
 
   pre-test:
     name: Build test


### PR DESCRIPTION
- depends on https://github.com/EasyTier/EasyTier/pull/1923
- depends on https://github.com/EasyTier/EasyTier/pull/1924