### PR TITLE
feat: core config server wss support path and use last path segment as user name

### DIFF
--- a/easytier/src/web_client/mod.rs
+++ b/easytier/src/web_client/mod.rs
@@ -130,7 +130,7 @@ pub async fn run_web_client(
     };
 
     let mut c_url = config_server_url.clone();
-    if !matches!(c_url.schema(), "ws" | "wss") {
+    if !matches!(c_url.scheme(), "ws" | "wss") {
         c_url.set_path("");
     }
     let token = config_server_url


### PR DESCRIPTION
此pr使得easytier-core可以配合easytier-web支持基于path的分流，便于放置在reverse proxy后面。
core wss 支持使用类似路径wss://xx.cn/username或者wss://xx.cn/fsdddfsf/username的方式连接config server，其中这里的username为实际使用的用户名，分流的路径为/username或者/fsdddfsf/username
或许可以解决 #1895 中的需求。