### PR TITLE
fix(peer_route): exclude local peer's own proxy CIDRs from system route installation

### DIFF
--- a/easytier/src/peers/peer_ospf_route.rs
+++ b/easytier/src/peers/peer_ospf_route.rs
@@ -3564,21 +3564,25 @@ impl Route for PeerRoute {
     }
 
     async fn list_proxy_cidrs(&self) -> BTreeSet<Ipv4Cidr> {
+        let my_peer_id = self.my_peer_id;
         self.service_impl
             .route_table
             .cidr_peer_id_map
             .load()
             .iter()
+            .filter(|(_, pv)| pv.peer_id != my_peer_id)
             .map(|(cidr, _)| *cidr)
             .collect()
     }
 
     async fn list_proxy_cidrs_v6(&self) -> BTreeSet<Ipv6Cidr> {
+        let my_peer_id = self.my_peer_id;
         self.service_impl
             .route_table
             .cidr_v6_peer_id_map
             .load()
             .iter()
+            .filter(|(_, pv)| pv.peer_id != my_peer_id)
             .map(|(cidr, _)| *cidr)
             .collect()
     }


### PR DESCRIPTION
## Problem

After commit ec7ddd3 (#2079), a node that declares a `proxy_network` (e.g. `192.168.0.0/24`) loses direct access to that subnet on its own machine.

### Root cause

`ec7ddd3` refactored `ProxyCidrsMonitor` to collect proxy CIDRs via the new `list_proxy_cidrs()` helper instead of the old `list_routes()` call.

The old `list_routes()` explicitly skipped `my_peer_id`:

```rust
// peer_ospf_route.rs – list_routes()
for item in route_table.peer_infos.iter() {
    if *item.key() == self.my_peer_id {
        continue; // local node's own CIDRs were excluded
    }
    ...
}
```

The new `list_proxy_cidrs()` read directly from `cidr_peer_id_map` without any filtering, so **the local node's own proxy CIDRs were included**.

`ProxyCidrsMonitor` then wrote those CIDRs as system routes into the TUN interface:

```
192.168.0.0/24 dev tun0 proto static metric 65535
```

Even though the metric is higher than a regular connected route, a `/24` is more specific than the `default` route and wins, so all traffic from the node to `192.168.0.x` gets trapped in tun0. The node itself is the subnet proxy, so there is no upstream peer to forward to — packets are dropped.

## Fix

Filter out entries where `peer_id == my_peer_id` in both `list_proxy_cidrs()` and `list_proxy_cidrs_v6()`, restoring the original semantics: a node does not install system routes for its own advertised proxy CIDRs.

```rust
// Before
.map(|(cidr, _)| *cidr)
.collect()

// After
.filter(|(_, pv)| pv.peer_id != my_peer_id)
.map(|(cidr, _)| *cidr)
.collect()
```

Other VPN peers are unaffected — they never have the local node's `my_peer_id`, so their routes continue to be installed normally.

## How to reproduce

1. Run EasyTier on machine A with `[[proxy_network]] cidr = "192.168.0.0/24"` where `192.168.0.x` hosts are reachable via the physical NIC.
2. After startup, run `ip route get 192.168.0.1` — it incorrectly resolves to `dev tun0`.
3. `ping 192.168.0.1` fails from machine A.

With this fix, `ip route get 192.168.0.1` resolves via the physical gateway, and ping succeeds again.
