### PR TITLE
feat(web): add OIDC SSO login support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,29 +515,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c953fe1ba023e6b7730c0d4b031d06f267f23a46167dcbd40316644b10a17ba"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
-dependencies = [
- "bindgen 0.69.5",
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "axum"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,6 +724,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base62"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,29 +775,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.8.0",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.87",
- "which 4.4.2",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -826,7 +786,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.0",
+ "rustc-hash",
  "shlex",
  "syn 2.0.87",
 ]
@@ -1391,15 +1351,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "codepage"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,6 +1651,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,6 +1728,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
+ "digest",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -2368,7 +2332,6 @@ dependencies = [
  "gethostname 1.0.2",
  "libc",
  "once_cell",
- "rustls",
  "security-framework-sys",
  "serde",
  "serde_json",
@@ -2456,8 +2419,10 @@ dependencies = [
  "maxminddb",
  "mimalloc",
  "once_cell",
+ "openidconnect",
  "password-auth",
  "rand 0.8.5",
+ "reqwest",
  "rust-embed",
  "rust-i18n",
  "rusttype",
@@ -2466,6 +2431,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "subtle",
  "sys-locale",
  "thiserror 1.0.63",
  "thunk-rs",
@@ -2479,12 +2445,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2756,6 +2781,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2885,12 +2920,6 @@ name = "fragile"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -3156,6 +3185,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -3374,6 +3404,17 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -3801,6 +3842,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4374,7 +4416,7 @@ source = "git+https://github.com/EasyTier/kcp-sys?rev=94964794caaed5d388463137da
 dependencies = [
  "anyhow",
  "auto_impl",
- "bindgen 0.72.1",
+ "bindgen",
  "bitflags 2.8.0",
  "bytes",
  "cc",
@@ -4420,12 +4462,6 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libappindicator"
@@ -5293,6 +5329,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.15",
+ "http",
+ "rand 0.8.5",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror 1.0.63",
+ "url",
+]
+
+[[package]]
 name = "objc-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5575,6 +5631,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "openidconnect"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c6709ba2ea764bbed26bce1adf3c10517113ddea6f2d4196e4851757ef2b2"
+dependencies = [
+ "base64 0.21.7",
+ "chrono",
+ "dyn-clone",
+ "ed25519-dalek",
+ "hmac",
+ "http",
+ "itertools 0.10.5",
+ "log",
+ "oauth2",
+ "p256",
+ "p384",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_plain",
+ "serde_with",
+ "sha2",
+ "subtle",
+ "thiserror 1.0.63",
+ "url",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5633,6 +5720,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ordered-float"
@@ -5721,6 +5817,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e6affeb1632d6ff6a23d2cd40ffed138e82f1532571a26f527c8a284bb2fbb"
 dependencies = [
  "ttf-parser",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
 ]
 
 [[package]]
@@ -6316,6 +6436,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6552,7 +6681,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.0",
+ "rustc-hash",
  "rustls",
  "socket2 0.5.10",
  "thiserror 2.0.11",
@@ -6585,7 +6714,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.1",
  "ring",
- "rustc-hash 2.1.0",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -6921,7 +7050,10 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -6929,6 +7061,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower 0.5.2",
  "tower-service",
@@ -6937,6 +7070,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
  "windows-registry",
 ]
 
@@ -6945,6 +7079,16 @@ name = "resolv-conf"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7c8f7f733062b66dc1c63f9db168ac0b97a9210e247fa90fdc9ad08f51b302"
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
 
 [[package]]
 name = "ring"
@@ -7177,12 +7321,6 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
@@ -7228,8 +7366,6 @@ version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
- "aws-lc-rs",
- "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -7301,7 +7437,6 @@ version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -7508,7 +7643,7 @@ dependencies = [
  "bigdecimal",
  "chrono",
  "inherent",
- "ordered-float",
+ "ordered-float 3.9.2",
  "rust_decimal",
  "sea-query-derive",
  "serde_json",
@@ -7574,6 +7709,20 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -7660,6 +7809,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float 2.10.1",
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7722,6 +7881,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
 dependencies = [
  "itoa",
+ "serde",
+]
+
+[[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
  "serde",
 ]
 

--- a/easytier-web/Cargo.toml
+++ b/easytier-web/Cargo.toml
@@ -63,6 +63,9 @@ uuid = { version = "1.5.0", features = [
 ] }
 
 chrono = { version = "0.4.37", features = ["serde"] }
+openidconnect = { version = "4.0", default-features = false, features = ["accept-rfc3339-timestamps", "reqwest"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+subtle = "2.6"
 
 mimalloc = { version = "*" }
 

--- a/easytier-web/frontend-lib/src/locales/cn.yaml
+++ b/easytier-web/frontend-lib/src/locales/cn.yaml
@@ -242,6 +242,7 @@ web:
     captcha: 验证码
     back_to_login: 返回登录
     login: 登录
+    sso_login: "SSO 登录"
 
   register:
     title: 注册

--- a/easytier-web/frontend-lib/src/locales/en.yaml
+++ b/easytier-web/frontend-lib/src/locales/en.yaml
@@ -242,6 +242,7 @@ web:
     captcha: Captcha
     back_to_login: Back to Login
     login: Login
+    sso_login: "SSO Login"
 
   register:
     title: Register

--- a/easytier-web/frontend/src/modules/api.ts
+++ b/easytier-web/frontend/src/modules/api.ts
@@ -6,6 +6,10 @@ export interface ValidateConfigResponse {
     toml_config: string;
 }
 
+export interface OidcConfigResponse {
+    enabled: boolean;
+}
+
 // 定义接口返回的数据结构
 export interface LoginResponse {
     success: boolean;
@@ -172,6 +176,19 @@ export class ApiClient {
 
     public captcha_url() {
         return this.client.defaults.baseURL + '/auth/captcha';
+    }
+
+    public async getOidcConfig(): Promise<OidcConfigResponse> {
+        try {
+            const response = await this.client.get<any, OidcConfigResponse>('/auth/oidc/config');
+            return response;
+        } catch (error) {
+            return { enabled: false };
+        }
+    }
+
+    public oidcLoginUrl() {
+        return this.client.defaults.baseURL + '/auth/oidc/login';
     }
 
     public get_remote_client(machine_id: string): Api.RemoteClient {

--- a/easytier-web/locales/app.yml
+++ b/easytier-web/locales/app.yml
@@ -37,3 +37,30 @@ cli:
   disable_registration:
     en: "Disable user registration"
     zh-CN: "禁用用户注册"
+  oidc_issuer_url:
+    en: "The OIDC issuer URL for single sign-on authentication"
+    zh-CN: "OIDC 签发者 URL，用于单点登录认证"
+  oidc_client_id:
+    en: "The OIDC client ID"
+    zh-CN: "OIDC 客户端 ID"
+  oidc_client_secret:
+    en: "The OIDC client secret (can also be set via OIDC_CLIENT_SECRET env var)"
+    zh-CN: "OIDC 客户端密钥（也可通过 OIDC_CLIENT_SECRET 环境变量设置）"
+  oidc_username_claim:
+    en: "The OIDC claim to use as the local username, default: preferred_username"
+    zh-CN: "用作本地用户名的 OIDC claim 字段，默认: preferred_username"
+  oidc_scopes:
+    en: "OIDC scopes to request during login. Supports comma-separated values or repeated --oidc-scopes flags, default: openid,profile"
+    zh-CN: "登录时请求的 OIDC scopes。支持逗号分隔或多次指定 --oidc-scopes，默认: openid,profile"
+  oidc_redirect_url:
+    en: "The OIDC redirect URL (callback URL), must match exactly what is registered with your Identity Provider. Required when using OIDC. Example: http://your-domain.com:11211/api/v1/auth/oidc/callback"
+    zh-CN: "OIDC 重定向 URL（回调 URL），必须与身份提供商注册的地址完全一致。使用 OIDC 时必须提供。示例: http://your-domain.com:11211/api/v1/auth/oidc/callback"
+  allow_auto_create_user:
+    en: "Allow auto-creating local user when easytier-core connects with an unknown username"
+    zh-CN: "当 easytier-core 使用未知用户名连接时，允许自动创建本地用户"
+  oidc_disable_pkce:
+    en: "Disable PKCE (Proof Key for Code Exchange) for OIDC authentication"
+    zh-CN: "禁用 OIDC 认证的 PKCE（授权码交换证明密钥）"
+  oidc_frontend_base_url:
+    en: "Frontend base URL to redirect to after successful OIDC callback. Required when frontend and API are deployed separately (non-embed build, --no-web mode, or different web_server_port)"
+    zh-CN: "OIDC 回调成功后跳转的前端入口地址。当前端与 API 分离部署时必须提供（非 embed 构建、--no-web 模式、或 web_server_port 与 api_server_port 不同）"

--- a/easytier-web/src/client_manager/storage.rs
+++ b/easytier-web/src/client_manager/storage.rs
@@ -21,7 +21,6 @@ struct ClientInfo {
 
 #[derive(Debug)]
 pub struct StorageInner {
-    // some map for indexing
     user_clients_map: DashMap<UserIdInDb, DashMap<uuid::Uuid, ClientInfo>>,
     pub db: Db,
 }
@@ -122,5 +121,11 @@ impl Storage {
 
     pub fn db(&self) -> &Db {
         &self.0.db
+    }
+
+    pub async fn auto_create_user(&self, username: &str) -> anyhow::Result<UserIdInDb> {
+        let new_user = self.db().auto_create_user(username).await?;
+        tracing::info!("Auto-created user '{}' with id {}", username, new_user.id);
+        Ok(new_user.id)
     }
 }

--- a/easytier-web/src/main.rs
+++ b/easytier-web/src/main.rs
@@ -110,12 +110,22 @@ struct Cli {
     )]
     api_host: Option<url::Url>,
 
-    #[arg(
-        long,
-        default_value = "false",
-        help = t!("cli.disable_registration").to_string(),
-    )]
-    disable_registration: bool,
+    #[command(flatten)]
+    feature_flags: FeatureFlags,
+
+    #[command(flatten)]
+    oidc: restful::oidc::OidcOptions,
+}
+
+#[derive(Debug, Clone, Default, clap::Args)]
+pub struct FeatureFlags {
+    /// Whether user registration via the web UI is disabled.
+    #[arg(long, default_value = "false", help = t!("cli.disable_registration").to_string())]
+    pub disable_registration: bool,
+
+    /// Whether to auto-create users when they connect via heartbeat with an unknown token.
+    #[arg(long, default_value = "false", help = t!("cli.allow_auto_create_user").to_string())]
+    pub allow_auto_create_user: bool,
 }
 
 impl LoggingConfigLoader for &Cli {
@@ -181,9 +191,37 @@ async fn main() {
     let cli = Cli::parse();
     init_logger(&cli, false).unwrap();
 
+    // Validate OIDC configuration: check split-deploy specific requirements
+    // Basic OIDC parameter validation is handled in OidcConfig::from_params
+    if cli.oidc.any_param_provided() {
+        let is_split_deploy = {
+            #[cfg(feature = "embed")]
+            {
+                let embed_split_by_port = cli.web_server_port.is_some()
+                    && cli.web_server_port != Some(cli.api_server_port);
+                cli.no_web || embed_split_by_port
+            }
+            #[cfg(not(feature = "embed"))]
+            {
+                true
+            }
+        };
+
+        if is_split_deploy && cli.oidc.oidc_frontend_base_url.is_none() {
+            eprintln!("Error: --oidc-frontend-base-url is required in split-deploy mode");
+            eprintln!(
+                "When frontend and API are deployed separately, you must specify the frontend URL"
+            );
+            eprintln!("Example: --oidc-frontend-base-url http://your-frontend-domain.com");
+            std::process::exit(1);
+        }
+    }
+
     // let db = db::Db::new(":memory:").await.unwrap();
     let db = db::Db::new(cli.db).await.unwrap();
-    let mut mgr = client_manager::ClientManager::new(db.clone(), cli.geoip_db);
+    let feature_flags = Arc::new(cli.feature_flags);
+    let mut mgr =
+        client_manager::ClientManager::new(db.clone(), cli.geoip_db, feature_flags.clone());
     let (v6_listener, v4_listener) =
         get_dual_stack_listener(&cli.config_server_protocol, cli.config_server_port)
             .await
@@ -214,12 +252,26 @@ async fn main() {
     #[cfg(not(feature = "embed"))]
     let web_router_restful = None;
 
+    let oidc_config = if cli.oidc.oidc_issuer_url.is_some() {
+        match restful::oidc::OidcConfig::from_params(cli.oidc).await {
+            Ok(config) => config,
+            Err(e) => {
+                eprintln!("Failed to initialize OIDC: {:?}", e);
+                eprintln!("Please check your OIDC configuration (issuer URL, client ID, etc.)");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        restful::oidc::OidcConfig::disabled()
+    };
+
     let _restful_server_tasks = restful::RestfulServer::new(
         format!("0.0.0.0:{}", cli.api_server_port).parse().unwrap(),
         mgr.clone(),
         db,
         web_router_restful,
-        cli.disable_registration,
+        feature_flags,
+        oidc_config,
     )
     .await
     .unwrap()

--- a/easytier-web/src/restful/auth.rs
+++ b/easytier-web/src/restful/auth.rs
@@ -9,17 +9,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::restful::users::Backend;
 
+use std::sync::Arc;
+
+use crate::FeatureFlags;
+
 use super::{
     users::{AuthSession, Credentials},
     AppStateInner,
 };
-
-/// Feature flags for the web server
-#[derive(Clone, Default)]
-pub struct FeatureFlags {
-    /// Whether user registration is disabled
-    pub disable_registration: bool,
-}
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct LoginResult {
@@ -117,7 +114,7 @@ mod post {
     }
 
     pub async fn register(
-        Extension(feature_flags): Extension<FeatureFlags>,
+        Extension(feature_flags): Extension<Arc<FeatureFlags>>,
         auth_session: AuthSession,
         captcha_session: tower_sessions::Session,
         Json(req): Json<RegisterNewUser>,

--- a/easytier-web/src/restful/oidc.rs
+++ b/easytier-web/src/restful/oidc.rs
@@ -1,0 +1,734 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use subtle::ConstantTimeEq;
+
+use axum::routing::get;
+use axum::Router;
+use openidconnect::core::{
+    CoreAuthDisplay, CoreAuthPrompt, CoreErrorResponseType, CoreGenderClaim, CoreJsonWebKey,
+    CoreJweContentEncryptionAlgorithm, CoreJwsSigningAlgorithm, CoreProviderMetadata,
+    CoreRevocableToken, CoreRevocationErrorResponse, CoreTokenIntrospectionResponse, CoreTokenType,
+};
+use openidconnect::{
+    Client, ClientId, ClientSecret, EmptyExtraTokenFields, EndpointMaybeSet, EndpointNotSet,
+    EndpointSet, IdTokenFields, IssuerUrl, RedirectUrl, StandardErrorResponse,
+    StandardTokenResponse,
+};
+use serde::{Deserialize, Serialize};
+
+use super::AppStateInner;
+
+const DEFAULT_OIDC_SCOPES: [&str; 2] = ["openid", "profile"];
+
+fn normalize_oidc_scopes(scopes: &[String]) -> Vec<String> {
+    let mut normalized: Vec<String> = scopes
+        .iter()
+        .map(|scope| scope.trim().to_string())
+        .filter(|scope| !scope.is_empty())
+        .collect();
+
+    if normalized.is_empty() {
+        normalized = DEFAULT_OIDC_SCOPES
+            .iter()
+            .map(|scope| scope.to_string())
+            .collect();
+    }
+
+    if !normalized.iter().any(|scope| scope == "openid") {
+        normalized.insert(0, "openid".to_string());
+    }
+
+    normalized
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct JsonAdditionalClaims {
+    #[serde(flatten)]
+    pub claims: HashMap<String, serde_json::Value>,
+}
+
+impl openidconnect::AdditionalClaims for JsonAdditionalClaims {}
+
+pub type AppIdTokenFields = IdTokenFields<
+    JsonAdditionalClaims,
+    EmptyExtraTokenFields,
+    CoreGenderClaim,
+    CoreJweContentEncryptionAlgorithm,
+    CoreJwsSigningAlgorithm,
+>;
+
+pub type AppTokenResponse = StandardTokenResponse<AppIdTokenFields, CoreTokenType>;
+
+pub type AppClient<
+    HasAuthUrl = EndpointNotSet,
+    HasDeviceAuthUrl = EndpointNotSet,
+    HasIntrospectionUrl = EndpointNotSet,
+    HasRevocationUrl = EndpointNotSet,
+    HasTokenUrl = EndpointNotSet,
+    HasUserInfoUrl = EndpointNotSet,
+> = Client<
+    JsonAdditionalClaims,
+    CoreAuthDisplay,
+    CoreGenderClaim,
+    CoreJweContentEncryptionAlgorithm,
+    CoreJsonWebKey,
+    CoreAuthPrompt,
+    StandardErrorResponse<CoreErrorResponseType>,
+    AppTokenResponse,
+    CoreTokenIntrospectionResponse,
+    CoreRevocableToken,
+    CoreRevocationErrorResponse,
+    HasAuthUrl,
+    HasDeviceAuthUrl,
+    HasIntrospectionUrl,
+    HasRevocationUrl,
+    HasTokenUrl,
+    HasUserInfoUrl,
+>;
+
+pub type ConfiguredAppClient = AppClient<
+    EndpointSet,
+    EndpointNotSet,
+    EndpointNotSet,
+    EndpointNotSet,
+    EndpointMaybeSet,
+    EndpointMaybeSet,
+>;
+
+/// Convert a dot-path (e.g. `realm_access.roles.0`) to a JSON Pointer (e.g. `/realm_access/roles/0`).
+/// Each segment is escaped per RFC 6901: `~` → `~0`, `/` → `~1`.
+fn dot_path_to_json_pointer(dot_path: &str) -> String {
+    let mut pointer = String::new();
+    for segment in dot_path.split('.') {
+        pointer.push('/');
+        for ch in segment.chars() {
+            match ch {
+                '~' => pointer.push_str("~0"),
+                '/' => pointer.push_str("~1"),
+                _ => pointer.push(ch),
+            }
+        }
+    }
+    pointer
+}
+
+/// Timing-safe string comparison via constant-time equality check.
+/// Prevents timing side-channel attacks on CSRF token verification.
+fn timing_safe_eq(a: &str, b: &str) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.as_bytes().ct_eq(b.as_bytes()).into()
+}
+
+#[derive(Debug, Clone, clap::Args)]
+pub struct OidcOptions {
+    #[arg(long, help = t!("cli.oidc_issuer_url").to_string())]
+    pub oidc_issuer_url: Option<String>,
+
+    #[arg(long, help = t!("cli.oidc_client_id").to_string())]
+    pub oidc_client_id: Option<String>,
+
+    #[arg(long, env = "OIDC_CLIENT_SECRET", help = t!("cli.oidc_client_secret").to_string())]
+    pub oidc_client_secret: Option<String>,
+
+    #[arg(long, default_value = "preferred_username", help = t!("cli.oidc_username_claim").to_string())]
+    pub oidc_username_claim: String,
+
+    #[arg(
+        long,
+        value_delimiter = ',',
+        default_values = DEFAULT_OIDC_SCOPES,
+        help = t!("cli.oidc_scopes").to_string()
+    )]
+    pub oidc_scopes: Vec<String>,
+
+    #[arg(long, help = t!("cli.oidc_redirect_url").to_string())]
+    pub oidc_redirect_url: Option<String>,
+
+    #[arg(long, default_value = "false", help = t!("cli.oidc_disable_pkce").to_string())]
+    pub oidc_disable_pkce: bool,
+
+    #[arg(long, help = t!("cli.oidc_frontend_base_url").to_string())]
+    pub oidc_frontend_base_url: Option<String>,
+}
+
+impl OidcOptions {
+    pub fn any_param_provided(&self) -> bool {
+        self.oidc_issuer_url.is_some()
+            || self.oidc_client_id.is_some()
+            || self.oidc_client_secret.is_some()
+            || self.oidc_redirect_url.is_some()
+            || self.oidc_frontend_base_url.is_some()
+            || self.oidc_username_claim != "preferred_username"
+            || self.oidc_scopes != DEFAULT_OIDC_SCOPES
+            || self.oidc_disable_pkce
+    }
+}
+
+#[derive(Clone)]
+pub struct OidcConfig {
+    pub enabled: bool,
+    pub provider_metadata: Option<Arc<CoreProviderMetadata>>,
+    pub client_id: String,
+    pub client_secret: Option<String>,
+    pub redirect_url: Option<RedirectUrl>,
+    pub username_claim: String,
+    pub scopes: Vec<String>,
+    pub pkce_enabled: bool,
+    pub frontend_base_url: Option<String>,
+    pub http_client: Option<reqwest::Client>,
+    cached_client: Option<Arc<ConfiguredAppClient>>,
+}
+
+impl OidcConfig {
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            provider_metadata: None,
+            client_id: String::new(),
+            client_secret: None,
+            redirect_url: None,
+            username_claim: "preferred_username".to_string(),
+            scopes: DEFAULT_OIDC_SCOPES
+                .iter()
+                .map(|scope| scope.to_string())
+                .collect(),
+            pkce_enabled: false,
+            frontend_base_url: None,
+            http_client: None,
+            cached_client: None,
+        }
+    }
+
+    pub async fn from_params(opts: OidcOptions) -> anyhow::Result<Self> {
+        let OidcOptions {
+            oidc_issuer_url,
+            oidc_client_id,
+            oidc_client_secret,
+            oidc_username_claim,
+            oidc_scopes,
+            oidc_redirect_url,
+            oidc_disable_pkce,
+            oidc_frontend_base_url,
+        } = opts;
+
+        if oidc_issuer_url.is_none() || oidc_client_id.is_none() || oidc_redirect_url.is_none() {
+            return Err(anyhow::anyhow!("--oidc-issuer-url, --oidc-client-id and --oidc-redirect-url are required when using OIDC authentication"));
+        }
+        if oidc_username_claim.trim().is_empty() {
+            return Err(anyhow::anyhow!("--oidc-username-claim cannot be empty"));
+        }
+        let http_client = reqwest::ClientBuilder::new()
+            .redirect(reqwest::redirect::Policy::none())
+            .timeout(Duration::from_secs(30))
+            .build()?;
+
+        let issuer_url = oidc_issuer_url.ok_or_else(|| {
+            anyhow::anyhow!("--oidc-issuer-url is required when using OIDC authentication")
+        })?;
+
+        let provider_metadata =
+            CoreProviderMetadata::discover_async(IssuerUrl::new(issuer_url)?, &http_client).await?;
+
+        let client_id = oidc_client_id.ok_or_else(|| {
+            anyhow::anyhow!("--oidc-client-id is required when using OIDC authentication")
+        })?;
+
+        let redirect_url = oidc_redirect_url
+            .ok_or_else(|| anyhow::anyhow!("--oidc-redirect-url is required when using OIDC authentication. The redirect URL must match exactly what is registered with your Identity Provider. Example: --oidc-redirect-url http://your-domain.com:11211/api/v1/auth/oidc/callback"))?;
+
+        let provider_metadata = Arc::new(provider_metadata);
+        let redirect_url = RedirectUrl::new(redirect_url)?;
+        let client_secret = oidc_client_secret;
+
+        let cached_client = {
+            let c = AppClient::from_provider_metadata(
+                provider_metadata.as_ref().clone(),
+                ClientId::new(client_id.clone()),
+                client_secret.as_ref().map(|s| ClientSecret::new(s.clone())),
+            )
+            .set_redirect_uri(redirect_url.clone());
+            Arc::new(c)
+        };
+
+        Ok(Self {
+            enabled: true,
+            provider_metadata: Some(provider_metadata),
+            client_id,
+            client_secret,
+            redirect_url: Some(redirect_url),
+            username_claim: oidc_username_claim,
+            scopes: normalize_oidc_scopes(&oidc_scopes),
+            pkce_enabled: !oidc_disable_pkce,
+            frontend_base_url: oidc_frontend_base_url,
+            http_client: Some(http_client),
+            cached_client: Some(cached_client),
+        })
+    }
+
+    pub fn client(&self) -> Option<&ConfiguredAppClient> {
+        self.cached_client.as_deref()
+    }
+}
+
+pub fn router() -> Router<AppStateInner> {
+    Router::new()
+        .route("/api/v1/auth/oidc/config", get(self::route::oidc_config))
+        .route("/api/v1/auth/oidc/login", get(self::route::oidc_login))
+        .route(
+            "/api/v1/auth/oidc/callback",
+            get(self::route::oidc_callback),
+        )
+}
+
+mod route {
+    use axum::extract::Query;
+    use axum::http::StatusCode;
+    use axum::response::{IntoResponse, Redirect, Response};
+    use axum::{Extension, Json};
+    use openidconnect::core::CoreAuthenticationFlow;
+    use openidconnect::{
+        AccessTokenHash, AuthorizationCode, CsrfToken, Nonce, OAuth2TokenResponse,
+        PkceCodeChallenge, PkceCodeVerifier, Scope, TokenResponse,
+    };
+    use serde::Deserialize;
+
+    use crate::restful::other_error;
+    use crate::restful::users::AuthSession;
+
+    use super::OidcConfig;
+
+    pub async fn oidc_config(Extension(oidc): Extension<OidcConfig>) -> Json<serde_json::Value> {
+        Json(serde_json::json!({ "enabled": oidc.enabled }))
+    }
+
+    pub async fn oidc_login(
+        Extension(oidc): Extension<OidcConfig>,
+        session: tower_sessions::Session,
+    ) -> Response {
+        if !oidc.enabled {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(other_error("OIDC is not enabled")),
+            )
+                .into_response();
+        }
+
+        let client = match oidc.client() {
+            Some(c) => c,
+            None => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(other_error("OIDC client not initialized")),
+                )
+                    .into_response();
+            }
+        };
+
+        let scopes = oidc.scopes.clone();
+        let pkce_enabled = oidc.pkce_enabled;
+
+        let (pkce_challenge, pkce_verifier) = if pkce_enabled {
+            let (challenge, verifier) = PkceCodeChallenge::new_random_sha256();
+            (Some(challenge), Some(verifier))
+        } else {
+            (None, None)
+        };
+
+        let mut auth_request = client.authorize_url(
+            CoreAuthenticationFlow::AuthorizationCode,
+            CsrfToken::new_random,
+            Nonce::new_random,
+        );
+
+        for scope in &scopes {
+            auth_request = auth_request.add_scope(Scope::new(scope.clone()));
+        }
+
+        if let Some(challenge) = pkce_challenge {
+            auth_request = auth_request.set_pkce_challenge(challenge);
+        }
+
+        let (auth_url, csrf_token, nonce) = auth_request.url();
+
+        if let Err(e) = session
+            .insert("oidc_csrf_token", csrf_token.secret().clone())
+            .await
+        {
+            tracing::error!("Failed to store csrf_token in session: {:?}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(other_error("Session error")),
+            )
+                .into_response();
+        }
+        if let Err(e) = session.insert("oidc_nonce", nonce.secret().clone()).await {
+            tracing::error!("Failed to store nonce in session: {:?}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(other_error("Session error")),
+            )
+                .into_response();
+        }
+        if let Some(verifier) = pkce_verifier {
+            if let Err(e) = session
+                .insert("oidc_pkce_verifier", verifier.secret().clone())
+                .await
+            {
+                tracing::error!("Failed to store pkce_verifier in session: {:?}", e);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(other_error("Session error")),
+                )
+                    .into_response();
+            }
+        }
+        if let Err(e) = session.insert("oidc_pkce_used", pkce_enabled).await {
+            tracing::error!("Failed to store pkce_used in session: {:?}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(other_error("Session error")),
+            )
+                .into_response();
+        }
+
+        Redirect::temporary(auth_url.as_str()).into_response()
+    }
+
+    #[derive(Deserialize)]
+    pub struct CallbackParams {
+        code: Option<String>,
+        state: Option<String>,
+        error: Option<String>,
+        error_description: Option<String>,
+    }
+
+    async fn cleanup_oidc_session(session: &tower_sessions::Session) {
+        let _ = session.remove::<String>("oidc_csrf_token").await;
+        let _ = session.remove::<String>("oidc_nonce").await;
+        let _ = session.remove::<String>("oidc_pkce_verifier").await;
+        let _ = session.remove::<bool>("oidc_pkce_used").await;
+    }
+
+    pub async fn oidc_callback(
+        Extension(oidc): Extension<OidcConfig>,
+        Query(params): Query<CallbackParams>,
+        session: tower_sessions::Session,
+        mut auth_session: AuthSession,
+    ) -> Response {
+        if !oidc.enabled {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(other_error("OIDC is not enabled")),
+            )
+                .into_response();
+        }
+
+        if let Some(ref error) = params.error {
+            tracing::error!(
+                "OIDC provider returned error: {}, description: {:?}",
+                error,
+                params.error_description
+            );
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(other_error(
+                    "Authentication failed at the identity provider",
+                )),
+            )
+                .into_response();
+        }
+
+        let code = match params.code {
+            Some(ref c) => c.clone(),
+            None => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(other_error("Missing authorization code")),
+                )
+                    .into_response();
+            }
+        };
+
+        let callback_state = match params.state {
+            Some(ref s) => s.clone(),
+            None => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(other_error("Missing state parameter in callback")),
+                )
+                    .into_response();
+            }
+        };
+
+        let stored_csrf: String = match session.get("oidc_csrf_token").await {
+            Ok(Some(v)) => v,
+            _ => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(other_error("Missing or invalid CSRF token in session")),
+                )
+                    .into_response();
+            }
+        };
+        if !super::timing_safe_eq(&stored_csrf, &callback_state) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(other_error("CSRF state mismatch")),
+            )
+                .into_response();
+        }
+
+        let stored_nonce: String = match session.get("oidc_nonce").await {
+            Ok(Some(v)) => v,
+            _ => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(other_error("Missing nonce in session")),
+                )
+                    .into_response();
+            }
+        };
+
+        let stored_pkce_verifier: Option<String> =
+            session.get("oidc_pkce_verifier").await.ok().flatten();
+        let pkce_was_used: Option<bool> = session.get("oidc_pkce_used").await.ok().flatten();
+
+        cleanup_oidc_session(&session).await;
+
+        let client = match oidc.client() {
+            Some(c) => c,
+            None => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(other_error("OIDC client not initialized")),
+                )
+                    .into_response();
+            }
+        };
+
+        let http_client = match oidc.http_client.as_ref() {
+            Some(c) => c,
+            None => {
+                tracing::error!("HTTP client not initialized in OIDC config");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(other_error("OIDC internal error")),
+                )
+                    .into_response();
+            }
+        };
+
+        let mut token_request = match client.exchange_code(AuthorizationCode::new(code)) {
+            Ok(req) => req,
+            Err(e) => {
+                tracing::error!("Failed to create token request: {:?}", e);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(other_error("Failed to create token exchange request")),
+                )
+                    .into_response();
+            }
+        };
+
+        if let Some(stored_pkce_verifier) = stored_pkce_verifier {
+            token_request =
+                token_request.set_pkce_verifier(PkceCodeVerifier::new(stored_pkce_verifier));
+        } else if pkce_was_used == Some(true) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(other_error(
+                    "PKCE was enabled but verifier is missing from session (session may have expired)",
+                )),
+            )
+                .into_response();
+        }
+
+        let token_response = match token_request.request_async(http_client).await {
+            Ok(resp) => resp,
+            Err(e) => {
+                tracing::error!("Failed to exchange code for token: {:?}", e);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(other_error("Token exchange failed")),
+                )
+                    .into_response();
+            }
+        };
+
+        let id_token = match token_response.id_token() {
+            Some(t) => t,
+            None => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(other_error("No ID token in response")),
+                )
+                    .into_response();
+            }
+        };
+
+        let claims = match id_token.claims(&client.id_token_verifier(), &Nonce::new(stored_nonce)) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::error!("Failed to verify ID token: {:?}", e);
+                return (
+                    StatusCode::UNAUTHORIZED,
+                    Json(other_error("ID token verification failed")),
+                )
+                    .into_response();
+            }
+        };
+
+        if let Some(expected_at_hash) = claims.access_token_hash() {
+            let id_token_verifier = client.id_token_verifier();
+            let (Ok(signing_alg), Ok(signing_key)) = (
+                id_token.signing_alg(),
+                id_token.signing_key(&id_token_verifier),
+            ) else {
+                tracing::error!("Failed to get signing algorithm or key for at_hash verification");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(other_error("Failed to determine token signing algorithm")),
+                )
+                    .into_response();
+            };
+
+            let actual_at_hash = match AccessTokenHash::from_token(
+                token_response.access_token(),
+                signing_alg,
+                signing_key,
+            ) {
+                Ok(hash) => hash,
+                Err(e) => {
+                    tracing::error!("Failed to compute access token hash: {:?}", e);
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(other_error("Failed to verify access token hash")),
+                    )
+                        .into_response();
+                }
+            };
+
+            if actual_at_hash != *expected_at_hash {
+                tracing::error!("Access token hash mismatch");
+                return (
+                    StatusCode::UNAUTHORIZED,
+                    Json(other_error("Access token hash mismatch")),
+                )
+                    .into_response();
+            }
+        }
+
+        let claims_json = match serde_json::to_value(claims) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::error!("Failed to serialize claims: {:?}", e);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(other_error("Failed to process ID token claims")),
+                )
+                    .into_response();
+            }
+        };
+
+        let pointer = super::dot_path_to_json_pointer(&oidc.username_claim);
+        let username: Option<String> = claims_json
+            .pointer(&pointer)
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let username = match username {
+            Some(u) if !u.is_empty() => u,
+            _ => {
+                tracing::error!(
+                    "Could not extract username from claim '{}' in token",
+                    oidc.username_claim
+                );
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(other_error("Could not extract username from token claims")),
+                )
+                    .into_response();
+            }
+        };
+
+        let user = match auth_session
+            .backend
+            .find_or_create_oidc_user(&username)
+            .await
+        {
+            Ok(u) => u,
+            Err(e) => {
+                tracing::error!("Failed to find or create OIDC user '{}': {:?}", username, e);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(other_error("Failed to provision user account")),
+                )
+                    .into_response();
+            }
+        };
+
+        if let Err(e) = auth_session.login(&user).await {
+            tracing::error!("Failed to login user via OIDC: {:?}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(other_error("Failed to establish session")),
+            )
+                .into_response();
+        }
+
+        if let Err(e) = session.cycle_id().await {
+            tracing::error!("Failed to cycle session ID after OIDC login: {:?}", e);
+        }
+        if let Some(frontend_url) = &oidc.frontend_base_url {
+            Redirect::temporary(frontend_url).into_response()
+        } else {
+            Redirect::temporary("/").into_response()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dot_path_to_json_pointer() {
+        use serde_json::json;
+
+        let cases = vec![
+            (
+                "realm_access.roles.0",
+                "/realm_access/roles/0",
+                json!({ "realm_access": { "roles": ["admin", "user"] } }),
+                "admin",
+            ),
+            (
+                "preferred_username",
+                "/preferred_username",
+                json!({ "preferred_username": "bob" }),
+                "bob",
+            ),
+            ("a~b.c", "/a~0b/c", json!({ "a~b": { "c": "v" } }), "v"),
+            ("a/b.c", "/a~1b/c", json!({ "a/b": { "c": "w" } }), "w"),
+            ("~/.x", "/~0~1/x", json!({ "~/": { "x": "z" } }), "z"),
+            ("a..b", "/a//b", json!({ "a": { "": { "b": "x" } } }), "x"),
+            ("", "/", json!({ "": "root" }), "root"),
+        ];
+
+        for (path, expected_ptr, json_val, expected_val) in cases {
+            let ptr = dot_path_to_json_pointer(path);
+            assert_eq!(ptr, expected_ptr, "Pointer mismatch for path: {}", path);
+            assert_eq!(
+                json_val.pointer(&ptr).and_then(|v| v.as_str()),
+                Some(expected_val),
+                "Value extraction failed for path: {}, pointer: {}",
+                path,
+                ptr
+            );
+        }
+    }
+}


### PR DESCRIPTION
## 摘要

为 `easytier-web` 添加 OIDC (OpenID Connect) 单点登录认证支持，允许用户通过外部身份提供商（如 Keycloak, Authentik, Okta, Azure AD）进行身份验证。

### 核心变更

- **OIDC SSO 认证**：完整的 Authorization Code + PKCE 流程实现，包含 CSRF 保护、nonce 验证和 access token hash 校验。
- **心跳自动创建用户**：新增 `--allow-auto-create-user` 命令行标志，当 `easytier-core` 以未知用户名连接时，可自动为其拨备本地账号。
- **用户创建逻辑重构**：将所有用户创建路径统一到事务函数 `create_user_and_join_users_group` 中，消除了原有 `register_new_user` 中的 `.unwrap()` panic 风险。
- **前端 SSO 按钮**：登录页面根据服务端配置动态显示“SSO 登录”按钮。

## 新增命令行选项

| 标志 | 说明 |
|------|-------------|
| `--oidc-issuer-url` | OIDC 发行者 URL（用于自动发现配置） |
| `--oidc-client-id` | OIDC 客户端 ID |
| `--oidc-client-secret` / `OIDC_CLIENT_SECRET` 环境变量 | 客户端密钥 |
| `--oidc-redirect-url` | 回调 URL（必须与 IdP 配置完全一致） |
| `--oidc-username-claim` | 用于提取用户名的 Claim（默认：`preferred_username`） |
| `--oidc-scopes` | 请求的权限范围（默认：`openid,profile`） |
| `--oidc-disable-pkce` | 为不支持 PKCE 的旧版 IdP 禁用 PKCE |
| `--oidc-frontend-base-url` | 前后端分离部署模式下的前端基础 URL |
| `--allow-auto-create-user` | 允许为未知的心跳 Token 自动创建本地用户 |

## 新增 API 端点

| 方法 | 路径 | 认证要求 | 说明 |
|--------|------|--------------|-------------|
| GET | `/api/v1/auth/oidc/config` | 无 | 检查 OIDC 是否已启用 |
| GET | `/api/v1/auth/oidc/login` | 无 | 发起 OIDC 登录流程 |
| GET | `/api/v1/auth/oidc/callback` | 无 | 处理 IdP 认证回调 |

## OIDC 流程说明

```
浏览器 → GET /auth/oidc/login
  → 服务端生成认证 URL (包含 CSRF + nonce + PKCE) → 存入 session
  → 302 重定向至身份提供商 (IdP)
  → 用户在 IdP 完成登录
  → IdP → 302 重定向至 /auth/oidc/callback?code=...&state=...
  → 服务端验证 CSRF，交换 Code，验证 ID Token
  → 查找或自动拨备本地用户账号
  → 建立登录会话 → 302 重定向回前端
```

## 安全措施

- 使用 `subtle` 库进行恒定时间比较（Constant-time comparison）验证 CSRF 状态，防止时序攻击。
- 默认启用 PKCE (Proof Key for Code Exchange)。
- 对 ID Token Claim 进行 Nonce 验证。
- 存在时强制执行 Access Token Hash (`at_hash`) 校验。
- 认证回调完成后立即清理 Session 中的一次性安全参数。
- Session 配置 `SameSite=Lax` 以支持跨站认证重定向。

## 已知局限

- 新用户的首次并发 OIDC 登录可能因用户创建时的 TOCTOU 竞态导致瞬间失败（唯一约束保护了数据一致性，重试即可成功）。
- `register_new_user` 和 `change_password` 在异步运行时中直接调用了 CPU 密集型的哈希函数（此为既有代码遗留问题，非本次 PR 引入）。
- **跨域 Cookie (SameSite) 限制**：`SessionManagerLayer` 配置为 `SameSite::Lax`，如果 API 与 Frontend 部署在完全不同的域名下（非同父域），OIDC 回调后浏览器不会携带 Cookie，导致用户始终处于未登录状态。当前假定通过反代将前后端置于同一域名下；若需完全跨域部署，后续需增加 `SameSite=None` + `Secure=true` 的可选配置。
- **OIDC 与本地账户按用户名统一匹配**：系统通过 `username_claim` 提取的用户名与本地 `username` 进行匹配，不区分用户来源（本地注册 vs OIDC）。这是有意为之的设计——同一用户名始终对应同一账户，无论通过密码还是 SSO 登录均操作同一身份。部署时管理员应确保 IdP 侧的用户名分配策略与本地用户体系一致。

## 测试情况

### 自动化单元测试

- `dot_path_to_json_pointer` 覆盖各种边缘情况（嵌套路径、RFC 6901 转义、空段等）。

### 集成 / 人工测试用例

> **前置条件**：需要一个可用的 OIDC IdP（推荐使用 Docker 启动 Keycloak 或 Authentik 进行本地测试）。

#### 一、CLI 参数验证

| # | 测试场景 | 操作步骤 | 预期结果 |
|----|---------|---------|---------|
| ✅ | 不提供 OIDC 参数正常启动 | 正常启动 `easytier-web`，不传任何 `--oidc-*` 参数 | 服务正常启动，`GET /api/v1/auth/oidc/config` 返回 `{"enabled": false}` |
| ✅ | 缺少必需参数报错退出 | 仅传 `--oidc-issuer-url` 而不传 `--oidc-client-id` 和 `--oidc-redirect-url` | 进程输出错误信息并以非零码退出 |
| ✅ | 无效 Issuer URL 报错退出 | 传入不可访问的 `--oidc-issuer-url`（如 `http://localhost:99999`） | 进程输出 OIDC 发现失败的错误信息并退出 |
| ✅ | 完整参数正常启动 | 传入全部必需 OIDC 参数（issuer-url, client-id, redirect-url） | 服务正常启动，日志无报错 |
| ✅ | 默认 scopes 生效 | 不传 `--oidc-scopes`，直接发起 OIDC 登录 | 授权请求中的 `scope` 至少包含 `openid profile`（按默认值） |
| ✅ | split-deploy 模式缺少 frontend-base-url | 使用 `--no-web` 或不同的 `--web-server-port`，但不传 `--oidc-frontend-base-url` | 进程输出 "--oidc-frontend-base-url is required" 并退出 |
| ✅ | `OIDC_CLIENT_SECRET` 环境变量 | 通过环境变量而非命令行传入 client secret | 服务正常启动，OIDC 流程使用该 secret |

#### 二、OIDC SSO 登录 — 正常流程

| # | 测试场景 | 操作步骤 | 预期结果 |
|----|---------|---------|---------|
| ✅ | OIDC 配置接口 | `GET /api/v1/auth/oidc/config` | OIDC 已启用时返回 `{"enabled": true}`；未启用时返回 `{"enabled": false}` |
| ✅ | 发起登录重定向 | `GET /api/v1/auth/oidc/login` | 返回 302，Location 指向 IdP 的授权端点，URL 中包含 `code_challenge`（PKCE）、`state`、`nonce` 参数 |
| ✅ | 首次 OIDC 用户登录 | 完整 SSO 流程：点击 SSO 登录 → IdP 认证 → 回调 | 自动创建本地用户并加入 `users` 组，回调后 302 重定向到前端，session cookie 有效，`GET /api/v1/auth/check_login_status` 返回 200 |
| ✅ | 已有用户 OIDC 登录 | 用户已存在（通过注册或之前的 OIDC 登录创建），再次通过 SSO 登录 | 直接查找到已有用户并登录，不创建重复账号 |
| ✅ | 回调后重定向到前端 | 未设 `--oidc-frontend-base-url` | 回调成功后重定向到 `/` |
| ✅ | 回调后重定向到自定义前端 | 设置 `--oidc-frontend-base-url http://localhost:3000` | 回调成功后重定向到 `http://localhost:3000` |
| ✅ | 自定义 username claim | 使用 `--oidc-username-claim email` 启动 | 从 ID Token 的 `email` 字段提取用户名 |
| ✅ | 嵌套 username claim | 使用 `--oidc-username-claim realm_access.roles.0` 启动 | 从嵌套 JSON 路径正确提取用户名 |
| ✅ | 禁用 PKCE | 使用 `--oidc-disable-pkce` 启动 | 登录重定向 URL 中不包含 `code_challenge` 参数，token 交换请求中不含 PKCE verifier |
| ✅ | 自定义 scopes | 使用 `--oidc-scopes profile,email,groups` 启动 | 登录重定向 URL 的 `scope` 参数中包含 `openid`（自动补充）、`profile`、`email`、`groups` |

#### 三、OIDC SSO 登录 — 异常与安全

| # | 测试场景 | 操作步骤 | 预期结果 |
|----|---------|---------|---------|
| ✅ | OIDC 未启用时访问登录端点 | 未配置 OIDC 参数时 `GET /api/v1/auth/oidc/login` | 返回 400 `{"message": "OIDC is not enabled"}` |
| ☑️ | CSRF state 篡改 | 手动构造回调 URL，将 `state` 参数替换为随机值 | 返回 400 `{"message": "CSRF state mismatch"}` |
| ☑️ | 缺少 code 参数 | 手动构造回调 URL，不携带 `code` 参数 | 返回 400 `{"message": "Missing authorization code"}` |
| ☑️ | 缺少 state 参数 | 手动构造回调 URL，不携带 `state` 参数 | 返回 400 `{"message": "Missing state parameter in callback"}` |
| ☑️ | IdP 返回错误 | IdP 拒绝认证（如用户取消），回调携带 `error=access_denied` | 返回 400，日志记录具体 error 和 error_description |
| ☑️ | Session 过期 | 发起登录后等待 session 过期（>1天），再用保存的回调 URL 访问 | 返回 400，提示 CSRF token 或 nonce 缺失 |
| ☑️ | PKCE verifier 丢失 | 启用 PKCE 的情况下，session 中的 pkce_verifier 被清除后回调 | 返回 400 `{"message": "PKCE was enabled but verifier is missing from session"}` |
| ☑️ | 无效 authorization code | 使用过期或伪造的 `code` 参数进行回调 | 返回 500，日志记录 token exchange 失败详情 |
| ☑️ | Nonce 不匹配 | 使用与登录发起阶段不同的 nonce（或伪造 ID Token）进行回调 | 返回 401 `{"message": "ID token verification failed"}` |
| ☑️ | ID Token 缺失 | IdP token endpoint 仅返回 access token，不返回 id_token | 返回 500 `{"message": "No ID token in response"}` |
| ☑️ | `at_hash` 不匹配 | 篡改 access token 或使用与 id_token 不匹配的 access token | 返回 401 `{"message": "Access token hash mismatch"}` |
| ✅ | username claim 不存在 | `--oidc-username-claim` 指定一个 ID Token 中不存在的字段名 | 返回 400 `{"message": "Could not extract username from token claims"}` |
| ✅ | username claim 类型错误 | `--oidc-username-claim` 指向非字符串字段（如对象/数组） | 返回 400 `{"message": "Could not extract username from token claims"}` |
| ☑️ | 回调重放攻击 | 成功回调后，尝试重放相同的回调 URL | 返回 400（CSRF token 已被 `cleanup_oidc_session` 清除） |

#### 四、心跳自动创建用户

| # | 测试场景 | 操作步骤 | 预期结果 |
|----|---------|---------|---------|
| ✅ | 默认不自动创建 | 不传 `--allow-auto-create-user`，用一个未注册的用户名作为 token 连接 `easytier-core` | 心跳返回 "User not found" 错误 |
| ✅ | 启用后自动创建 | 传 `--allow-auto-create-user`，用一个未注册的用户名作为 token 连接 | 自动创建用户并加入 `users` 组，后续心跳正常处理 |
| ✅ | 已存在用户不重复创建 | 传 `--allow-auto-create-user`，用一个已注册的用户名连接 | 直接查找到已有用户，不触发创建逻辑 |
| ✅ | 自动创建用户权限正确 | 通过自动创建的用户登录 Web 界面 | 用户具有 `users` 组的默认权限，可正常使用 |

#### 五、用户注册回归

| # | 测试场景 | 操作步骤 | 预期结果 |
|----|---------|---------|---------|
| ✅ | 正常注册 | 通过前端注册页面注册新用户 | 注册成功，用户加入 `users` 组，可正常登录 |
| ✅ | 重复用户名注册 | 注册一个已存在的用户名 | 返回错误（唯一约束），不会 panic |
| ✅ | 禁用注册 | 启动时传 `--disable-registration`，尝试注册 | 返回 403 Forbidden |
| ✅ | 密码登录不受影响 | 配置 OIDC 后，仍然使用用户名/密码登录 | 登录正常，OIDC 与密码登录互不干扰 |
| ✅ | 修改密码 | 使用已登录用户修改密码 | 修改成功，旧 session 失效，需重新登录 |

#### 六、前端行为

| # | 测试场景 | 操作步骤 | 预期结果 |
|----|---------|---------|---------|
| ✅ | OIDC 未启用时隐藏 SSO 按钮 | 访问未配置 OIDC 的服务器登录页 | 登录页面仅显示用户名/密码表单和注册按钮，不显示 SSO 按钮 |
| ✅ | OIDC 启用时显示 SSO 按钮 | 访问已配置 OIDC 的服务器登录页 | 登录页面显示 "SSO 登录" 按钮（severity="info" 蓝色按钮） |
| ✅ | 切换 API Host 后动态刷新 | 在 API Host 输入框中切换到一个未启用 OIDC 的服务器 | SSO 按钮消失；切换回已启用 OIDC 的服务器后 SSO 按钮重新出现 |
| ✅ | 点击 SSO 按钮跳转 | 点击 "SSO 登录" 按钮 | 浏览器跳转到 `{apiHost}/api/v1/auth/oidc/login`，apiHost 已保存至 localStorage |
| ✅ | SSO 登录后回跳正常 | 完成 SSO 流程后浏览器回到前端 | 前端页面加载正常，用户处于已登录状态 |
| ✅ | 快速切换 API Host 的竞态保护 | 在两个 host 间快速切换（一个启用 OIDC，一个未启用）并观察按钮状态 | 最终状态以“当前输入框 host”查询结果为准，不会被旧请求覆盖（`if (apiHost.value !== host) return`） |
| ✅ | API Host 不可达时 SSO 按钮 | 在 API Host 输入框中填入不可达的地址 | SSO 按钮不显示（`getOidcConfig` 静默返回 `{enabled: false}`） |
| ✅ | 注册页面不显示 SSO 按钮 | 切换到注册页面 | 注册表单中不包含 SSO 按钮（`v-if="!isRegistering"` 限制） |
| ✅ | 中英文切换 | 切换语言后检查 SSO 按钮文案 | 中文显示 "SSO 登录"，英文显示 "SSO Login" |

#### 七、多 IdP 兼容性

| # | IdP | 备注 |
|---|-----|------|
| ✅ | Auth0 | 需要使用 `--oidc-username-claim=nickname` |
| ✅ | Kanidm | - |
