### PR TITLE
feat: make magic DNS server IP and DNS suffix configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,6 +2175,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "cfg-if",
+ "cfg_aliases 0.2.1",
  "chrono",
  "cidr",
  "clap",

--- a/easytier-gui/src/composables/mobile_vpn.ts
+++ b/easytier-gui/src/composables/mobile_vpn.ts
@@ -3,6 +3,17 @@ import { addPluginListener } from '@tauri-apps/api/core'
 import { Utils } from 'easytier-frontend-lib'
 import { get_vpn_status, prepare_vpn, start_vpn, stop_vpn } from 'tauri-plugin-vpnservice-api'
 
+const DEFAULT_MAGIC_DNS_IP = '100.100.100.101'
+const IPV4_RE = /^(\d{1,3}\.){3}\d{1,3}$/
+
+function resolveMagicDnsIp(configured: string | undefined): string {
+  const ip = configured?.trim() ?? ''
+  if (ip && IPV4_RE.test(ip)) {
+    return ip
+  }
+  return DEFAULT_MAGIC_DNS_IP
+}
+
 type Route = NetworkTypes.Route
 
 interface vpnStatus {
@@ -183,8 +194,7 @@ function getRoutesForVpn(routes: Route[], node_config: NetworkTypes.NetworkConfi
   })
 
   if (node_config.enable_magic_dns) {
-    const dnsIp = node_config.magic_dns_server_ip || '100.100.100.101'
-    ret.push(`${dnsIp}/32`)
+    ret.push(`${resolveMagicDnsIp(node_config.magic_dns_server_ip)}/32`)
   }
 
   // sort and dedup
@@ -245,7 +255,7 @@ export async function onNetworkInstanceChange(instanceId: string) {
 
   const routes = getRoutesForVpn(curNetworkInfo?.routes, config)
 
-  const dns = config.enable_magic_dns ? (config.magic_dns_server_ip || '100.100.100.101') : undefined
+  const dns = config.enable_magic_dns ? resolveMagicDnsIp(config.magic_dns_server_ip) : undefined
 
   const ipChanged = virtual_ip !== curVpnStatus.ipv4Addr
   const cidrChanged = network_length !== curVpnStatus.ipv4Cidr

--- a/easytier-gui/src/composables/mobile_vpn.ts
+++ b/easytier-gui/src/composables/mobile_vpn.ts
@@ -183,7 +183,8 @@ function getRoutesForVpn(routes: Route[], node_config: NetworkTypes.NetworkConfi
   })
 
   if (node_config.enable_magic_dns) {
-    ret.push('100.100.100.101/32')
+    const dnsIp = node_config.magic_dns_server_ip || '100.100.100.101'
+    ret.push(`${dnsIp}/32`)
   }
 
   // sort and dedup
@@ -244,7 +245,7 @@ export async function onNetworkInstanceChange(instanceId: string) {
 
   const routes = getRoutesForVpn(curNetworkInfo?.routes, config)
 
-  const dns = config.enable_magic_dns ? '100.100.100.101' : undefined
+  const dns = config.enable_magic_dns ? (config.magic_dns_server_ip || '100.100.100.101') : undefined
 
   const ipChanged = virtual_ip !== curVpnStatus.ipv4Addr
   const cidrChanged = network_length !== curVpnStatus.ipv4Cidr

--- a/easytier-gui/src/composables/mobile_vpn.ts
+++ b/easytier-gui/src/composables/mobile_vpn.ts
@@ -4,14 +4,19 @@ import { Utils } from 'easytier-frontend-lib'
 import { get_vpn_status, prepare_vpn, start_vpn, stop_vpn } from 'tauri-plugin-vpnservice-api'
 
 const DEFAULT_MAGIC_DNS_IP = '100.100.100.101'
-const IPV4_RE = /^(\d{1,3}\.){3}\d{1,3}$/
+
+function isValidIPv4(ip: string): boolean {
+  const parts = ip.split('.')
+  if (parts.length !== 4) return false
+  return parts.every((p) => {
+    const n = Number(p)
+    return p !== '' && !isNaN(n) && Number.isInteger(n) && n >= 0 && n <= 255
+  })
+}
 
 function resolveMagicDnsIp(configured: string | undefined): string {
   const ip = configured?.trim() ?? ''
-  if (ip && IPV4_RE.test(ip)) {
-    return ip
-  }
-  return DEFAULT_MAGIC_DNS_IP
+  return isValidIPv4(ip) ? ip : DEFAULT_MAGIC_DNS_IP
 }
 
 type Route = NetworkTypes.Route

--- a/easytier-web/frontend-lib/src/components/Config.vue
+++ b/easytier-web/frontend-lib/src/components/Config.vue
@@ -237,6 +237,25 @@ watch(() => curNetwork.value, syncNormalizedNetwork, { immediate: true, deep: fa
                 </div>
               </div>
 
+              <div v-if="curNetwork.enable_magic_dns" class="flex flex-row gap-x-9 flex-wrap">
+                <div class="flex flex-col gap-2 basis-5/12 grow">
+                  <label for="tld_dns_zone">
+                    {{ t('tld_dns_zone') }}
+                    <span class="pi pi-question-circle ml-2" v-tooltip="t('tld_dns_zone_help')"></span>
+                  </label>
+                  <InputText id="tld_dns_zone" v-model="curNetwork.tld_dns_zone"
+                    :placeholder="t('tld_dns_zone_placeholder')" />
+                </div>
+                <div class="flex flex-col gap-2 basis-5/12 grow">
+                  <label for="magic_dns_server_ip">
+                    {{ t('magic_dns_server_ip') }}
+                    <span class="pi pi-question-circle ml-2" v-tooltip="t('magic_dns_server_ip_help')"></span>
+                  </label>
+                  <InputText id="magic_dns_server_ip" v-model="curNetwork.magic_dns_server_ip"
+                    :placeholder="t('magic_dns_server_ip_placeholder')" />
+                </div>
+              </div>
+
               <div class="flex flex-row gap-x-9 flex-wrap">
                 <div class="flex flex-col gap-2 basis-5/12 grow">
                   <label for="hostname">{{ t('hostname') }}</label>

--- a/easytier-web/frontend-lib/src/locales/cn.yaml
+++ b/easytier-web/frontend-lib/src/locales/cn.yaml
@@ -164,6 +164,16 @@ enable_magic_dns: 启用魔法DNS
 enable_magic_dns_help: |
   启用魔法DNS，允许通过EasyTier的DNS服务器访问其他节点的虚拟IPv4地址， 如 node1.et.net。
 
+tld_dns_zone: 魔法DNS后缀
+tld_dns_zone_help: |
+  魔法DNS的顶级域名区域。留空则使用默认值（et.net.）。仅在启用魔法DNS时生效。
+tld_dns_zone_placeholder: 默认：et.net.
+
+magic_dns_server_ip: 魔法DNS服务器IP
+magic_dns_server_ip_help: |
+  魔法DNS服务器使用的虚拟IP地址。留空则使用默认值（100.100.100.101）。仅在启用魔法DNS时生效。
+magic_dns_server_ip_placeholder: 默认：100.100.100.101
+
 enable_private_mode: 启用私有模式
 enable_private_mode_help: |
   启用私有模式，则不允许使用了与本网络不相同的网络名称和密码的节点通过本节点进行握手或中转。

--- a/easytier-web/frontend-lib/src/locales/en.yaml
+++ b/easytier-web/frontend-lib/src/locales/en.yaml
@@ -163,6 +163,16 @@ enable_magic_dns: Enable Magic DNS
 enable_magic_dns_help: |
   Enable magic dns, all nodes in the network can access each other by domain name, e.g.: node1.et.net.
 
+tld_dns_zone: Magic DNS Suffix
+tld_dns_zone_help: |
+  Top-level domain zone for Magic DNS. Leave blank to use the default (et.net.). Only used when Magic DNS is enabled.
+tld_dns_zone_placeholder: "Default: et.net."
+
+magic_dns_server_ip: Magic DNS Server IP
+magic_dns_server_ip_help: |
+  The virtual IP address used by the Magic DNS server. Leave blank to use the default (100.100.100.101). Only used when Magic DNS is enabled.
+magic_dns_server_ip_placeholder: "Default: 100.100.100.101"
+
 enable_private_mode: Enable Private Mode
 enable_private_mode_help: |
   Enable private mode, nodes with different network names or passwords from this network are not allowed to perform handshake or relay through this node.

--- a/easytier-web/frontend-lib/src/types/network.ts
+++ b/easytier-web/frontend-lib/src/types/network.ts
@@ -82,6 +82,8 @@ export interface NetworkConfig {
   mapped_listeners: string[]
 
   enable_magic_dns?: boolean
+  tld_dns_zone?: string
+  magic_dns_server_ip?: string
   enable_private_mode?: boolean
 
   port_forwards: PortForwardConfig[]
@@ -150,6 +152,8 @@ export function DEFAULT_NETWORK_CONFIG(): NetworkConfig {
     instance_recv_bps_limit: null,
     mapped_listeners: [],
     enable_magic_dns: false,
+    tld_dns_zone: '',
+    magic_dns_server_ip: '',
     enable_private_mode: false,
     port_forwards: [],
   }

--- a/easytier/locales/app.yml
+++ b/easytier/locales/app.yml
@@ -211,6 +211,9 @@ core_clap:
   tld_dns_zone:
     en: "specify the top-level domain zone for magic DNS. if not provided, defaults to the value from dns_server module (et.net.). only used when accept_dns is true."
     zh-CN: "指定魔法DNS的顶级域名区域。如果未提供，默认使用dns_server模块中的值（et.net.）。仅在accept_dns为true时使用。"
+  magic_dns_server_ip:
+    en: "specify the virtual IPv4 address used as the magic DNS server. if not provided, defaults to 100.100.100.101. only used when accept_dns is true."
+    zh-CN: "指定魔法DNS服务器使用的虚拟IPv4地址。如果未提供，默认使用100.100.100.101。仅在accept_dns为true时使用。"
   private_mode:
     en: "if true, foreign networks are only allowed when this node can verify they use the same network secret, or when a foreign credential node is already trusted via admin-issued credential propagation; different or missing secrets are otherwise rejected."
     zh-CN: "如果为true，则仅允许两类 foreign network 接入：本节点能验证其使用相同 network secret 的节点，或已通过 foreign network 管理节点传播而被信任的 credential 节点；否则 secret 不同或缺失时会被拒绝。"

--- a/easytier/src/common/config.rs
+++ b/easytier/src/common/config.rs
@@ -66,6 +66,7 @@ pub fn gen_default_flags() -> Flags {
         encryption_algorithm: EncryptionAlgorithm::default().to_string(),
         disable_sym_hole_punching: false,
         tld_dns_zone: DEFAULT_ET_DNS_ZONE.to_string(),
+        magic_dns_server_ip: "".to_string(),
 
         quic_listen_port: u32::MAX,
         need_p2p: false,

--- a/easytier/src/core.rs
+++ b/easytier/src/core.rs
@@ -548,7 +548,7 @@ struct NetworkOptions {
     #[arg(
         long = "magic-dns-server-ip",
         env = "ET_MAGIC_DNS_SERVER_IP",
-        help = "specify the IP address of the magic DNS server. if not provided, defaults to 100.100.100.101. only used when accept_dns is true."
+        help = t!("core_clap.magic_dns_server_ip").to_string()
     )]
     magic_dns_server_ip: Option<String>,
 

--- a/easytier/src/core.rs
+++ b/easytier/src/core.rs
@@ -545,6 +545,12 @@ struct NetworkOptions {
         env = "ET_TLD_DNS_ZONE",
         help = t!("core_clap.tld_dns_zone").to_string())]
     tld_dns_zone: Option<String>,
+    #[arg(
+        long = "magic-dns-server-ip",
+        env = "ET_MAGIC_DNS_SERVER_IP",
+        help = "specify the IP address of the magic DNS server. if not provided, defaults to 100.100.100.101. only used when accept_dns is true."
+    )]
+    magic_dns_server_ip: Option<String>,
 
     #[arg(
         long,
@@ -1083,6 +1089,9 @@ impl NetworkOptions {
         // Configure tld_dns_zone: use provided value if set
         if let Some(tld_dns_zone) = &self.tld_dns_zone {
             f.tld_dns_zone = tld_dns_zone.clone();
+        }
+        if let Some(magic_dns_server_ip) = &self.magic_dns_server_ip {
+            f.magic_dns_server_ip = magic_dns_server_ip.clone();
         }
         cfg.set_flags(f);
 

--- a/easytier/src/instance/instance.rs
+++ b/easytier/src/instance/instance.rs
@@ -703,13 +703,14 @@ impl Instance {
         }
 
         let flags = ctx.config.get_flags();
-        let fake_ip = if !flags.magic_dns_server_ip.is_empty() {
-            match flags.magic_dns_server_ip.parse() {
+        let configured_ip = flags.magic_dns_server_ip.trim();
+        let fake_ip = if !configured_ip.is_empty() {
+            match configured_ip.parse() {
                 Ok(ip) => ip,
                 Err(e) => {
                     tracing::warn!(
                         "Invalid magic_dns_server_ip '{}': {}, using default",
-                        flags.magic_dns_server_ip,
+                        configured_ip,
                         e
                     );
                     MAGIC_DNS_FAKE_IP.parse().unwrap()

--- a/easytier/src/instance/instance.rs
+++ b/easytier/src/instance/instance.rs
@@ -702,12 +702,24 @@ impl Instance {
             return None;
         }
 
-        let runner = DnsRunner::new(
-            peer_mgr,
-            tun_dev,
-            tun_ip,
-            MAGIC_DNS_FAKE_IP.parse().unwrap(),
-        );
+        let flags = ctx.config.get_flags();
+        let fake_ip = if !flags.magic_dns_server_ip.is_empty() {
+            match flags.magic_dns_server_ip.parse() {
+                Ok(ip) => ip,
+                Err(e) => {
+                    tracing::warn!(
+                        "Invalid magic_dns_server_ip '{}': {}, using default",
+                        flags.magic_dns_server_ip,
+                        e
+                    );
+                    MAGIC_DNS_FAKE_IP.parse().unwrap()
+                }
+            }
+        } else {
+            MAGIC_DNS_FAKE_IP.parse().unwrap()
+        };
+
+        let runner = DnsRunner::new(peer_mgr, tun_dev, tun_ip, fake_ip);
         Some(runner)
     }
 

--- a/easytier/src/launcher.rs
+++ b/easytier/src/launcher.rs
@@ -809,6 +809,16 @@ impl NetworkConfig {
             flags.accept_dns = enable_magic_dns;
         }
 
+        if let Some(tld_dns_zone) = &self.tld_dns_zone {
+            if !tld_dns_zone.is_empty() {
+                flags.tld_dns_zone = tld_dns_zone.clone();
+            }
+        }
+
+        if let Some(magic_dns_server_ip) = &self.magic_dns_server_ip {
+            flags.magic_dns_server_ip = magic_dns_server_ip.clone();
+        }
+
         if let Some(mtu) = self.mtu {
             flags.mtu = mtu as u32;
         }
@@ -959,6 +969,12 @@ impl NetworkConfig {
         result.disable_udp_hole_punching = Some(flags.disable_udp_hole_punching);
         result.disable_sym_hole_punching = Some(flags.disable_sym_hole_punching);
         result.enable_magic_dns = Some(flags.accept_dns);
+        result.tld_dns_zone = Some(flags.tld_dns_zone.clone());
+        result.magic_dns_server_ip = if flags.magic_dns_server_ip.is_empty() {
+            None
+        } else {
+            Some(flags.magic_dns_server_ip.clone())
+        };
         result.mtu = Some(flags.mtu as i32);
         result.instance_recv_bps_limit =
             (flags.instance_recv_bps_limit != u64::MAX).then_some(flags.instance_recv_bps_limit);

--- a/easytier/src/launcher.rs
+++ b/easytier/src/launcher.rs
@@ -1038,6 +1038,33 @@ mod tests {
     }
 
     #[test]
+    fn test_network_config_magic_dns_round_trip() -> Result<(), anyhow::Error> {
+        // non-empty magic_dns_server_ip should survive round-trip
+        let config = gen_default_config();
+        let mut flags = config.get_flags();
+        flags.accept_dns = true;
+        flags.magic_dns_server_ip = "10.0.0.53".to_string();
+        flags.tld_dns_zone = "myhome.".to_string();
+        config.set_flags(flags);
+
+        let network_config = super::NetworkConfig::new_from_config(&config)?;
+        assert_eq!(network_config.magic_dns_server_ip.as_deref(), Some("10.0.0.53"));
+        assert_eq!(network_config.tld_dns_zone.as_deref(), Some("myhome."));
+
+        let generated_config = network_config.gen_config()?;
+        let generated_flags = generated_config.get_flags();
+        assert_eq!(generated_flags.magic_dns_server_ip, "10.0.0.53");
+        assert_eq!(generated_flags.tld_dns_zone, "myhome.");
+
+        // empty magic_dns_server_ip should produce None in NetworkConfig
+        let config2 = gen_default_config();
+        let network_config2 = super::NetworkConfig::new_from_config(&config2)?;
+        assert!(network_config2.magic_dns_server_ip.is_none());
+
+        Ok(())
+    }
+
+    #[test]
     fn test_network_config_conversion_random() -> Result<(), anyhow::Error> {
         let mut rng = rand::thread_rng();
 

--- a/easytier/src/proto/api_manage.proto
+++ b/easytier/src/proto/api_manage.proto
@@ -88,6 +88,9 @@ message NetworkConfig {
   optional bool lazy_p2p = 58;
   optional bool need_p2p = 59;
   optional uint64 instance_recv_bps_limit = 60;
+
+  optional string tld_dns_zone = 61;
+  optional string magic_dns_server_ip = 62;
 }
 
 message PortForwardConfig {

--- a/easytier/src/proto/common.proto
+++ b/easytier/src/proto/common.proto
@@ -74,6 +74,9 @@ message FlagsInConfig {
   bool lazy_p2p = 37;
   bool need_p2p = 38;
   uint64 instance_recv_bps_limit = 39;
+
+  // custom fake IP for magic dns server; empty means use the default (100.100.100.101)
+  string magic_dns_server_ip = 40;
 }
 
 message RpcDescriptor {


### PR DESCRIPTION
## Summary

The magic DNS server IP was hardcoded as `100.100.100.101`, which causes routing conflicts in certain network environments (#1826). The DNS suffix (`tld_dns_zone`) was already configurable via CLI but not exposed in the GUI. This PR makes both fields fully configurable end-to-end.

## What Changed

- added `magic_dns_server_ip` field to `FlagsInConfig` proto (field 40); empty string falls back to `100.100.100.101` with a warning logged on invalid input
- added `--magic-dns-server-ip` CLI arg and `ET_MAGIC_DNS_SERVER_IP` env var
- exposed `tld_dns_zone` (field 61) and `magic_dns_server_ip` (field 62) in `api.manage.NetworkConfig` proto so both fields survive TOML round-trip parse
- wired new fields through `launcher` config mapping (`gen_config` / `new_from_config`)
- added frontend type/default wiring in `NetworkConfig` TypeScript interface
- added GUI input fields in `Config.vue`, conditionally shown when Magic DNS is enabled
- added i18n strings in English and Chinese
- fixed hardcoded `100.100.100.101` in `mobile_vpn.ts` to use the configured value

## Bug Fix

The "Edit Config File" dialog was silently losing `tld_dns_zone` and `magic_dns_server_ip` edits because those fields were absent from the `NetworkConfig` proto definition. They are now preserved correctly through the parse round-trip.

## Closes

Closes #1826
Closes #927