### PR TITLE
docs: streamline README landing pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,6 @@
 
 > ✨ A simple, secure, decentralized SD-WAN solution powered by Rust and Tokio
 
-<p align="center">
-  <img src="assets/config-page.png" width="300" alt="EasyTier configuration page">
-  <img src="assets/running-page.png" width="300" alt="EasyTier running page">
-</p>
-
 🌐 **[Official Website](https://easytier.rs)** | 📚 **[Documentation](https://easytier.rs/en/)** | 🚀 **[Get Started](https://easytier.rs/en/guide/introduction.html)** | 📝 **[Download Releases](https://github.com/EasyTier/EasyTier/releases)** | 🇨🇳 **[China Site](https://easytier.cn)** | ❤️ **[Sponsor](#sponsor)**
 
 ## Get Started

--- a/README.md
+++ b/README.md
@@ -11,286 +11,93 @@
 
 [简体中文](/README_CN.md) | [English](/README.md)
 
-> ✨ A simple, secure, decentralized virtual private network solution powered by Rust and Tokio
+> ✨ A simple, secure, decentralized SD-WAN solution powered by Rust and Tokio
 
 <p align="center">
-<img src="assets/config-page.png" width="300" alt="config page">
-<img src="assets/running-page.png" width="300" alt="running page">
+  <img src="assets/config-page.png" width="300" alt="EasyTier configuration page">
+  <img src="assets/running-page.png" width="300" alt="EasyTier running page">
 </p>
 
-📚 **[Full Documentation](https://easytier.cn/en/)** | 🖥️ **[Web Console](https://easytier.cn/web)** | 📝 **[Download Releases](https://github.com/EasyTier/EasyTier/releases)** | 🧩 **[Third Party Tools](https://easytier.cn/en/guide/installation_gui.html#third-party-graphical-interfaces)** | ❤️ **[Sponsor](#sponsor)**
+🌐 **[Official Website](https://easytier.rs)** | 📚 **[Documentation](https://easytier.rs/en/)** | 🚀 **[Get Started](https://easytier.rs/en/guide/introduction.html)** | 📝 **[Download Releases](https://github.com/EasyTier/EasyTier/releases)** | 🇨🇳 **[China Site](https://easytier.cn)** | ❤️ **[Sponsor](#sponsor)**
 
-## Features
+## Get Started
 
-### Core Features
+### Install
 
-- 🔒 **Decentralized**: Nodes are equal and independent, no centralized services required  
-- 🚀 **Easy to Use**: Multiple operation methods via web, client, and command line  
-- 🌍 **Cross-Platform**: Supports Win/MacOS/Linux/FreeBSD/Android and X86/ARM/MIPS architectures  
-- 🔐 **Secure**: AES-GCM or WireGuard encryption, prevents man-in-the-middle attacks  
+Linux:
 
-### Advanced Capabilities
-
-- 🔌 **Efficient NAT Traversal**: Supports UDP and IPv6 traversal, works with NAT4-NAT4 networks  
-- 🌐 **Subnet Proxy**: Nodes can share subnets for other nodes to access  
-- 🔄 **Intelligent Routing**: Latency priority and automatic route selection for best network experience  
-- ⚡ **High Performance**: Zero-copy throughout the entire link, supports TCP/UDP/WSS/WG protocols  
-
-### Network Optimization
-
-- 📊 **UDP Loss Resistance**: KCP/QUIC proxy optimizes latency and bandwidth in high packet loss environments  
-- 🔧 **Web Management**: Easy configuration and monitoring through web interface  
-- 🛠️ **Zero Config**: Simple deployment with statically linked executables  
-
-## Quick Start
-
-### 📥 Installation
-
-Choose the installation method that best suits your needs:
-
-Linux (Recommended):
 ```bash
 curl -fsSL "https://github.com/EasyTier/EasyTier/blob/main/script/install.sh?raw=true" | sudo bash -s install
 ```
 
-Homebrew (MacOS/Linux):
+Windows (run with administrator privileges):
+
+```powershell
+irm "https://github.com/EasyTier/EasyTier/blob/main/script/install.ps1?raw=true" | iex
+```
+
+Homebrew (macOS/Linux):
+
 ```bash
 brew tap brewforge/chinese
 brew install --cask easytier-gui
 ```
 
-Windows (Recommended, run with administrator privileges):
-```powershell
-irm "https://github.com/EasyTier/EasyTier/blob/main/script/install.ps1?raw=true" | iex
-```
+Install from source (latest development version):
 
-Install via cargo (Latest development version): 
 ```bash
 cargo install --git https://github.com/EasyTier/EasyTier.git easytier
 ```
 
-[Install pre-built binary](https://github.com/EasyTier/EasyTier/releases) (Recommended, All platforms supported)
+More installation options:
 
-[Install via Docker](https://easytier.cn/en/guide/installation.html#installation-methods)
+- [CLI installation guide](https://easytier.rs/en/guide/installation.html)
+- [GUI installation guide](https://easytier.rs/en/guide/installation_gui.html)
+- [Pre-built binaries](https://github.com/EasyTier/EasyTier/releases)
+- [OpenWrt package](https://github.com/EasyTier/luci-app-easytier)
+- [One-click register service](https://easytier.rs/en/guide/network/oneclick-install-as-service.html)
 
-[Install OpenWrt ipk package](https://github.com/EasyTier/luci-app-easytier)
+### Quick Example
 
-Additional steps:
-
-[One-Click Register Service](https://easytier.cn/en/guide/network/oneclick-install-as-service.html) (Automatically start when the system boots and run in the background)
-
-### 🚀 Basic Usage
-
-#### Quick Networking with Shared Nodes
-
-EasyTier supports quick networking using shared public nodes. When you don't have a public IP, you can use the free shared nodes provided by the EasyTier community. Nodes will automatically attempt NAT traversal and establish P2P connections. When P2P fails, data will be relayed through shared nodes.
-
-When using shared nodes, each node entering the network needs to provide the same `--network-name` and `--network-secret` parameters as the unique identifier of the network.
-
-Taking two nodes as an example (Please use more complex network name to avoid conflicts):
-
-1. Run on Node A:
+Join the same network from multiple nodes with a shared public node:
 
 ```bash
-# Run with administrator privileges
-sudo easytier-core -d --network-name abc --network-secret abc -p tcp://<SharedNodeIP>:11010
+# Node A
+sudo easytier-core -d --network-name demo --network-secret demo -p tcp://<SharedNodeIP>:11010
+
+# Node B
+sudo easytier-core -d --network-name demo --network-secret demo -p tcp://<SharedNodeIP>:11010
 ```
 
-2. Run on Node B:
+Use the same `--network-name` and `--network-secret` on every node to join the same network. After startup, check peers with `easytier-cli peer`, `easytier-cli route`, or `easytier-cli node`.
 
-```bash
-# Run with administrator privileges
-sudo easytier-core -d --network-name abc --network-secret abc -p tcp://<SharedNodeIP>:11010
-```
+## Why EasyTier
 
-After successful execution, you can check the network status using `easytier-cli`:
+- 🔒 **Decentralized**: Nodes are equal and independent, with no centralized controller required.
+- 🚀 **Easy to Use**: Use EasyTier from the web console, GUI clients, or the command line.
+- 🌍 **Cross-Platform**: Supports Windows, macOS, Linux, FreeBSD, Android, and multiple CPU architectures.
+- 🔐 **Secure**: Protects traffic with AES-GCM or WireGuard encryption.
+- 🔌 **Efficient NAT Traversal**: Supports UDP and IPv6 traversal, including NAT4-to-NAT4 scenarios.
+- 🌐 **Subnet Proxy**: Share private subnets with other nodes in the virtual network.
+- 🔄 **Intelligent Routing**: Chooses lower-latency paths automatically for a better network experience.
+- ⚡ **High Performance**: Uses zero-copy data paths and supports TCP, UDP, WS, WSS, WG, QUIC, and more.
 
-```text
-| ipv4         | hostname       | cost  | lat_ms | loss_rate | rx_bytes | tx_bytes | tunnel_proto | nat_type | id         | version         |
-| ------------ | -------------- | ----- | ------ | --------- | -------- | -------- | ------------ | -------- | ---------- | --------------- |
-| 10.126.126.1 | abc-1          | Local | *      | *         | *        | *        | udp          | FullCone | 439804259  | 2.5.0-70e69a38~ |
-| 10.126.126.2 | abc-2          | p2p   | 3.452  | 0         | 17.33 kB | 20.42 kB | udp          | FullCone | 390879727  | 2.5.0-70e69a38~ |
-|              | PublicServer_a | p2p   | 27.796 | 0.000     | 50.01 kB | 67.46 kB | tcp          | Unknown  | 3771642457 | 2.5.0-70e69a38~ |
-```
+## Learn More
 
-You can test connectivity between nodes:
+- [Introduction](https://easytier.rs/en/guide/introduction.html)
+- [Command line networking](https://easytier.rs/en/guide/networking.html)
+- [Decentralized networking](https://easytier.rs/en/guide/network/decentralized-networking.html)
+- [Networking with web console](https://easytier.rs/en/guide/network/web-console.html)
+- [WireGuard client access](https://easytier.rs/en/guide/network/use-easytier-with-wireguard-client.html)
+- [Subnet proxy (point-to-network)](https://easytier.rs/en/guide/network/point-to-networking.html)
+- [Bandwidth and latency optimization](https://easytier.rs/en/guide/network/kcp-proxy.html)
+- [Hosting public shared nodes](https://easytier.rs/en/guide/network/host-public-server.html)
+- [Third-party graphical interfaces](https://easytier.rs/en/guide/installation_gui.html#third-party-graphical-interfaces)
 
-```bash
-# Test connectivity
-ping 10.126.126.1
-ping 10.126.126.2
-```
-
-Note: If you cannot ping through, it may be that the firewall is blocking incoming traffic. Please turn off the firewall or add allow rules.
-
-To improve availability, you can connect to multiple shared nodes simultaneously:
-
-```bash
-# Connect to multiple shared nodes
-sudo easytier-core -d --network-name abc --network-secret abc -p tcp://<SharedNodeIP1>:11010 -p udp://<SharedNodeIP2>:11010
-```
-
-Once your network is set up successfully, you can easily configure it to start automatically on system boot. Refer to the [One-Click Register Service guide](https://easytier.cn/en/guide/network/oneclick-install-as-service.html) for step-by-step instructions on registering EasyTier as a system service.
-
-#### Decentralized Networking
-
-EasyTier is fundamentally decentralized, with no distinction between server and client. As long as one device can communicate with any node in the virtual network, it can join the virtual network. Here's how to set up a decentralized network:
-
-1. Start First Node (Node A):
-
-```bash
-# Start the first node
-sudo easytier-core -i 10.144.144.1
-```
-
-After startup, this node will listen on the following ports by default:
-- TCP: 11010
-- UDP: 11010
-- WebSocket: 11011
-- WebSocket SSL: 11012
-- WireGuard: 11013
-
-2. Connect Second Node (Node B):
-
-```bash
-# Connect to the first node using its public IP
-sudo easytier-core -i 10.144.144.2 -p udp://FIRST_NODE_PUBLIC_IP:11010
-```
-
-3. Verify Connection:
-
-```bash
-# Test connectivity
-ping 10.144.144.2
-
-# View connected peers
-easytier-cli peer
-
-# View routing information
-easytier-cli route
-
-# View local node information
-easytier-cli node
-```
-
-For more nodes to join the network, they can connect to any existing node in the network using the `-p` parameter:
-
-```bash
-# Connect to any existing node using its public IP
-sudo easytier-core -i 10.144.144.3 -p udp://ANY_EXISTING_NODE_PUBLIC_IP:11010
-```
-
-### 🔍 Advanced Features
-
-#### Subnet Proxy
-
-Assuming the network topology is as follows, Node B wants to share its accessible subnet 10.1.1.0/24 with other nodes:
-
-```mermaid
-flowchart LR
-
-subgraph Node A Public IP 22.1.1.1
-nodea[EasyTier<br/>10.144.144.1]
-end
-
-subgraph Node B
-nodeb[EasyTier<br/>10.144.144.2]
-end
-
-id1[[10.1.1.0/24]]
-
-nodea <--> nodeb <-.-> id1
-```
-
-To share a subnet, add the `-n` parameter when starting EasyTier:
-
-```bash
-# Share subnet 10.1.1.0/24 with other nodes
-sudo easytier-core -i 10.144.144.2 -n 10.1.1.0/24
-```
-
-Subnet proxy information will automatically sync to each node in the virtual network, and each node will automatically configure the corresponding route. You can verify the subnet proxy setup:
-
-1. Check if the routing information has been synchronized (the proxy_cidrs column shows the proxied subnets):
-
-```bash
-# View routing information
-easytier-cli route
-```
-
-![Routing Information](/assets/image-3.png)
-
-2. Test if you can access nodes in the proxied subnet:
-
-```bash
-# Test connectivity to proxied subnet
-ping 10.1.1.2
-```
-
-#### WireGuard Integration
-
-EasyTier can act as a WireGuard server, allowing any device with a WireGuard client (including iOS and Android) to access the EasyTier network. Here's an example setup:
-
-```mermaid
-flowchart LR
-
-ios[[iPhone<br/>WireGuard Installed]]
-
-subgraph Node A Public IP 22.1.1.1
-nodea[EasyTier<br/>10.144.144.1]
-end
-
-subgraph Node B
-nodeb[EasyTier<br/>10.144.144.2]
-end
-
-id1[[10.1.1.0/24]]
-
-ios <-.-> nodea <--> nodeb <-.-> id1
-```
-
-1. Start EasyTier with WireGuard portal enabled:
-
-```bash
-# Listen on 0.0.0.0:11013 and use 10.14.14.0/24 subnet for WireGuard clients
-sudo easytier-core -i 10.144.144.1 --vpn-portal wg://0.0.0.0:11013/10.14.14.0/24
-```
-
-2. Get WireGuard client configuration:
-
-```bash
-# Get WireGuard client configuration
-easytier-cli vpn-portal
-```
-
-3. In the output configuration:
-   - Set `Interface.Address` to an available IP from the WireGuard subnet
-   - Set `Peer.Endpoint` to the public IP/domain of your EasyTier node
-   - Import the modified configuration into your WireGuard client
-
-#### Self-Hosted Public Shared Node
-
-You can run your own public shared node to help other nodes discover each other. A public shared node is just a regular EasyTier network (with same network name and secret) that other networks can connect to.
-
-To run a public shared node:
-
-```bash
-# No need to specify IPv4 address for public shared nodes
-sudo easytier-core --network-name mysharednode --network-secret mysharednode
-```
-
-## Related Projects
-
-- [ZeroTier](https://www.zerotier.com/): A global virtual network for connecting devices.
-- [TailScale](https://tailscale.com/): A VPN solution aimed at simplifying network configuration.
-
-### Contact Us
+## Community
 
 - 💬 **[Telegram Group](https://t.me/easytier)**
-- 👥 **[QQ Group]**
-  - No.1 [949700262](https://qm.qq.com/q/wFoTUChqZW)
-  - No.2 [837676408](https://qm.qq.com/q/4V33DrfgHe)
-  - No.3 [957189589](https://qm.qq.com/q/YNyTQjwlai)
+- 👥 **QQ Groups**: [No.1 949700262](https://qm.qq.com/q/wFoTUChqZW), [No.2 837676408](https://qm.qq.com/q/4V33DrfgHe), [No.3 957189589](https://qm.qq.com/q/YNyTQjwlai)
 
 ## License
 
@@ -306,21 +113,20 @@ CDN acceleration and security protection for this project are sponsored by Tence
   </a>
 </p>
 
-Special thanks to [Langlang Cloud](https://langlangy.cn/?i26c5a5)  and [RainCloud](https://www.rainyun.com/NjM0NzQ1_) for sponsoring our public servers.
+Special thanks to [Langlang Cloud](https://langlangy.cn/?i26c5a5) and [RainCloud](https://www.rainyun.com/NjM0NzQ1_) for sponsoring our public servers.
 
 <p align="center">
-<a href="https://langlangy.cn/?i26c5a5" target="_blank">
-<img src="assets/langlang.png" width="200">
-</a>
-<a href="https://langlangy.cn/?i26c5a5" target="_blank">
-<img src="assets/raincloud.png" width="200">
-</a>
+  <a href="https://langlangy.cn/?i26c5a5" target="_blank">
+    <img src="assets/langlang.png" width="200" alt="Langlang Cloud Logo">
+  </a>
+  <a href="https://www.rainyun.com/NjM0NzQ1_" target="_blank">
+    <img src="assets/raincloud.png" width="200" alt="RainCloud Logo">
+  </a>
 </p>
 
-
-If you find EasyTier helpful, please consider sponsoring us. Software development and maintenance require a lot of time and effort, and your sponsorship will help us better maintain and improve EasyTier.
+If you find EasyTier helpful, please consider sponsoring us. Software development and maintenance require time and effort, and your sponsorship helps us keep improving EasyTier.
 
 <p align="center">
-<img src="assets/wechat.png" width="200">
-<img src="assets/alipay.png" width="200">
+  <img src="assets/wechat.png" width="200" alt="WeChat sponsor QR code">
+  <img src="assets/alipay.png" width="200" alt="Alipay sponsor QR code">
 </p>

--- a/README_CN.md
+++ b/README_CN.md
@@ -11,286 +11,93 @@
 
 [简体中文](/README_CN.md) | [English](/README.md)
 
-> ✨ 一个由 Rust 和 Tokio 驱动的简单、安全、去中心化的异地组网方案
+> ✨ 一个由 Rust 和 Tokio 驱动的简单、安全、去中心化 SD-WAN 组网方案
 
 <p align="center">
-<img src="assets/config-page.png" width="300" alt="配置页面">
-<img src="assets/running-page.png" width="300" alt="运行页面">
+  <img src="assets/config-page.png" width="300" alt="EasyTier 配置页面">
+  <img src="assets/running-page.png" width="300" alt="EasyTier 运行页面">
 </p>
 
-📚 **[完整文档](https://easytier.cn)** | 🖥️ **[Web 控制台](https://easytier.cn/web)** | 📝 **[下载发布版本](https://github.com/EasyTier/EasyTier/releases)** | 🧩 **[第三方工具](https://easytier.cn/guide/installation_gui.html#%E7%AC%AC%E4%B8%89%E6%96%B9%E5%9B%BE%E5%BD%A2%E7%95%8C%E9%9D%A2)** | ❤️ **[赞助](#赞助)**
-
-## 特性
-
-### 核心特性
-
-- 🔒 **去中心化**：节点平等且独立，无需中心化服务
-- 🚀 **易于使用**：支持通过网页、客户端和命令行多种操作方式
-- 🌍 **跨平台**：支持 Win/MacOS/Linux/FreeBSD/Android 和 X86/ARM/MIPS 架构
-- 🔐 **安全**：AES-GCM 或 WireGuard 加密，防止中间人攻击
-
-### 高级功能
-
-- 🔌 **高效 NAT 穿透**：支持 UDP 和 IPv6 穿透，可在 NAT4-NAT4 网络中工作
-- 🌐 **子网代理**：节点可以共享子网供其他节点访问
-- 🔄 **智能路由**：延迟优先和自动路由选择，提供最佳网络体验
-- ⚡ **高性能**：整个链路零拷贝，支持 TCP/UDP/WSS/WG 协议
-
-### 网络优化
-
-- 📊 **UDP 丢包抗性**：KCP/QUIC 代理在高丢包环境下优化延迟和带宽
-- 🔧 **Web 管理**：通过 Web 界面轻松配置和监控
-- 🛠️ **零配置**：静态链接的可执行文件，简单部署
+🌐 **[官网文档](https://easytier.cn)** | 🚀 **[快速开始](https://easytier.cn/guide/introduction.html)** | 📝 **[下载发布版本](https://github.com/EasyTier/EasyTier/releases)** | 🌍 **[国际站](https://easytier.rs)** | ❤️ **[赞助](#赞助)**
 
 ## 快速开始
 
-### 📥 安装
+### 安装
 
-选择最适合您需求的安装方式：
+Linux：
 
-Linux（推荐）：
 ```bash
 curl -fsSL "https://github.com/EasyTier/EasyTier/blob/main/script/install.sh?raw=true" | sudo bash -s install
 ```
 
-Homebrew（MacOS/Linux）：
+Windows（请使用管理员权限运行）：
+
+```powershell
+irm "https://github.com/EasyTier/EasyTier/blob/main/script/install.ps1?raw=true" | iex
+```
+
+Homebrew（macOS/Linux）：
+
 ```bash
 brew tap brewforge/chinese
 brew install --cask easytier-gui
 ```
 
-Windows（推荐，请以管理员权限运行）：
-```powershell
-irm "https://github.com/EasyTier/EasyTier/blob/main/script/install.ps1?raw=true" | iex
-```
-
 通过 cargo 安装（最新开发版本）：
+
 ```bash
 cargo install --git https://github.com/EasyTier/EasyTier.git easytier
 ```
 
-[下载预编译文件](https://github.com/EasyTier/EasyTier/releases)（推荐，支持所有平台）
+更多安装方式：
 
-[通过 Docker 安装](https://easytier.cn/guide/installation.html#%E5%AE%89%E8%A3%85%E6%96%B9%E5%BC%8F)
+- [CLI 安装文档](https://easytier.cn/guide/installation.html)
+- [GUI 安装文档](https://easytier.cn/guide/installation_gui.html)
+- [下载预编译文件](https://github.com/EasyTier/EasyTier/releases)
+- [OpenWrt 插件](https://github.com/EasyTier/luci-app-easytier)
+- [一键注册系统服务](https://easytier.cn/guide/network/oneclick-install-as-service.html)
 
-[安装 OpenWrt ipk 软件包](https://github.com/EasyTier/luci-app-easytier)
+### 最小示例
 
-附加步骤：
-
-[一键注册系统服务](https://easytier.cn/guide/network/oneclick-install-as-service.html)（系统启动时自动后台运行）
-
-### 🚀 基本用法
-
-#### 使用共享节点快速组网
-
-EasyTier 支持使用共享节点快速组网。当您没有公网 IP 时，可以使用公共共享节点。节点会自动尝试 NAT 穿透并建立 P2P 连接。当 P2P 失败时，数据将通过共享节点中继。
-
-使用共享节点时，每个进入网络的节点需要提供相同的 `--network-name` 和 `--network-secret` 参数作为网络的唯一标识符。
-
-以两个节点为例（请使用更复杂的网络名称以避免冲突）：
-
-1. 在节点 A 上运行：
+使用共享公共节点，让多台设备加入同一个网络：
 
 ```bash
-# 以管理员权限运行
-sudo easytier-core -d --network-name abc --network-secret abc -p tcp://<共享节点IP>:11010
+# 节点 A
+sudo easytier-core -d --network-name demo --network-secret demo -p tcp://<共享节点IP>:11010
+
+# 节点 B
+sudo easytier-core -d --network-name demo --network-secret demo -p tcp://<共享节点IP>:11010
 ```
 
-2. 在节点 B 上运行：
+所有节点使用相同的 `--network-name` 和 `--network-secret` 即可加入同一个网络。启动后可通过 `easytier-cli peer`、`easytier-cli route` 或 `easytier-cli node` 查看状态。
 
-```bash
-# 以管理员权限运行
-sudo easytier-core -d --network-name abc --network-secret abc -p tcp://<共享节点IP>:11010
-```
+## 为什么选择 EasyTier
 
-执行成功后，可以使用 `easytier-cli` 检查网络状态：
+- 🔒 **去中心化**：节点平等独立，无需中心化控制器。
+- 🚀 **易于使用**：支持 Web 控制台、图形界面和命令行多种使用方式。
+- 🌍 **跨平台**：支持 Windows、macOS、Linux、FreeBSD、Android 和多种 CPU 架构。
+- 🔐 **安全**：支持 AES-GCM 或 WireGuard 加密，保护网络通信。
+- 🔌 **高效 NAT 穿透**：支持 UDP、IPv6 穿透，可打通 NAT4-NAT4 场景。
+- 🌐 **子网代理**：可将私有子网共享给虚拟网络中的其他节点访问。
+- 🔄 **智能路由**：自动选择更优链路，降低延迟并提升体验。
+- ⚡ **高性能**：全链路零拷贝，支持 TCP、UDP、WS、WSS、WG、QUIC 等协议。
 
-```text
-| ipv4         | hostname       | cost  | lat_ms | loss_rate | rx_bytes | tx_bytes | tunnel_proto | nat_type | id         | version         |
-| ------------ | -------------- | ----- | ------ | --------- | -------- | -------- | ------------ | -------- | ---------- | --------------- |
-| 10.126.126.1 | abc-1          | Local | *      | *         | *        | *        | udp          | FullCone | 439804259  | 2.5.0-70e69a38~ |
-| 10.126.126.2 | abc-2          | p2p   | 3.452  | 0         | 17.33 kB | 20.42 kB | udp          | FullCone | 390879727  | 2.5.0-70e69a38~ |
-|              | PublicServer_a | p2p   | 27.796 | 0.000     | 50.01 kB | 67.46 kB | tcp          | Unknown  | 3771642457 | 2.5.0-70e69a38~ |
-```
+## 深入了解
 
-您可以测试节点之间的连通性：
+- [简介](https://easytier.cn/guide/introduction.html)
+- [命令行组网](https://easytier.cn/guide/networking.html)
+- [去中心化组网](https://easytier.cn/guide/network/decentralized-networking.html)
+- [通过 Web 控制台组网](https://easytier.cn/guide/network/web-console.html)
+- [使用 WireGuard 客户端接入](https://easytier.cn/guide/network/use-easytier-with-wireguard-client.html)
+- [子网代理](https://easytier.cn/guide/network/point-to-networking.html)
+- [带宽与延迟优化](https://easytier.cn/guide/network/kcp-proxy.html)
+- [自建公共共享节点](https://easytier.cn/guide/network/host-public-server.html)
+- [第三方图形界面](https://easytier.cn/guide/installation_gui.html#%E7%AC%AC%E4%B8%89%E6%96%B9%E5%9B%BE%E5%BD%A2%E7%95%8C%E9%9D%A2)
 
-```bash
-# 测试连通性
-ping 10.126.126.1
-ping 10.126.126.2
-```
-
-注意：如果无法 ping 通，可能是防火墙阻止了入站流量。请关闭防火墙或添加允许规则。
-
-为了提高可用性，您可以同时连接多个共享节点：
-
-```bash
-# 连接多个共享节点
-sudo easytier-core -d --network-name abc --network-secret abc -p tcp://<公共节点IP>:11010 -p udp://<公共节点IP>:11010
-```
-
-#### 去中心化组网
-
-EasyTier 本质上是去中心化的，没有服务器和客户端的区分。只要一个设备能与虚拟网络中的任何节点通信，它就可以加入虚拟网络。以下是如何设置去中心化网络：
-
-1. 启动第一个节点（节点 A）：
-
-```bash
-# 启动第一个节点
-sudo easytier-core -i 10.144.144.1
-```
-
-启动后，该节点将默认监听以下端口：
-- TCP：11010
-- UDP：11010
-- WebSocket：11011
-- WebSocket SSL：11012
-- WireGuard：11013
-
-2. 连接第二个节点（节点 B）：
-
-```bash
-# 使用第一个节点的公网 IP 连接
-sudo easytier-core -i 10.144.144.2 -p udp://第一个节点的公网IP:11010
-```
-
-3. 验证连接：
-
-```bash
-# 测试连通性
-ping 10.144.144.2
-
-# 查看已连接的对等节点
-easytier-cli peer
-
-# 查看路由信息
-easytier-cli route
-
-# 查看本地节点信息
-easytier-cli node
-```
-
-更多节点要加入网络，可以使用 `-p` 参数连接到网络中的任何现有节点：
-
-```bash
-# 使用任何现有节点的公网 IP 连接
-sudo easytier-core -i 10.144.144.3 -p udp://任何现有节点的公网IP:11010
-```
-
-### 🔍 高级功能
-
-#### 子网代理
-
-假设网络拓扑如下，节点 B 想要与其他节点共享其可访问的子网 10.1.1.0/24：
-
-```mermaid
-flowchart LR
-
-subgraph 节点 A 公网 IP 22.1.1.1
-nodea[EasyTier<br/>10.144.144.1]
-end
-
-subgraph 节点 B
-nodeb[EasyTier<br/>10.144.144.2]
-end
-
-id1[[10.1.1.0/24]]
-
-nodea <--> nodeb <-.-> id1
-```
-
-要共享子网，在启动 EasyTier 时添加 `-n` 参数：
-
-```bash
-# 与其他节点共享子网 10.1.1.0/24
-sudo easytier-core -i 10.144.144.2 -n 10.1.1.0/24
-```
-
-子网代理信息将自动同步到虚拟网络中的每个节点，每个节点将自动配置相应的路由。您可以验证子网代理设置：
-
-1. 检查路由信息是否已同步（proxy_cidrs 列显示代理的子网）：
-
-```bash
-# 查看路由信息
-easytier-cli route
-```
-
-![路由信息](/assets/image-3.png)
-
-2. 测试是否可以访问代理子网中的节点：
-
-```bash
-# 测试到代理子网的连通性
-ping 10.1.1.2
-```
-
-#### WireGuard 集成
-
-EasyTier 可以作为 WireGuard 服务器，允许任何安装了 WireGuard 客户端的设备（包括 iOS 和 Android）访问 EasyTier 网络。以下是设置示例：
-
-```mermaid
-flowchart LR
-
-ios[[iPhone<br/>已安装 WireGuard]]
-
-subgraph 节点 A 公网 IP 22.1.1.1
-nodea[EasyTier<br/>10.144.144.1]
-end
-
-subgraph 节点 B
-nodeb[EasyTier<br/>10.144.144.2]
-end
-
-id1[[10.1.1.0/24]]
-
-ios <-.-> nodea <--> nodeb <-.-> id1
-```
-
-1. 启动启用 WireGuard 门户的 EasyTier：
-
-```bash
-# 在 0.0.0.0:11013 上监听，并使用 10.14.14.0/24 子网作为 WireGuard 客户端
-sudo easytier-core -i 10.144.144.1 --vpn-portal wg://0.0.0.0:11013/10.14.14.0/24
-```
-
-2. 获取 WireGuard 客户端配置：
-
-```bash
-# 获取 WireGuard 客户端配置
-easytier-cli vpn-portal
-```
-
-3. 在输出配置中：
-   - 将 `Interface.Address` 设置为 WireGuard 子网中的可用 IP
-   - 将 `Peer.Endpoint` 设置为您的 EasyTier 节点的公网 IP/域名
-   - 将修改后的配置导入到您的 WireGuard 客户端
-
-#### 自建公共共享节点
-
-您可以运行自己的公共共享节点来帮助其他节点相互发现。公共共享节点只是一个普通的 EasyTier 网络（具有相同的网络名称和密钥），其他网络可以连接到它。
-
-要运行公共共享节点：
-
-```bash
-# 公共共享节点无需指定 IPv4 地址
-sudo easytier-core --network-name mysharednode --network-secret mysharednode
-```
-
-网络设置成功后，您可以轻松配置它以在系统启动时自动启动。请参阅 [一键注册服务指南](https://easytier.cn/en/guide/network/oneclick-install-as-service.html) 了解如何将 EasyTier 注册为系统服务。
-
-## 相关项目
-
-- [ZeroTier](https://www.zerotier.com/)：用于连接设备的全球虚拟网络。
-- [TailScale](https://tailscale.com/)：旨在简化网络配置的 VPN 解决方案。
-
-### 联系我们
+## 社区
 
 - 💬 **[Telegram 群组](https://t.me/easytier)**
-- 👥 **QQ 群**
-  - 一群 [949700262](https://qm.qq.com/q/wFoTUChqZW)
-  - 二群 [837676408](https://qm.qq.com/q/4V33DrfgHe)
-  - 三群 [957189589](https://qm.qq.com/q/YNyTQjwlai)
+- 👥 **QQ 群**：[一群 949700262](https://qm.qq.com/q/wFoTUChqZW)、[二群 837676408](https://qm.qq.com/q/4V33DrfgHe)、[三群 957189589](https://qm.qq.com/q/YNyTQjwlai)
 
 ## 许可证
 
@@ -301,25 +108,25 @@ EasyTier 在 [LGPL-3.0](https://github.com/EasyTier/EasyTier/blob/main/LICENSE) 
 本项目的 CDN 加速和安全防护由腾讯云 EdgeOne 赞助。
 
 <p align="center">
-<a href="https://edgeone.ai/?from=github" target="_blank">
-<img src="assets/edgeone.png" width="200">
-</a>
+  <a href="https://edgeone.ai/?from=github" target="_blank">
+    <img src="assets/edgeone.png" width="200" alt="EdgeOne Logo">
+  </a>
 </p>
 
 特别感谢 [浪浪云](https://langlangy.cn/?i26c5a5) 和 [雨云](https://www.rainyun.com/NjM0NzQ1_) 赞助我们的公共服务器。
 
 <p align="center">
-<a href="https://langlangy.cn/?i26c5a5" target="_blank">
-<img src="assets/langlang.png" width="200">
-</a>
-<a href="https://langlangy.cn/?i26c5a5" target="_blank">
-<img src="assets/raincloud.png" width="200">
-</a>
+  <a href="https://langlangy.cn/?i26c5a5" target="_blank">
+    <img src="assets/langlang.png" width="200" alt="浪浪云 Logo">
+  </a>
+  <a href="https://www.rainyun.com/NjM0NzQ1_" target="_blank">
+    <img src="assets/raincloud.png" width="200" alt="雨云 Logo">
+  </a>
 </p>
 
-如果您觉得 EasyTier 有帮助，请考虑赞助我们。软件开发和维护需要大量的时间和精力，您的赞助将帮助我们更好地维护和改进 EasyTier。
+如果您觉得 EasyTier 有帮助，欢迎赞助我们。软件开发和维护需要持续投入，您的支持将帮助我们更好地维护和改进 EasyTier。
 
 <p align="center">
-<img src="assets/wechat.png" width="200">
-<img src="assets/alipay.png" width="200">
+  <img src="assets/wechat.png" width="200" alt="微信赞助二维码">
+  <img src="assets/alipay.png" width="200" alt="支付宝赞助二维码">
 </p>

--- a/README_CN.md
+++ b/README_CN.md
@@ -13,11 +13,6 @@
 
 > ✨ 一个由 Rust 和 Tokio 驱动的简单、安全、去中心化 SD-WAN 组网方案
 
-<p align="center">
-  <img src="assets/config-page.png" width="300" alt="EasyTier 配置页面">
-  <img src="assets/running-page.png" width="300" alt="EasyTier 运行页面">
-</p>
-
 🌐 **[官网文档](https://easytier.cn)** | 🚀 **[快速开始](https://easytier.cn/guide/introduction.html)** | 📝 **[下载发布版本](https://github.com/EasyTier/EasyTier/releases)** | 🌍 **[国际站](https://easytier.rs)** | ❤️ **[赞助](#赞助)**
 
 ## 快速开始


### PR DESCRIPTION
Refocus the repository homepage on visuals, quick start guidance, and documentation links so new users can understand EasyTier faster.

Align the English and Chinese READMEs with the global and mainland documentation entry points.