### PR TITLE
deps: remove hashbrown

### DIFF
--- a/easytier/Cargo.toml
+++ b/easytier/Cargo.toml
@@ -165,7 +165,6 @@ network-interface = "2.0"
 
 # for ospf route
 petgraph = "0.8.1"
-hashbrown = "0.15.3"
 ordered_hash_map = "0.5.0"
 
 # for wireguard

--- a/easytier/src/peers/graph_algo.rs
+++ b/easytier/src/peers/graph_algo.rs
@@ -1,12 +1,10 @@
 use core::cmp::Ordering;
-use hashbrown::hash_map::{
-    Entry::{Occupied, Vacant},
-    HashMap,
-};
 use petgraph::{
     algo::Measure,
-    visit::{EdgeRef as _, IntoEdges, VisitMap as _, Visitable},
+    visit::{EdgeRef, IntoEdges, VisitMap, Visitable},
 };
+use std::collections::HashMap;
+use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::{collections::BinaryHeap, hash::Hash};
 
 /// `MinScored<K, T>` holds a score `K` and a scored object `T` in


### PR DESCRIPTION
~~- part of https://github.com/EasyTier/EasyTier/pull/1862~~

~~`indexmap` 的 `shift_remove` 时间复杂度比 `ordered_hash_map` 的 `remove` 更高，但应该问题不大~~