### PR TITLE
refactor: centralize route management

### DIFF
--- a/easytier/src/common/ifcfg/darwin.rs
+++ b/easytier/src/common/ifcfg/darwin.rs
@@ -1,12 +1,13 @@
 use std::net::Ipv4Addr;
 
-use super::{cidr_to_subnet_mask, run_shell_cmd, Error, IfConfiguerTrait};
+use super::{cidr_to_subnet_mask, run_shell_cmd, Error, IfConfigerTrait};
 use async_trait::async_trait;
 use cidr::{Ipv4Inet, Ipv6Inet};
 
-pub struct MacIfConfiger {}
+pub struct IfConfiger;
+
 #[async_trait]
-impl IfConfiguerTrait for MacIfConfiger {
+impl IfConfigerTrait for IfConfiger {
     async fn add_ipv4_route(
         &self,
         name: &str,
@@ -61,39 +62,11 @@ impl IfConfiguerTrait for MacIfConfiger {
         .await
     }
 
-    async fn set_link_status(&self, name: &str, up: bool) -> Result<(), Error> {
-        run_shell_cmd(format!("ifconfig {} {}", name, if up { "up" } else { "down" }).as_str())
-            .await
-    }
-
-    async fn remove_ip(&self, name: &str, ip: Option<Ipv4Inet>) -> Result<(), Error> {
+    async fn remove_ipv4_ip(&self, name: &str, ip: Option<Ipv4Inet>) -> Result<(), Error> {
         if let Some(ip) = ip {
             run_shell_cmd(format!("ifconfig {} inet {} delete", name, ip.address()).as_str()).await
         } else {
             run_shell_cmd(format!("ifconfig {} inet delete", name).as_str()).await
-        }
-    }
-
-    async fn set_mtu(&self, name: &str, mtu: u32) -> Result<(), Error> {
-        run_shell_cmd(format!("ifconfig {} mtu {}", name, mtu).as_str()).await
-    }
-
-    async fn add_ipv6_ip(
-        &self,
-        name: &str,
-        address: std::net::Ipv6Addr,
-        cidr_prefix: u8,
-    ) -> Result<(), Error> {
-        run_shell_cmd(format!("ifconfig {} inet6 {}/{} add", name, address, cidr_prefix).as_str())
-            .await
-    }
-
-    async fn remove_ipv6(&self, name: &str, ip: Option<Ipv6Inet>) -> Result<(), Error> {
-        if let Some(ip) = ip {
-            run_shell_cmd(format!("ifconfig {} inet6 {} delete", name, ip.address()).as_str()).await
-        } else {
-            // Remove all IPv6 addresses is more complex on macOS, just succeed
-            Ok(())
         }
     }
 
@@ -132,5 +105,33 @@ impl IfConfiguerTrait for MacIfConfiger {
             .as_str(),
         )
         .await
+    }
+
+    async fn add_ipv6_ip(
+        &self,
+        name: &str,
+        address: std::net::Ipv6Addr,
+        cidr_prefix: u8,
+    ) -> Result<(), Error> {
+        run_shell_cmd(format!("ifconfig {} inet6 {}/{} add", name, address, cidr_prefix).as_str())
+            .await
+    }
+
+    async fn remove_ipv6_ip(&self, name: &str, ip: Option<Ipv6Inet>) -> Result<(), Error> {
+        if let Some(ip) = ip {
+            run_shell_cmd(format!("ifconfig {} inet6 {} delete", name, ip.address()).as_str()).await
+        } else {
+            // Remove all IPv6 addresses is more complex on macOS, just succeed
+            Ok(())
+        }
+    }
+
+    async fn set_link_status(&self, name: &str, up: bool) -> Result<(), Error> {
+        run_shell_cmd(format!("ifconfig {} {}", name, if up { "up" } else { "down" }).as_str())
+            .await
+    }
+
+    async fn set_mtu(&self, name: &str, mtu: u32) -> Result<(), Error> {
+        run_shell_cmd(format!("ifconfig {} mtu {}", name, mtu).as_str()).await
     }
 }

--- a/easytier/src/common/ifcfg/mod.rs
+++ b/easytier/src/common/ifcfg/mod.rs
@@ -21,7 +21,7 @@ use tokio::process::Command;
 use super::error::Error;
 
 #[async_trait]
-pub trait IfConfiguerTrait: Send + Sync {
+pub trait IfConfigerTrait: Send + Sync {
     async fn add_ipv4_route(
         &self,
         _name: &str,
@@ -45,6 +45,9 @@ pub trait IfConfiguerTrait: Send + Sync {
         _address: Ipv4Addr,
         _cidr_prefix: u8,
     ) -> Result<(), Error> {
+        Ok(())
+    }
+    async fn remove_ipv4_ip(&self, _name: &str, _ip: Option<Ipv4Inet>) -> Result<(), Error> {
         Ok(())
     }
     async fn add_ipv6_route(
@@ -72,17 +75,14 @@ pub trait IfConfiguerTrait: Send + Sync {
     ) -> Result<(), Error> {
         Ok(())
     }
+    async fn remove_ipv6_ip(&self, _name: &str, _ip: Option<Ipv6Inet>) -> Result<(), Error> {
+        Ok(())
+    }
     async fn set_link_status(&self, _name: &str, _up: bool) -> Result<(), Error> {
         Ok(())
     }
-    async fn remove_ip(&self, _name: &str, _ip: Option<Ipv4Inet>) -> Result<(), Error> {
-        Ok(())
-    }
-    async fn remove_ipv6(&self, _name: &str, _ip: Option<Ipv6Inet>) -> Result<(), Error> {
-        Ok(())
-    }
     async fn wait_interface_show(&self, _name: &str) -> Result<(), Error> {
-        return Ok(());
+        Ok(())
     }
     async fn set_mtu(&self, _name: &str, _mtu: u32) -> Result<(), Error> {
         Ok(())
@@ -140,21 +140,19 @@ async fn run_shell_cmd(cmd: &str) -> Result<(), Error> {
     Ok(())
 }
 
-pub struct DummyIfConfiger {}
-#[async_trait]
-impl IfConfiguerTrait for DummyIfConfiger {}
+pub struct DummyIfConfiger;
 
 #[cfg(target_os = "linux")]
-pub type IfConfiger = netlink::NetlinkIfConfiger;
+const IF_CONFIGER: netlink::IfConfiger = netlink::IfConfiger;
 
 #[cfg(any(
     all(target_os = "macos", not(feature = "macos-ne")),
     target_os = "freebsd"
 ))]
-pub type IfConfiger = darwin::MacIfConfiger;
+const IF_CONFIGER: darwin::IfConfiger = darwin::IfConfiger;
 
 #[cfg(target_os = "windows")]
-pub type IfConfiger = windows::WindowsIfConfiger;
+const IF_CONFIGER: windows::IfConfiger = windows::IfConfiger;
 
 #[cfg(not(any(
     all(target_os = "macos", not(feature = "macos-ne")),
@@ -162,7 +160,13 @@ pub type IfConfiger = windows::WindowsIfConfiger;
     target_os = "windows",
     target_os = "freebsd",
 )))]
-pub type IfConfiger = DummyIfConfiger;
+const IF_CONFIGER: DummyIfConfiger = DummyIfConfiger;
 
 #[cfg(target_os = "windows")]
 pub use windows::RegistryManager;
+
+pub type IfConfiger = &'static dyn IfConfigerTrait;
+
+pub fn get() -> IfConfiger {
+    &IF_CONFIGER
+}

--- a/easytier/src/common/ifcfg/netlink.rs
+++ b/easytier/src/common/ifcfg/netlink.rs
@@ -30,7 +30,7 @@ use nix::{
 };
 use pnet::ipnetwork::ip_mask_to_prefix;
 
-use super::{route::Route, Error, IfConfiguerTrait};
+use super::{route::Route, Error, IfConfigerTrait};
 
 pub(crate) fn dummy_socket() -> Result<std::net::UdpSocket, Error> {
     Ok(std::net::UdpSocket::bind("0:0")?)
@@ -157,9 +157,9 @@ impl From<RouteMessage> for Route {
     }
 }
 
-pub struct NetlinkIfConfiger {}
+pub struct IfConfiger;
 
-impl NetlinkIfConfiger {
+impl IfConfiger {
     fn get_interface_index(name: &str) -> Result<u32, Error> {
         let name = CString::new(name).with_context(|| "failed to convert interface name")?;
         match unsafe { libc::if_nametoindex(name.as_ptr()) } {
@@ -181,7 +181,7 @@ impl NetlinkIfConfiger {
     fn remove_one_ip(name: &str, ip: Ipv4Addr, prefix_len: u8) -> Result<(), Error> {
         let mut message = AddressMessage::default();
         message.header.prefix_len = prefix_len;
-        message.header.index = NetlinkIfConfiger::get_interface_index(name)?;
+        message.header.index = IfConfiger::get_interface_index(name)?;
         message.header.family = AddressFamily::Inet;
 
         message
@@ -207,7 +207,7 @@ impl NetlinkIfConfiger {
     fn remove_one_ipv6(name: &str, ip: Ipv6Addr, prefix_len: u8) -> Result<(), Error> {
         let mut message = AddressMessage::default();
         message.header.prefix_len = prefix_len;
-        message.header.index = NetlinkIfConfiger::get_interface_index(name)?;
+        message.header.index = IfConfiger::get_interface_index(name)?;
         message.header.family = AddressFamily::Inet6;
 
         message
@@ -370,7 +370,13 @@ impl NetlinkIfConfiger {
 }
 
 #[async_trait]
-impl IfConfiguerTrait for NetlinkIfConfiger {
+impl IfConfigerTrait for IfConfiger {
+    fn new() -> Self
+    where
+        Self: Sized + 'static,
+    {
+        Self(())
+    }
     async fn add_ipv4_route(
         &self,
         name: &str,
@@ -392,7 +398,7 @@ impl IfConfiguerTrait for NetlinkIfConfiger {
         // output interface
         message
             .attributes
-            .push(RouteAttribute::Oif(NetlinkIfConfiger::get_interface_index(
+            .push(RouteAttribute::Oif(IfConfiger::get_interface_index(
                 name,
             )?));
         // source address
@@ -411,7 +417,7 @@ impl IfConfiguerTrait for NetlinkIfConfiger {
         cidr_prefix: u8,
     ) -> Result<(), Error> {
         let routes = Self::list_routes()?;
-        let ifidx = NetlinkIfConfiger::get_interface_index(name)?;
+        let ifidx = IfConfiger::get_interface_index(name)?;
 
         for msg in routes {
             let other_route: Route = msg.clone().into();
@@ -436,7 +442,7 @@ impl IfConfiguerTrait for NetlinkIfConfiger {
         let mut message = AddressMessage::default();
 
         message.header.prefix_len = cidr_prefix;
-        message.header.index = NetlinkIfConfiger::get_interface_index(name)?;
+        message.header.index = IfConfiger::get_interface_index(name)?;
         message.header.family = AddressFamily::Inet;
 
         message
@@ -466,14 +472,7 @@ impl IfConfiguerTrait for NetlinkIfConfiger {
         )
     }
 
-    async fn set_link_status(&self, name: &str, up: bool) -> Result<(), Error> {
-        let mut flags = Self::get_flags(name)?;
-        flags.set(InterfaceFlags::IFF_UP, up);
-        Self::set_flags(name, flags)?;
-        Ok(())
-    }
-
-    async fn remove_ip(&self, name: &str, ip: Option<Ipv4Inet>) -> Result<(), Error> {
+    async fn remove_ipv4_ip(&self, name: &str, ip: Option<Ipv4Inet>) -> Result<(), Error> {
         if let Some(ip) = ip {
             let prefix_len = Self::get_prefix_len(name, ip.address())?;
             Self::remove_one_ip(name, ip.address(), prefix_len)?;
@@ -482,52 +481,6 @@ impl IfConfiguerTrait for NetlinkIfConfiger {
             for addr in addrs {
                 if let IpAddr::V4(ipv4) = addr.address() {
                     Self::remove_one_ip(name, ipv4, addr.network_length())?;
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    async fn set_mtu(&self, name: &str, mtu: u32) -> Result<(), Error> {
-        Self::mtu_op(name, SIOCSIFMTU, mtu as libc::c_int)?;
-
-        Ok(())
-    }
-
-    async fn add_ipv6_ip(
-        &self,
-        name: &str,
-        address: std::net::Ipv6Addr,
-        cidr_prefix: u8,
-    ) -> Result<(), Error> {
-        let mut message = AddressMessage::default();
-
-        message.header.prefix_len = cidr_prefix;
-        message.header.index = NetlinkIfConfiger::get_interface_index(name)?;
-        message.header.family = AddressFamily::Inet6;
-
-        message
-            .attributes
-            .push(AddressAttribute::Address(std::net::IpAddr::V6(address)));
-
-        // For IPv6, we don't need IFA_LOCAL or IFA_BROADCAST
-        send_netlink_req_and_wait_one_resp::<RouteNetlinkMessage>(
-            RouteNetlinkMessage::NewAddress(message),
-            false,
-        )
-    }
-
-    async fn remove_ipv6(&self, name: &str, ip: Option<Ipv6Inet>) -> Result<(), Error> {
-        if let Some(ipv6) = ip {
-            let prefix_len = Self::get_prefix_len_ipv6(name, ipv6.address())?;
-            Self::remove_one_ipv6(name, ipv6.address(), prefix_len)?;
-        } else {
-            let addrs = Self::list_addresses(name)?;
-            for addr in addrs {
-                if let IpAddr::V6(ipv6) = addr.address() {
-                    let prefix_len = addr.network_length();
-                    Self::remove_one_ipv6(name, ipv6, prefix_len)?;
                 }
             }
         }
@@ -560,7 +513,7 @@ impl IfConfiguerTrait for NetlinkIfConfiger {
 
         message
             .attributes
-            .push(RouteAttribute::Oif(NetlinkIfConfiger::get_interface_index(
+            .push(RouteAttribute::Oif(IfConfiger::get_interface_index(
                 name,
             )?));
 
@@ -578,7 +531,7 @@ impl IfConfiguerTrait for NetlinkIfConfiger {
         cidr_prefix: u8,
     ) -> Result<(), Error> {
         let routes = Self::list_routes()?;
-        let ifidx = NetlinkIfConfiger::get_interface_index(name)?;
+        let ifidx = IfConfiger::get_interface_index(name)?;
 
         for msg in routes {
             let other_route: Route = msg.clone().into();
@@ -593,12 +546,63 @@ impl IfConfiguerTrait for NetlinkIfConfiger {
 
         Ok(())
     }
+
+    async fn add_ipv6_ip(
+        &self,
+        name: &str,
+        address: std::net::Ipv6Addr,
+        cidr_prefix: u8,
+    ) -> Result<(), Error> {
+        let mut message = AddressMessage::default();
+
+        message.header.prefix_len = cidr_prefix;
+        message.header.index = IfConfiger::get_interface_index(name)?;
+        message.header.family = AddressFamily::Inet6;
+
+        message
+            .attributes
+            .push(AddressAttribute::Address(std::net::IpAddr::V6(address)));
+
+        // For IPv6, we don't need IFA_LOCAL or IFA_BROADCAST
+        send_netlink_req_and_wait_one_resp::<RouteNetlinkMessage>(
+            RouteNetlinkMessage::NewAddress(message),
+            false,
+        )
+    }
+
+    async fn remove_ipv6_ip(&self, name: &str, ip: Option<Ipv6Inet>) -> Result<(), Error> {
+        if let Some(ipv6) = ip {
+            let prefix_len = Self::get_prefix_len_ipv6(name, ipv6.address())?;
+            Self::remove_one_ipv6(name, ipv6.address(), prefix_len)?;
+        } else {
+            let addrs = Self::list_addresses(name)?;
+            for addr in addrs {
+                if let IpAddr::V6(ipv6) = addr.address() {
+                    let prefix_len = addr.network_length();
+                    Self::remove_one_ipv6(name, ipv6, prefix_len)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn set_link_status(&self, name: &str, up: bool) -> Result<(), Error> {
+        let mut flags = Self::get_flags(name)?;
+        flags.set(InterfaceFlags::IFF_UP, up);
+        Self::set_flags(name, flags)?;
+        Ok(())
+    }
+
+    async fn set_mtu(&self, name: &str, mtu: u32) -> Result<(), Error> {
+        Self::mtu_op(name, SIOCSIFMTU, mtu as libc::c_int)?;
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     const DUMMY_IFACE_NAME: &str = "dummy";
 
     fn run_cmd(cmd: &str) -> String {

--- a/easytier/src/common/ifcfg/windows.rs
+++ b/easytier/src/common/ifcfg/windows.rs
@@ -20,8 +20,9 @@ use winreg::{
     RegKey,
 };
 
-use super::{Error, IfConfiguerTrait};
-pub struct WindowsIfConfiger {}
+use super::{Error, IfConfigerTrait};
+
+pub struct IfConfiger;
 
 fn format_win_error(error: u32) -> String {
     // use FormatMessageW to get the error message
@@ -48,7 +49,7 @@ fn format_win_error(error: u32) -> String {
     )
 }
 
-impl WindowsIfConfiger {
+impl IfConfiger {
     pub fn get_interface_index(name: &str) -> Option<u32> {
         crate::arch::windows::find_interface_index(name).ok()
     }
@@ -179,7 +180,7 @@ impl WindowsIfConfiger {
 }
 
 #[async_trait]
-impl IfConfiguerTrait for WindowsIfConfiger {
+impl IfConfigerTrait for IfConfiger {
     async fn add_ipv4_route(
         &self,
         name: &str,
@@ -232,45 +233,8 @@ impl IfConfiguerTrait for WindowsIfConfiger {
         Self::add_ip_address(name, Ipv4Inet::new(address, cidr_prefix).unwrap()).await
     }
 
-    async fn set_link_status(&self, name: &str, up: bool) -> Result<(), Error> {
-        Self::set_interface_status(name, up).await
-    }
-
-    async fn remove_ip(&self, name: &str, ip: Option<Ipv4Inet>) -> Result<(), Error> {
+    async fn remove_ipv4_ip(&self, name: &str, ip: Option<Ipv4Inet>) -> Result<(), Error> {
         Self::remove_ip_address(name, ip).await
-    }
-
-    async fn wait_interface_show(&self, name: &str) -> Result<(), Error> {
-        Ok(
-            tokio::time::timeout(std::time::Duration::from_secs(10), async move {
-                loop {
-                    if let Some(idx) = Self::get_interface_index(name) {
-                        tracing::info!(?name, ?idx, "Interface found");
-                        break;
-                    }
-                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                }
-                Ok::<(), Error>(())
-            })
-            .await??,
-        )
-    }
-
-    async fn set_mtu(&self, name: &str, mtu: u32) -> Result<(), Error> {
-        Self::set_interface_mtu(name, mtu).await
-    }
-
-    async fn add_ipv6_ip(
-        &self,
-        name: &str,
-        address: Ipv6Addr,
-        cidr_prefix: u8,
-    ) -> Result<(), Error> {
-        Self::add_ipv6_address(name, Ipv6Inet::new(address, cidr_prefix).unwrap()).await
-    }
-
-    async fn remove_ipv6(&self, name: &str, ip: Option<Ipv6Inet>) -> Result<(), Error> {
-        Self::remove_ipv6_address(name, ip).await
     }
 
     async fn add_ipv6_route(
@@ -317,6 +281,43 @@ impl IfConfiguerTrait for WindowsIfConfiger {
         )
         .map_err(|e| anyhow::anyhow!("Failed to delete route: {}", format_win_error(e)))?;
         Ok(())
+    }
+
+    async fn add_ipv6_ip(
+        &self,
+        name: &str,
+        address: Ipv6Addr,
+        cidr_prefix: u8,
+    ) -> Result<(), Error> {
+        Self::add_ipv6_address(name, Ipv6Inet::new(address, cidr_prefix).unwrap()).await
+    }
+
+    async fn remove_ipv6_ip(&self, name: &str, ip: Option<Ipv6Inet>) -> Result<(), Error> {
+        Self::remove_ipv6_address(name, ip).await
+    }
+
+    async fn set_link_status(&self, name: &str, up: bool) -> Result<(), Error> {
+        Self::set_interface_status(name, up).await
+    }
+
+    async fn wait_interface_show(&self, name: &str) -> Result<(), Error> {
+        Ok(
+            tokio::time::timeout(std::time::Duration::from_secs(10), async move {
+                loop {
+                    if let Some(idx) = Self::get_interface_index(name) {
+                        tracing::info!(?name, ?idx, "Interface found");
+                        break;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                }
+                Ok::<(), Error>(())
+            })
+            .await??,
+        )
+    }
+
+    async fn set_mtu(&self, name: &str, mtu: u32) -> Result<(), Error> {
+        Self::set_interface_mtu(name, mtu).await
     }
 }
 

--- a/easytier/src/instance/dns_server/server_instance.rs
+++ b/easytier/src/instance/dns_server/server_instance.rs
@@ -13,10 +13,7 @@ use super::{
     MAGIC_DNS_INSTANCE_ADDR,
 };
 use crate::{
-    common::{
-        ifcfg::{IfConfiger, IfConfiguerTrait},
-        PeerId,
-    },
+    common::{ifcfg, PeerId},
     instance::dns_server::{
         config::{Record, RecordBuilder, RecordType},
         server::build_authority,
@@ -535,8 +532,7 @@ impl MagicDnsServerInstance {
                 } else {
                     None
                 };
-                let ifcfg = IfConfiger {};
-                ifcfg
+                ifcfg::get()
                     .add_ipv4_route(tun_dev_name, fake_ip, 32, cost)
                     .await?;
             }
@@ -589,8 +585,7 @@ impl MagicDnsServerInstance {
             }
             if !self.tun_inet.contains(&self.data.fake_ip) {
                 if let Some(tun_dev_name) = &self.data.tun_dev {
-                    let ifcfg = IfConfiger {};
-                    let _ = ifcfg
+                    let _ = ifcfg::get()
                         .remove_ipv4_route(tun_dev_name, self.data.fake_ip, 32)
                         .await;
                 }

--- a/easytier/src/instance/virtual_nic.rs
+++ b/easytier/src/instance/virtual_nic.rs
@@ -7,11 +7,14 @@ use std::{
     task::{Context, Poll},
 };
 
+#[cfg(target_os = "windows")]
+use crate::common::ifcfg::RegistryManager;
 use crate::{
     common::{
         error::Error,
         global_ctx::{ArcGlobalCtx, GlobalCtxEvent},
-        ifcfg::{IfConfiger, IfConfiguerTrait},
+        ifcfg,
+        ifcfg::IfConfiger,
         log,
     },
     instance::proxy_cidrs_monitor::ProxyCidrsMonitor,
@@ -22,7 +25,6 @@ use crate::{
         StreamItem, Tunnel, TunnelError, ZCPacketSink, ZCPacketStream,
     },
 };
-
 use byteorder::WriteBytesExt as _;
 use bytes::{BufMut, BytesMut};
 use cidr::{Ipv4Inet, Ipv6Inet};
@@ -37,9 +39,6 @@ use tokio::{
 use tokio_util::bytes::Bytes;
 use tun::{AbstractDevice, AsyncDevice, Configuration, Layer};
 use zerocopy::{NativeEndian, NetworkEndian};
-
-#[cfg(target_os = "windows")]
-use crate::common::ifcfg::RegistryManager;
 
 pin_project! {
     pub struct TunStream {
@@ -241,7 +240,7 @@ pub struct VirtualNic {
     global_ctx: ArcGlobalCtx,
 
     ifname: Option<String>,
-    ifcfg: Box<dyn IfConfiguerTrait + Send + Sync + 'static>,
+    ifcfg: IfConfiger,
 }
 
 impl Drop for VirtualNic {
@@ -267,7 +266,7 @@ impl VirtualNic {
         Self {
             global_ctx,
             ifname: None,
-            ifcfg: Box::new(IfConfiger {}),
+            ifcfg: ifcfg::get(),
         }
     }
 
@@ -746,13 +745,13 @@ impl VirtualNic {
 
     pub async fn remove_ip(&self, ip: Option<Ipv4Inet>) -> Result<(), Error> {
         let _g = self.global_ctx.net_ns.guard();
-        self.ifcfg.remove_ip(self.ifname(), ip).await?;
+        self.ifcfg.remove_ipv4_ip(self.ifname(), ip).await?;
         Ok(())
     }
 
     pub async fn remove_ipv6(&self, ip: Option<Ipv6Inet>) -> Result<(), Error> {
         let _g = self.global_ctx.net_ns.guard();
-        self.ifcfg.remove_ipv6(self.ifname(), ip).await?;
+        self.ifcfg.remove_ipv6_ip(self.ifname(), ip).await?;
         Ok(())
     }
 
@@ -770,10 +769,6 @@ impl VirtualNic {
             .add_ipv6_ip(self.ifname(), ip, cidr as u8)
             .await?;
         Ok(())
-    }
-
-    pub fn get_ifcfg(&self) -> impl IfConfiguerTrait {
-        IfConfiger {}
     }
 }
 
@@ -991,7 +986,7 @@ impl NicCtx {
     }
 
     async fn apply_route_changes(
-        ifcfg: &impl IfConfiguerTrait,
+        ifcfg: IfConfiger,
         ifname: &str,
         net_ns: &crate::common::netns::NetNS,
         cur_proxy_cidrs: &mut BTreeSet<cidr::Ipv4Cidr>,
@@ -1048,7 +1043,7 @@ impl NicCtx {
         let global_ctx = self.global_ctx.clone();
         let net_ns = self.global_ctx.net_ns.clone();
         let nic = self.nic.lock().await;
-        let ifcfg = nic.get_ifcfg();
+        let ifcfg = ifcfg::get();
         let ifname = nic.ifname().to_owned();
         let mut event_receiver = global_ctx.subscribe();
 
@@ -1063,7 +1058,7 @@ impl NicCtx {
             )
             .await;
             Self::apply_route_changes(
-                &ifcfg,
+                ifcfg,
                 &ifname,
                 &net_ns,
                 &mut cur_proxy_cidrs,
@@ -1102,7 +1097,7 @@ impl NicCtx {
                 };
 
                 Self::apply_route_changes(
-                    &ifcfg,
+                    ifcfg,
                     &ifname,
                     &net_ns,
                     &mut cur_proxy_cidrs,


### PR DESCRIPTION
目标
---
1. 重写 `NicCtx`、`NicCtxContainer`
2. 实现一个路由管理器以提供一致、灵活的路由表管理，替代 `ProxyCidrsMonitor`。
3. 
```
0:      from all lookup local
105:    from all lookup main suppress_prefixlength 0
110:    not from all fwmark 0xEA5971E2 lookup 5971
32766:  from all lookup main
32767:  from all lookup default
```

---
- requires https://github.com/EasyTier/EasyTier/pull/1862