### PR TITLE
build(deps): bump axios from 1.11.0 to 1.13.6 in frontend packages

### DIFF
--- a/easytier-contrib/easytier-uptime/frontend/package-lock.json
+++ b/easytier-contrib/easytier-uptime/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@element-plus/icons-vue": "^2.3.1",
-        "axios": "^1.7.9",
+        "axios": "^1.13.5",
         "dayjs": "^1.11.13",
         "element-plus": "^2.8.8",
         "vue": "^3.5.18",
@@ -1220,13 +1220,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -1616,9 +1616,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",

--- a/easytier-contrib/easytier-uptime/frontend/package.json
+++ b/easytier-contrib/easytier-uptime/frontend/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@element-plus/icons-vue": "^2.3.1",
-    "axios": "^1.7.9",
+    "axios": "^1.13.5",
     "dayjs": "^1.11.13",
     "easytier-uptime-frontend": "link:",
     "element-plus": "^2.8.8",

--- a/easytier-web/frontend-lib/package.json
+++ b/easytier-web/frontend-lib/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@primeuix/themes": "^1.2.3",
     "@vueuse/core": "^11.1.0",
-    "axios": "^1.7.7",
+    "axios": "^1.13.5",
     "chart.js": "^4.5.0",
     "floating-vue": "^5.2",
     "ip-num": "1.5.1",

--- a/easytier-web/frontend/package.json
+++ b/easytier-web/frontend/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@modyfi/vite-plugin-yaml": "^1.1.0",
     "@primeuix/themes": "^1.2.3",
-    "axios": "^1.7.7",
+    "axios": "^1.13.5",
     "easytier-frontend-lib": "workspace:*",
     "primevue": "^4.3.9",
     "tailwindcss-primeui": "^0.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,8 +148,8 @@ importers:
         specifier: ^1.2.3
         version: 1.2.3
       axios:
-        specifier: ^1.7.7
-        version: 1.11.0
+        specifier: ^1.13.5
+        version: 1.13.6
       easytier-frontend-lib:
         specifier: workspace:*
         version: link:../frontend-lib
@@ -212,8 +212,8 @@ importers:
         specifier: ^11.1.0
         version: 11.3.0(vue@3.5.21(typescript@5.6.3))
       axios:
-        specifier: ^1.7.7
-        version: 1.11.0
+        specifier: ^1.13.5
+        version: 1.13.6
       chart.js:
         specifier: ^4.5.0
         version: 4.5.0
@@ -2093,8 +2093,8 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
-  axios@1.11.0:
-    resolution: {integrity: sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==}
+  axios@1.13.6:
+    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -2677,8 +2677,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.4:
-    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
   format@0.2.2:
@@ -6057,10 +6057,10 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  axios@1.11.0:
+  axios@1.13.6:
     dependencies:
       follow-redirects: 1.15.11
-      form-data: 4.0.4
+      form-data: 4.0.5
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -6754,7 +6754,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.4:
+  form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8


### PR DESCRIPTION
## Summary

- Updates `axios` version specifier to `^1.13.5` in all three frontend `package.json` files (`easytier-contrib/easytier-uptime/frontend`, `easytier-web/frontend-lib`, `easytier-web/frontend`)
- Regenerates `package-lock.json` (npm) and `pnpm-lock.yaml` — both now resolve axios to **1.13.6**
- Addresses security vulnerabilities present in axios versions prior to 1.13.5

## Affected files

| File | Change |
|------|--------|
| `easytier-contrib/easytier-uptime/frontend/package.json` | `^1.7.9` → `^1.13.5` |
| `easytier-web/frontend-lib/package.json` | `^1.7.7` → `^1.13.5` |
| `easytier-web/frontend/package.json` | `^1.7.7` → `^1.13.5` |
| `easytier-contrib/easytier-uptime/frontend/package-lock.json` | resolved `1.11.0` → `1.13.6` |
| `pnpm-lock.yaml` | resolved `1.11.0` → `1.13.6` |

## Test plan

- [x] `npm install` succeeds in `easytier-contrib/easytier-uptime/frontend/`
- [x] `pnpm install` succeeds at repo root
- [x] `pnpm build` passes in `easytier-web/frontend-lib`
- [x] Both lock files confirm axios `1.13.6` with updated integrity checksums

🤖 Generated with [Claude Code](https://claude.com/claude-code)