### PR TITLE
fix(quic): lower max_udp_payload_size to 1200

### DIFF
--- a/easytier/src/tunnel/quic.rs
+++ b/easytier/src/tunnel/quic.rs
@@ -52,7 +52,7 @@ pub fn client_config() -> ClientConfig {
 
 pub fn endpoint_config() -> EndpointConfig {
     let mut config = EndpointConfig::default();
-    config.max_udp_payload_size(65527).unwrap();
+    config.max_udp_payload_size(1200).unwrap();
     config
 }
 //endregion


### PR DESCRIPTION
- closes https://github.com/EasyTier/EasyTier/issues/2154

max_udp_payload_size 过大时在使用 mimalloc 的目标上内存用量暴涨

开启 GSO/GRO 的情况下调整该设置值对性能影响不大
