### PR TITLE
fix: guard `macos-ne` feature with `target_os = "macos"` in cfg expressions

### DIFF
--- a/easytier/src/connector/mod.rs
+++ b/easytier/src/connector/mod.rs
@@ -36,7 +36,10 @@ async fn set_bind_addr_for_peer_connector(
 ) {
     if cfg!(any(
         target_os = "android",
-        any(target_os = "ios", feature = "macos-ne"),
+        any(
+            target_os = "ios",
+            all(target_os = "macos", feature = "macos-ne")
+        ),
         target_env = "ohos"
     )) {
         return;

--- a/easytier/src/gateway/tcp_proxy.rs
+++ b/easytier/src/gateway/tcp_proxy.rs
@@ -539,7 +539,10 @@ impl<C: NatDstConnector> TcpProxy<C> {
             || self.global_ctx.no_tun()
             || cfg!(any(
                 target_os = "android",
-                any(target_os = "ios", feature = "macos-ne"),
+                any(
+                    target_os = "ios",
+                    all(target_os = "macos", feature = "macos-ne")
+                ),
                 target_env = "ohos"
             ))
         {

--- a/easytier/src/instance/instance.rs
+++ b/easytier/src/instance/instance.rs
@@ -115,7 +115,10 @@ impl IpProxy {
             tracing::error!("start icmp proxy failed: {:?}", e);
             if cfg!(not(any(
                 target_os = "android",
-                any(target_os = "ios", feature = "macos-ne"),
+                any(
+                    target_os = "ios",
+                    all(target_os = "macos", feature = "macos-ne")
+                ),
                 target_env = "ohos"
             ))) {
                 // android, ios and ohos not support icmp proxy
@@ -805,7 +808,7 @@ impl Instance {
                     #[cfg(all(
                         not(any(
                             target_os = "android",
-                            any(target_os = "ios", feature = "macos-ne"),
+                            any(target_os = "ios", all(target_os = "macos", feature = "macos-ne")),
                             target_env = "ohos"
                         )),
                         feature = "tun"
@@ -853,7 +856,7 @@ impl Instance {
     #[cfg(all(
         not(any(
             target_os = "android",
-            any(target_os = "ios", feature = "macos-ne"),
+            any(target_os = "ios", all(target_os = "macos", feature = "macos-ne")),
             target_env = "ohos"
         )),
         feature = "tun"
@@ -947,7 +950,7 @@ impl Instance {
 
             #[cfg(not(any(
                 target_os = "android",
-                any(target_os = "ios", feature = "macos-ne"),
+                any(target_os = "ios", all(target_os = "macos", feature = "macos-ne")),
                 target_env = "ohos"
             )))]
             if !self.global_ctx.config.get_flags().no_tun {
@@ -1463,7 +1466,7 @@ impl Instance {
 
     #[cfg(any(
         target_os = "android",
-        any(target_os = "ios", feature = "macos-ne"),
+        any(target_os = "ios", all(target_os = "macos", feature = "macos-ne")),
         target_env = "ohos"
     ))]
     pub async fn setup_nic_ctx_for_mobile(

--- a/easytier/src/instance/virtual_nic.rs
+++ b/easytier/src/instance/virtual_nic.rs
@@ -577,7 +577,7 @@ impl VirtualNic {
 
     #[cfg(any(
         target_os = "android",
-        any(target_os = "ios", feature = "macos-ne"),
+        any(target_os = "ios", all(target_os = "macos", feature = "macos-ne")),
         target_env = "ohos"
     ))]
     pub async fn create_dev_for_mobile(
@@ -588,7 +588,7 @@ impl VirtualNic {
         let mut config = Configuration::default();
         config.layer(Layer::L3);
 
-        #[cfg(any(target_os = "ios", feature = "macos-ne"))]
+        #[cfg(any(target_os = "ios", all(target_os = "macos", feature = "macos-ne")))]
         config.platform_config(|config| {
             // disable packet information so we can process the header by ourselves, see tun2 impl for more details
             config.packet_information(false);
@@ -598,7 +598,10 @@ impl VirtualNic {
         config.close_fd_on_drop(false);
         config.up();
 
-        let has_packet_info = cfg!(any(target_os = "ios", feature = "macos-ne"));
+        let has_packet_info = cfg!(any(
+            target_os = "ios",
+            all(target_os = "macos", feature = "macos-ne")
+        ));
         let dev = tun::create(&config)?;
         let dev = AsyncDevice::new(dev)?;
         let (a, b) = BiLock::new(dev);
@@ -1174,7 +1177,7 @@ impl NicCtx {
 
     #[cfg(any(
         target_os = "android",
-        any(target_os = "ios", feature = "macos-ne"),
+        any(target_os = "ios", all(target_os = "macos", feature = "macos-ne")),
         target_env = "ohos"
     ))]
     pub async fn run_for_mobile(&mut self, tun_fd: std::os::fd::RawFd) -> Result<(), Error> {

--- a/easytier/src/launcher.rs
+++ b/easytier/src/launcher.rs
@@ -95,7 +95,7 @@ impl EasyTierLauncher {
 
     #[cfg(any(
         target_os = "android",
-        any(target_os = "ios", feature = "macos-ne"),
+        any(target_os = "ios", all(target_os = "macos", feature = "macos-ne")),
         target_env = "ohos"
     ))]
     async fn run_routine_for_mobile(
@@ -158,7 +158,7 @@ impl EasyTierLauncher {
 
         #[cfg(any(
             target_os = "android",
-            any(target_os = "ios", feature = "macos-ne"),
+            any(target_os = "ios", all(target_os = "macos", feature = "macos-ne")),
             target_env = "ohos"
         ))]
         Self::run_routine_for_mobile(&instance, &data, &mut tasks).await;


### PR DESCRIPTION
All 13 occurrences of `any(target_os = "ios", feature = "macos-ne")` are
replaced with `any(target_os = "ios", all(target_os = "macos", feature = "macos-ne"))`.

Previously, enabling `macos-ne` on non-macOS platforms (e.g. `--all-features`
on Linux) would incorrectly compile macOS/mobile-specific code paths, causing
build failures or wrong runtime behavior.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
