### PR TITLE
fix: allow loopback to local virtual IP on self delivery

### DIFF
--- a/easytier/src/peers/peer_manager.rs
+++ b/easytier/src/peers/peer_manager.rs
@@ -1657,8 +1657,12 @@ impl PeerManager {
 
             #[cfg(not(target_env = "ohos"))]
             {
-                if not_send_to_self && *peer_id == self.my_peer_id {
-                    // the packet may be sent to vpn portal, so we just set flags instead of drop it
+                if not_send_to_self
+                    && *peer_id == self.my_peer_id
+                    && !self.global_ctx.is_ip_local_virtual_ip(&ip_addr)
+                {
+                    // Keep the loop-prevention flags for proxy-induced self-delivery where
+                    // the destination is not this node's own virtual IP.
                     hdr.set_not_send_to_tun(true);
                     hdr.set_no_proxy(true);
                 }

--- a/easytier/src/tests/three_node.rs
+++ b/easytier/src/tests/three_node.rs
@@ -477,6 +477,26 @@ pub async fn basic_three_node_test(
 
 #[tokio::test]
 #[serial_test::serial]
+pub async fn ping_own_virtual_ip_should_work() {
+    let insts = init_three_node("udp").await;
+
+    wait_for_condition(
+        || async { ping_test("net_a", "10.144.144.1", None).await },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    wait_for_condition(
+        || async { ping6_test("net_a", "fd00::1", None).await },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    drop_insts(insts).await;
+}
+
+#[tokio::test]
+#[serial_test::serial]
 pub async fn subnet_proxy_loop_prevention_test() {
     // 测试场景：inst1 和 inst2 都代理了 10.1.2.0/24 网段，
     // inst1 发起对 10.1.2.5 的 ping，不应该出现环路


### PR DESCRIPTION
## Summary
- allow self-delivery packets targeting the node's own virtual IP to return to TUN
- keep the existing subnet-proxy loop prevention for proxy-induced self-delivery
- add a regression test covering pinging the node's own virtual IPv4/IPv6

## Validation
- `cargo fmt --all`
- `cargo clippy -p easytier --all-targets -- -D warnings`
- `cargo test -p easytier ping_own_virtual_ip_should_work -- --nocapture` could not be completed in this environment because `ip netns` is unavailable

Fixes #2092