### PR TITLE
fix(web): allow configuring listen address for API and web servers

### DIFF
--- a/easytier-web/locales/app.yml
+++ b/easytier-web/locales/app.yml
@@ -22,9 +22,15 @@ cli:
   api_server_port:
     en: "The port to listen for the restful server, acting as ApiHost and used by the web frontend"
     zh-CN: "restful 服务器的监听端口，作为 ApiHost 并被 web 前端使用"
+  api_server_addr:
+    en: "The listen address for the restful server, e.g. 0.0.0.0, ::, 127.0.0.1"
+    zh-CN: "restful 服务器的监听地址, 例如 0.0.0.0, ::, 127.0.0.1"
   web_server_port:
     en: "The port to listen for the web dashboard server, default is same as the api server port"
     zh-CN: "web dashboard 服务器的监听端口, 默认为与 api 服务器端口相同"
+  web_server_addr:
+    en: "The listen address for the web dashboard server (only effective when web_server_port differs from api_server_port or web_server_addr differs from api_server_addr), e.g. 0.0.0.0, ::, 127.0.0.1"
+    zh-CN: "web dashboard 服务器的监听地址（仅在 web_server_port 与 api_server_port 不同，或 web_server_addr 与 api_server_addr 不同时生效）, 例如 0.0.0.0, ::, 127.0.0.1"
   no_web:
     en: "Do not run the web dashboard server"
     zh-CN: "不运行 web dashboard 服务器"


### PR DESCRIPTION
## fix(web): allow configuring listen address for API and web servers (#1919)

### 背景

在此之前，`easytier-web` 的 API 服务器和 Web Dashboard 服务器的监听地址被硬编码为 `0.0.0.0`，用户只能配置端口。这在以下场景中存在限制：

- **IPv6 VPS**：无法通过 `http://[ipv6]:11211` 访问 Web 管理页面（需要监听 `::` 而非 `0.0.0.0`）
- **反向代理部署**：希望将服务器绑定到 `127.0.0.1` 仅允许本地 nginx 反向代理访问，减少攻击面
- **多网卡环境**：需要指定服务器监听特定网络接口

### 变更内容

#### 新增 CLI 参数

| 参数 | 类型 | 默认值 | 条件编译 | 说明 |
|------|------|--------|----------|------|
| `--api-server-addr` | `IpAddr` | `0.0.0.0` | 无 | API（RESTful）服务器的监听地址 |
| `--web-server-addr` | `IpAddr` | `0.0.0.0` | `#[cfg(feature = "embed")]` | Web Dashboard 服务器的监听地址 |

#### 核心改动

1. **`easytier-web/src/main.rs`**：
   - 新增 `api_server_addr` 和 `web_server_addr` CLI 参数定义
   - 使用 `std::net::SocketAddr::new(ip, port)` 替代 `format!("0.0.0.0:{}").parse().unwrap()`，消除了 IPv6 地址拼接导致的运行时解析错误风险
   - 扩展了 Web 服务器合并条件：当 `web_server_addr` 与 `api_server_addr` 不同时，即使端口相同也会启动独立的 Web 服务器，确保地址配置始终生效

2. **`easytier-web/locales/app.yml`**：
   - 新增 `api_server_addr` 和 `web_server_addr` 的中英文帮助文本
   - `web_server_addr` 帮助文本明确标注了生效条件

### 使用示例

```bash
# 仅绑定到本地回环地址（适用于 nginx 反向代理）
easytier-web --api-server-addr 127.0.0.1

# 绑定到 IPv6 地址
easytier-web --api-server-addr ::

# API 和 Web Dashboard 绑定到不同地址
easytier-web --api-server-addr 0.0.0.0 --web-server-addr 127.0.0.1 --web-server-port 8080
```

### 向后兼容性

- 默认值保持 `0.0.0.0`，与之前行为完全一致
- 未修改 `RestfulServer::new()` 或 `WebServer::new()` 的方法签名
- 未修改 `get_dual_stack_listener` 函数或 config server 的监听逻辑
- 未引入新的依赖

### Web 服务器合并逻辑说明

当启用 `embed` feature 时，Web Dashboard 的路由服务有两种模式：

1. **合并模式**（默认）：Web Dashboard 路由合并到 API 服务器中，共享同一监听地址和端口
2. **独立模式**：Web Dashboard 运行在独立的服务器上，使用 `--web-server-addr` 和 `--web-server-port` 指定的地址

触发独立模式的条件：`web_server_port` 与 `api_server_port` 不同，**或** `web_server_addr` 与 `api_server_addr` 不同。

### 相关 Issue
- close #1919