### PR TITLE
fix(UrlInput): update parseUrl and buildUrlValue to handle null ports…

### DIFF
--- a/easytier-web/frontend-lib/src/components/UrlInput.vue
+++ b/easytier-web/frontend-lib/src/components/UrlInput.vue
@@ -32,7 +32,7 @@ onMounted(() => {
     }
 })
 
-const parseUrl = (val: string | null | undefined) => {
+const parseUrl = (val: string | null | undefined): { proto: string; host: string; port: number | null } => {
     const getValidPort = (portStr: string, proto: string) => {
         const p = parseInt(portStr)
         return isNaN(p) ? (props.protos[proto] ?? 11010) : p
@@ -55,13 +55,16 @@ const parseUrl = (val: string | null | undefined) => {
             if (ipv6End > 0) {
                 const host = hostAndMaybePort.slice(0, ipv6End + 1)
                 const remain = hostAndMaybePort.slice(ipv6End + 1)
-                const port = remain.startsWith(':') ? getValidPort(remain.slice(1), proto) : (props.protos[proto] ?? 11010)
+                // null = no explicit port in URL; do not fabricate a default
+                const port: number | null = remain.startsWith(':') ? getValidPort(remain.slice(1), proto) : null
                 return { proto, host, port }
             }
         }
         const portMatch = hostAndMaybePort.match(/^(.*):(\d+)$/)
         const host = portMatch ? portMatch[1] : hostAndMaybePort
-        const port = portMatch ? parseInt(portMatch[2]) : (props.protos[proto] ?? 11010)
+        // null = no explicit port in URL; buildUrlValue will omit the port entirely,
+        // preserving the protocol's implied standard port (e.g. 443 for wss://).
+        const port: number | null = portMatch ? parseInt(portMatch[2]) : null
         return { proto, host, port }
     }
 
@@ -72,28 +75,26 @@ const parseUrl = (val: string | null | undefined) => {
     if (parsedByPattern) {
         return parsedByPattern
     }
-    return { proto: 'tcp', host: '', port: 11010 }
+    return { proto: 'tcp', host: '', port: null }
 }
 
 const internalValue = ref(parseUrl(url.value))
 const defaultHost = '0.0.0.0'
 
-const buildUrlValue = (value: { proto: string, host: string, port: number }, forceDefaultHost = false) => {
+const buildUrlValue = (value: { proto: string, host: string, port: number | null }, forceDefaultHost = false) => {
     const proto = value.proto || 'tcp'
     const rawHost = (value.host ?? '').trim()
     const host = rawHost || (forceDefaultHost ? defaultHost : '')
     if (!host) {
         return null
     }
-    let port = value.port
-    if (isNaN(parseInt(port as any))) {
-        port = props.protos[proto] ?? 11010
-    }
-
-    if (props.protos[proto] === 0) {
+    // Omit port when the protocol uses no port (protos value = 0), or when the
+    // original URL had no explicit port (port === null) – avoids overwriting an
+    // implicit standard port (e.g. 443 for wss) with an EasyTier default (11012).
+    if (props.protos[proto] === 0 || value.port === null) {
         return `${proto}://${host}`
     }
-    return `${proto}://${host}:${port}`
+    return `${proto}://${host}:${value.port}`
 }
 
 const syncUrlFromInternal = (forceDefaultHost = false) => {
@@ -180,6 +181,7 @@ const onProtoChange = (newProto: string) => {
                     <span style="font-weight: bold">:</span>
                 </InputGroupAddon>
                 <InputNumber v-model="internalValue.port" :format="false" :min="1" :max="65535" class="max-w-24"
+                    :placeholder="String(protos[internalValue.proto] ?? 11010)"
                     fluid />
             </template>
             <slot name="actions"></slot>
@@ -207,7 +209,8 @@ const onProtoChange = (newProto: string) => {
                 </div>
                 <div v-if="!isNoPortProto" class="flex flex-col gap-2">
                     <label>{{ t('port') }}</label>
-                    <InputNumber v-model="internalValue.port" :format="false" :min="1" :max="65535" class="w-full" />
+                    <InputNumber v-model="internalValue.port" :format="false" :min="1" :max="65535" class="w-full"
+                        :placeholder="String(protos[internalValue.proto] ?? 11010)" />
                 </div>
             </div>
             <template #footer>


### PR DESCRIPTION
This pull request refines how the `UrlInput` Vue component handles the port portion of URLs, ensuring that the port is only included in the URL if it was explicitly specified by the user. This prevents the component from automatically inserting a default port where the protocol’s standard port should be implied, improving accuracy and user experience.

**URL parsing and construction improvements:**

* Updated `parseUrl` to return `port: null` when no explicit port is present in the input, instead of fabricating a default port. This change ensures that the component distinguishes between an absent port and a user-specified one. [[1]](diffhunk://#diff-bfbbf4b8aaf50be245b06af87d016c65e15ca4a8da266243b1e9e8f36d94db4bL35-R35) [[2]](diffhunk://#diff-bfbbf4b8aaf50be245b06af87d016c65e15ca4a8da266243b1e9e8f36d94db4bL58-R67) [[3]](diffhunk://#diff-bfbbf4b8aaf50be245b06af87d016c65e15ca4a8da266243b1e9e8f36d94db4bL75-R97)
* Modified `buildUrlValue` to omit the port from the constructed URL when `port` is `null` or when the protocol does not use a port, preserving standard protocol behavior (e.g., omitting `:443` for `wss://`).

**User interface enhancements:**

* Added a `placeholder` to the port input fields, showing the default port for the selected protocol to guide the user, without automatically populating the value. [[1]](diffhunk://#diff-bfbbf4b8aaf50be245b06af87d016c65e15ca4a8da266243b1e9e8f36d94db4bR184) [[2]](diffhunk://#diff-bfbbf4b8aaf50be245b06af87d016c65e15ca4a8da266243b1e9e8f36d94db4bL210-R213)

## 现有问题
- 当配置文件中的peer填写的是类似 wss://example.com 这种默认使用443端口进行连接的配置时，在GUI中打开编辑网络，节点的端口会被填充成11012,导致保存时，peer变成了 wss://example.com:11012