### PR TITLE
chore: update Rust to 1.95; replace cfg_if with cfg_select

### DIFF
--- a/.github/actions/prepare-build/action.yml
+++ b/.github/actions/prepare-build/action.yml
@@ -52,7 +52,7 @@ runs:
 
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.95
         target: ${{ !contains(inputs.target, 'mips') && inputs.target || '' }}
         cache: false
         rustflags: ''

--- a/.github/actions/prepare-build/action.yml
+++ b/.github/actions/prepare-build/action.yml
@@ -54,15 +54,13 @@ runs:
       with:
         toolchain: 1.95
         target: ${{ !contains(inputs.target, 'mips') && inputs.target || '' }}
+        components: ${{ contains(inputs.target, 'mips') && 'rust-src' || '' }}
         cache: false
         rustflags: ''
 
     - name: Install Rust (MIPS)
       if: ${{ contains(inputs.target, 'mips') }}
       run: |
-        rustup toolchain install nightly-2026-02-02-x86_64-unknown-linux-gnu
-        rustup component add rust-src --toolchain nightly-2026-02-02-x86_64-unknown-linux-gnu
-        
         MUSL_TARGET=${{ inputs.target }}sf
         mkdir -p ./musl_gcc
         wget --inet4-only -c https://github.com/cross-tools/musl-cross/releases/download/20250520/${MUSL_TARGET}.tar.xz -P ./musl_gcc/

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -191,8 +191,10 @@ jobs:
 
       - name: Build (MIPS)
         if: ${{ contains(matrix.TARGET, 'mips') }}
+        env:
+          RUSTC_BOOTSTRAP: 1
         run: |
-          cargo +nightly-2026-02-02 build -r --target $TARGET -Z build-std=std,panic_abort --package=easytier --features=jemalloc
+          cargo build -r --target $TARGET -Z build-std=std,panic_abort --package=easytier --features=jemalloc
 
       - name: Compress
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Thank you for your interest in contributing to EasyTier! This document provides 
 #### Required Tools
 - Node.js v21 or higher
 - pnpm v9 or higher
-- Rust toolchain (version 1.93)
+- Rust toolchain (version 1.95)
 - LLVM and Clang
 - Protoc (Protocol Buffers compiler)
 
@@ -79,8 +79,8 @@ sudo apt install -y bridge-utils
 2. Install dependencies:
    ```bash
    # Install Rust toolchain
-   rustup install 1.93
-   rustup default 1.93
+   rustup install 1.95
+   rustup default 1.95
 
    # Install project dependencies
    pnpm -r install

--- a/CONTRIBUTING_zh.md
+++ b/CONTRIBUTING_zh.md
@@ -34,7 +34,7 @@
 #### 必需工具
 - Node.js v21 或更高版本
 - pnpm v9 或更高版本
-- Rust 工具链（版本 1.93）
+- Rust 工具链（版本 1.95）
 - LLVM 和 Clang
 - Protoc（Protocol Buffers 编译器）
 
@@ -87,8 +87,8 @@ sudo apt install -y bridge-utils
 2. 安装依赖：
    ```bash
    # 安装 Rust 工具链
-   rustup install 1.93
-   rustup default 1.93
+   rustup install 1.95
+   rustup default 1.95
 
    # 安装项目依赖
    pnpm -r install

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.93.0"
+rust-version = "1.95"
 
 [profile.dev]
 panic = "unwind"

--- a/easytier/Cargo.toml
+++ b/easytier/Cargo.toml
@@ -50,7 +50,6 @@ time = "0.3"
 toml = "0.8.12"
 chrono = { version = "0.4.37", features = ["serde"] }
 
-cfg-if = "1.0"
 delegate = "0.13.5"
 
 itertools = "0.14.0"

--- a/easytier/src/common/acl_processor.rs
+++ b/easytier/src/common/acl_processor.rs
@@ -345,7 +345,7 @@ impl AclProcessor {
                     .collect::<Vec<_>>();
 
                 // Sort by priority (higher priority first)
-                rules.sort_by(|a, b| b.priority.cmp(&a.priority));
+                rules.sort_by_key(|r| std::cmp::Reverse(r.priority));
 
                 match chain.chain_type() {
                     ChainType::Inbound => inbound_rules.extend(rules),

--- a/easytier/src/common/config.rs
+++ b/easytier/src/common/config.rs
@@ -7,7 +7,6 @@ use std::{
 
 use anyhow::Context;
 use base64::{Engine as _, prelude::BASE64_STANDARD};
-use cfg_if::cfg_if;
 use clap::ValueEnum;
 use clap::builder::PossibleValue;
 use serde::{Deserialize, Serialize};
@@ -109,10 +108,9 @@ impl ValueEnum for EncryptionAlgorithm {
 #[allow(clippy::derivable_impls)]
 impl Default for EncryptionAlgorithm {
     fn default() -> Self {
-        cfg_if! {
-            if #[cfg(any(feature = "aes-gcm", feature = "wireguard", feature = "openssl-crypto"))] {
-                EncryptionAlgorithm::AesGcm
-            } else {
+        cfg_select! {
+            any(feature = "aes-gcm", feature = "wireguard", feature = "openssl-crypto") => EncryptionAlgorithm::AesGcm,
+            _ => {
                 crate::common::log::warn!("no AEAD encryption algorithm is available, using INSECURE XOR");
                 EncryptionAlgorithm::Xor
             }

--- a/easytier/src/common/log.rs
+++ b/easytier/src/common/log.rs
@@ -3,7 +3,6 @@ use crate::common::get_logger_timer_rfc3339;
 use crate::common::tracing_rolling_appender::{FileAppenderWrapper, RollingFileAppenderBase};
 use crate::rpc_service::logger::{CURRENT_LOG_LEVEL, LOGGER_LEVEL_SENDER};
 use anyhow::Context;
-use cfg_if::cfg_if;
 use paste::paste;
 use std::io::IsTerminal;
 use tracing::level_filters::LevelFilter;
@@ -121,14 +120,13 @@ fn console_layers(default_level: Option<LevelFilter>) -> anyhow::Result<Vec<BoxL
     let (console_filter, _) =
         tracing_subscriber::reload::Layer::new(parse_env_filter(default_level)?);
 
-    cfg_if! {
-        if #[cfg(test)] {
+    let (stdout, stderr) = cfg_select! {
+        test => {{
             let w = tracing_subscriber::fmt::TestWriter::new;
-            let (stdout, stderr) = (w, w);
-        } else {
-            let (stdout, stderr) = (std::io::stdout, std::io::stderr);
-        }
-    }
+            (w, w)
+        }}
+        _ => (std::io::stdout, std::io::stderr),
+    };
 
     let ansi = std::io::stderr().is_terminal() || cfg!(test);
 

--- a/easytier/src/common/stun.rs
+++ b/easytier/src/common/stun.rs
@@ -239,15 +239,11 @@ impl StunClient {
         let mut mapped_addr = None;
         for x in msg.attributes() {
             match x {
-                Attribute::MappedAddress(addr) => {
-                    if mapped_addr.is_none() {
-                        let _ = mapped_addr.insert(addr.address());
-                    }
+                Attribute::MappedAddress(addr) if mapped_addr.is_none() => {
+                    let _ = mapped_addr.insert(addr.address());
                 }
-                Attribute::XorMappedAddress(addr) => {
-                    if mapped_addr.is_none() {
-                        let _ = mapped_addr.insert(addr.address());
-                    }
+                Attribute::XorMappedAddress(addr) if mapped_addr.is_none() => {
+                    let _ = mapped_addr.insert(addr.address());
                 }
                 _ => {}
             }
@@ -259,15 +255,11 @@ impl StunClient {
         let mut changed_addr = None;
         for x in msg.attributes() {
             match x {
-                Attribute::OtherAddress(m) => {
-                    if changed_addr.is_none() {
-                        let _ = changed_addr.insert(m.address());
-                    }
+                Attribute::OtherAddress(m) if changed_addr.is_none() => {
+                    let _ = changed_addr.insert(m.address());
                 }
-                Attribute::ChangedAddress(m) => {
-                    if changed_addr.is_none() {
-                        let _ = changed_addr.insert(m.address());
-                    }
+                Attribute::ChangedAddress(m) if changed_addr.is_none() => {
+                    let _ = changed_addr.insert(m.address());
                 }
                 _ => {}
             }
@@ -714,15 +706,11 @@ impl TcpStunClient {
         let mut mapped_addr = None;
         for x in msg.attributes() {
             match x {
-                Attribute::MappedAddress(addr) => {
-                    if mapped_addr.is_none() {
-                        let _ = mapped_addr.insert(addr.address());
-                    }
+                Attribute::MappedAddress(addr) if mapped_addr.is_none() => {
+                    let _ = mapped_addr.insert(addr.address());
                 }
-                Attribute::XorMappedAddress(addr) => {
-                    if mapped_addr.is_none() {
-                        let _ = mapped_addr.insert(addr.address());
-                    }
+                Attribute::XorMappedAddress(addr) if mapped_addr.is_none() => {
+                    let _ = mapped_addr.insert(addr.address());
                 }
                 _ => {}
             }

--- a/easytier/src/peers/encrypt/mod.rs
+++ b/easytier/src/peers/encrypt/mod.rs
@@ -62,9 +62,6 @@ pub fn create_encryptor(
     key_128: [u8; 16],
     #[allow(unused_variables)] key_256: [u8; 32],
 ) -> Arc<dyn Encryptor> {
-    #[cfg(any(feature = "aes-gcm", feature = "wireguard", feature = "openssl-crypto"))]
-    use cfg_if::cfg_if;
-
     let algorithm = match EncryptionAlgorithm::try_from(algorithm) {
         Ok(algorithm) => algorithm,
         Err(_) => {
@@ -83,44 +80,27 @@ pub fn create_encryptor(
 
         #[cfg(any(feature = "aes-gcm", feature = "wireguard", feature = "openssl-crypto"))]
         EncryptionAlgorithm::AesGcm => {
-            cfg_if! {
-                if #[cfg(feature = "openssl-crypto")] {
-                    Arc::new(openssl::OpenSslCipher::new_aes128_gcm(key_128))
-                } else if #[cfg(feature = "wireguard")] {
-                    Arc::new(ring::RingCipher::new_aes128_gcm(key_128))
-                } else if #[cfg(feature = "aes-gcm")] {
-                    Arc::new(aes_gcm::AesGcmCipher::new_128(key_128))
-                } else {
-                    compile_error!("unreachable!");
-                }
+            cfg_select! {
+                feature = "openssl-crypto" => Arc::new(openssl::OpenSslCipher::new_aes128_gcm(key_128)),
+                feature = "wireguard" => Arc::new(ring::RingCipher::new_aes128_gcm(key_128)),
+                feature = "aes-gcm" => Arc::new(aes_gcm::AesGcmCipher::new_128(key_128)),
             }
         }
 
         #[cfg(any(feature = "aes-gcm", feature = "wireguard", feature = "openssl-crypto"))]
         EncryptionAlgorithm::Aes256Gcm => {
-            cfg_if! {
-                if #[cfg(feature = "openssl-crypto")] {
-                    Arc::new(openssl::OpenSslCipher::new_aes256_gcm(key_256))
-                } else if #[cfg(feature = "wireguard")] {
-                    Arc::new(ring::RingCipher::new_aes256_gcm(key_256))
-                } else if #[cfg(feature = "aes-gcm")] {
-                    Arc::new(aes_gcm::AesGcmCipher::new_256(key_256))
-                } else {
-                    compile_error!("unreachable!");
-                }
+            cfg_select! {
+                feature = "openssl-crypto" => Arc::new(openssl::OpenSslCipher::new_aes256_gcm(key_256)),
+                feature = "wireguard" => Arc::new(ring::RingCipher::new_aes256_gcm(key_256)),
+                feature = "aes-gcm" => Arc::new(aes_gcm::AesGcmCipher::new_256(key_256)),
             }
         }
 
         #[cfg(any(feature = "wireguard", feature = "openssl-crypto"))]
         EncryptionAlgorithm::ChaCha20 => {
-            cfg_if! {
-                if #[cfg(feature = "openssl-crypto")] {
-                    Arc::new(openssl::OpenSslCipher::new_chacha20(key_256))
-                } else if #[cfg(feature = "wireguard")] {
-                    Arc::new(ring::RingCipher::new_chacha20(key_256))
-                } else {
-                    compile_error!("unreachable!");
-                }
+            cfg_select! {
+                feature = "openssl-crypto" => Arc::new(openssl::OpenSslCipher::new_chacha20(key_256)),
+                feature = "wireguard" => Arc::new(ring::RingCipher::new_chacha20(key_256)),
             }
         }
     }

--- a/easytier/src/peers/peer_ospf_route.rs
+++ b/easytier/src/peers/peer_ospf_route.rs
@@ -4392,9 +4392,9 @@ mod tests {
 
         // find the smallest peer_id, which should be a center node
         let mut all_route = [r_a.clone(), r_b.clone(), r_c.clone(), r_d.clone()];
-        all_route.sort_by(|a, b| a.my_peer_id.cmp(&b.my_peer_id));
+        all_route.sort_by_key(|r| r.my_peer_id);
         let mut all_peer_mgr = [p_a.clone(), p_b.clone(), p_c.clone(), p_d.clone()];
-        all_peer_mgr.sort_by_key(|a| a.my_peer_id());
+        all_peer_mgr.sort_by_key(|p| p.my_peer_id());
 
         wait_for_condition(
             || async { all_route[0].service_impl.sessions.len() == 3 },

--- a/easytier/src/tunnel/fake_tcp/netfilter/mod.rs
+++ b/easytier/src/tunnel/fake_tcp/netfilter/mod.rs
@@ -2,8 +2,8 @@ pub mod pnet;
 
 use std::{io, net::SocketAddr, sync::Arc};
 
-cfg_if::cfg_if! {
-    if #[cfg(target_os = "linux")] {
+cfg_select! {
+    target_os = "linux" => {
         pub mod linux_bpf;
 
         pub fn create_tun(
@@ -26,7 +26,9 @@ cfg_if::cfg_if! {
                 }
             }
         }
-    } else if #[cfg(all(target_os = "macos", not(feature = "macos-ne")))] {
+    }
+
+    all(target_os = "macos", not(feature = "macos-ne")) => {
         pub mod macos_bpf;
 
         pub fn create_tun(
@@ -49,7 +51,9 @@ cfg_if::cfg_if! {
                 }
             }
         }
-    } else if #[cfg(all(windows, any(target_arch = "x86_64", target_arch = "x86")))] {
+    }
+
+    all(windows, any(target_arch = "x86_64", target_arch = "x86")) => {
         pub mod windivert;
 
         pub fn create_tun(
@@ -72,7 +76,9 @@ cfg_if::cfg_if! {
                 }
             }
         }
-    } else {
+    }
+
+    _ => {
         pub fn create_tun(
             interface_name: &str,
             src_addr: Option<SocketAddr>,

--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770174315,
-        "narHash": "sha256-GUaMxDmJB1UULsIYpHtfblskVC6zymAaQ/Zqfo+13jc=",
+        "lastModified": 1776395632,
+        "narHash": "sha256-Mi1uF5f2FsdBIvy+v7MtsqxD3Xjhd0ARJdwoqqqPtJo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "095c394bb91342882f27f6c73f64064fb9de9f2a",
+        "rev": "8087ff1f47fff983a1fba70fa88b759f2fd8ae97",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -29,15 +29,15 @@
             allowUnfree = true;
           };
         };
-        rustVersion = "1.95.0";
         makeRust =
           features:
           let
             rustTarget = pkgs.stdenv.hostPlatform.config;
             muslTarget = pkgs.lib.replaceStrings [ "gnu" ] [ "musl" ] rustTarget;
             muslTargets = if pkgs.stdenv.isLinux then [ muslTarget ] else [ ];
+            toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
           in
-          pkgs.rust-bin.stable.${rustVersion}.default.override {
+          toolchain.override {
             extensions = [
               "rust-src"
               "rust-analyzer"

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
             allowUnfree = true;
           };
         };
-        rustVersion = "1.93.0";
+        rustVersion = "1.95.0";
         makeRust =
           features:
           let

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95"
+profile = "minimal"


### PR DESCRIPTION
- replace cfg_if with cfg_select
- resolve clippy warnings
- pin Rust version of workspace & CI to 1.95

注意 `rust-toolchain.toml` 的存在会导致 Cargo 在这个目录下默认使用 `1.95`