### PR TITLE
fix(foreign_network): set avoid_relay_data when relay_data is false

### DIFF
--- a/easytier/src/peers/foreign_network_manager.rs
+++ b/easytier/src/peers/foreign_network_manager.rs
@@ -93,7 +93,8 @@ impl ForeignNetworkEntry {
         pm_packet_sender: PacketRecvChan,
     ) -> Self {
         let stats_mgr = global_ctx.stats_manager().clone();
-        let foreign_global_ctx = Self::build_foreign_global_ctx(&network, global_ctx.clone());
+        let foreign_global_ctx =
+            Self::build_foreign_global_ctx(&network, global_ctx.clone(), relay_data);
 
         let (packet_sender, packet_recv) = create_packet_recv_chan();
 
@@ -158,6 +159,7 @@ impl ForeignNetworkEntry {
     fn build_foreign_global_ctx(
         network: &NetworkIdentity,
         global_ctx: ArcGlobalCtx,
+        relay_data: bool,
     ) -> ArcGlobalCtx {
         let config = TomlConfigLoader::default();
         config.set_network_identity(network.clone());
@@ -180,6 +182,9 @@ impl ForeignNetworkEntry {
 
         let mut feature_flag = global_ctx.get_feature_flags();
         feature_flag.is_public_server = true;
+        if !relay_data {
+            feature_flag.avoid_relay_data = true;
+        }
         foreign_global_ctx.set_feature_flags(feature_flag);
 
         for u in global_ctx.get_running_listeners().into_iter() {


### PR DESCRIPTION
## Problem

When a public server is configured with `relay_all_peer_rpc = true` and a non-empty `relay_network_whitelist`, peers from non-whitelisted networks can connect (for hole punching) but their data packets are silently dropped by the server.

The issue is that the server's identity in the foreign network's OSPF does **not** advertise `avoid_relay_data = true`, so peers see a seemingly cheap route through the server and route data through it — only to have it silently dropped until a direct P2P connection is established.

## Fix

In `build_foreign_global_ctx`, propagate the `relay_data` flag and set `avoid_relay_data = true` on the `foreign_global_ctx` feature flags when `relay_data = false`.

This causes OSPF to assign `AVOID_RELAY_COST` (`i32::MAX`) to routes through the server for non-whitelisted networks, so peers immediately prefer direct P2P connections. Hole punching (RPC) continues to work normally since it is unaffected by `avoid_relay_data`.

```
relay_all_peer_rpc=true + relay_network_whitelist="net1"
├── net1: relay_data=true  → data forwarded normally
└── net2: relay_data=false → avoid_relay_data=true on foreign_global_ctx
       → OSPF cost = AVOID_RELAY_COST for routes via this server
       → peers prefer direct P2P; hole punch via RPC still works
```

## Test plan

- [x] All existing `foreign_network_manager` tests pass (`cargo test -p easytier foreign_network_manager`)
- [x] Manual: connect two peers from a non-whitelisted network through a public server, verify data flows directly (not via server) once P2P is established
- [x] Manual: verify whitelisted network peers are still relayed normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)