### PR TITLE
tests(relay_peer_e2e_encryption): wait for the key of inst3 before ping test

### DIFF
--- a/easytier/src/tests/three_node.rs
+++ b/easytier/src/tests/three_node.rs
@@ -3150,6 +3150,20 @@ pub async fn relay_peer_e2e_encryption(#[values("tcp", "udp")] proto: &str) {
             .map(|i| i.noise_static_pubkey.len())
     );
 
+    // Wait until relay route info includes inst3 static pubkey for IK handshake.
+    wait_for_condition(
+        || async {
+            insts[0]
+                .get_peer_manager()
+                .get_peer_map()
+                .get_route_peer_info(inst3_peer_id)
+                .await
+                .is_some_and(|info| !info.noise_static_pubkey.is_empty())
+        },
+        Duration::from_secs(10),
+    )
+    .await;
+
     // Test basic connectivity through relay
     println!("Starting ping test from net_a to 10.144.144.3...");
 


### PR DESCRIPTION
- part of https://github.com/EasyTier/EasyTier/pull/1862