### PR TITLE
fix: prevent URL input layout flicker with container queries

### DIFF
--- a/easytier-web/frontend-lib/src/components/UrlInput.vue
+++ b/easytier-web/frontend-lib/src/components/UrlInput.vue
@@ -2,7 +2,7 @@
 import { AutoComplete, Button, Dialog, InputNumber, InputText } from 'primevue'
 import InputGroup from 'primevue/inputgroup'
 import InputGroupAddon from 'primevue/inputgroupaddon'
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const props = defineProps<{
@@ -13,24 +13,7 @@ const props = defineProps<{
 const { t } = useI18n()
 const url = defineModel<string>({ required: true })
 const editing = ref(false)
-const container = ref<HTMLElement | null>(null)
-const internalCompact = ref(false)
 const hostFocused = ref(false)
-
-onMounted(() => {
-    if (container.value) {
-        const observer = new ResizeObserver(entries => {
-            for (const entry of entries) {
-                internalCompact.value = entry.contentRect.width < 400
-            }
-        })
-        observer.observe(container.value)
-
-        onUnmounted(() => {
-            observer.disconnect()
-        })
-    }
-})
 
 const parseUrl = (val: string | null | undefined): { proto: string; host: string; port: number | null } => {
     const getValidPort = (portStr: string, proto: string) => {
@@ -169,28 +152,30 @@ const onProtoChange = (newProto: string) => {
 </script>
 
 <template>
-    <div ref="container" class="w-full">
-        <InputGroup v-if="!internalCompact" class="w-full">
+    <div class="url-input-container w-full min-w-0 overflow-hidden">
+        <InputGroup class="url-input-full w-full min-w-0">
             <AutoComplete :model-value="internalValue.proto" :suggestions="filteredProtos" dropdown
                 class="max-w-32 proto-autocomplete-in-group" @complete="searchProtos"
                 @update:model-value="onProtoChange" />
-            <InputText v-model="internalValue.host" :placeholder="placeholder || '0.0.0.0'" class="grow"
+            <InputText v-model="internalValue.host" :placeholder="placeholder || '0.0.0.0'" class="grow min-w-0"
                 @focus="onHostFocus" @blur="onHostBlur" />
             <template v-if="!isNoPortProto">
                 <InputGroupAddon>
                     <span style="font-weight: bold">:</span>
                 </InputGroupAddon>
                 <InputNumber v-model="internalValue.port" :format="false" :min="1" :max="65535" class="max-w-24"
-                    :placeholder="String(protos[internalValue.proto] ?? 11010)"
-                    fluid />
+                    :placeholder="String(protos[internalValue.proto] ?? 11010)" fluid />
             </template>
+            <!-- Rendered in both responsive branches; keep action slot content free of side effects and duplicate IDs. -->
             <slot name="actions"></slot>
         </InputGroup>
 
-        <div v-else class="flex justify-between items-center p-2 border rounded w-full">
-            <span class="truncate mr-2">{{ url }}</span>
-            <div class="flex items-center">
-                <Button icon="pi pi-pencil" class="p-button-sm p-button-text" @click="editing = true" />
+        <div
+            class="url-input-compact flex justify-between items-center p-2 border rounded w-full min-w-0 overflow-hidden">
+            <span class="truncate mr-2 min-w-0 flex-1 overflow-hidden">{{ url }}</span>
+            <div class="flex items-center shrink-0">
+                <Button icon="pi pi-pencil" class="p-button-sm p-button-text" :aria-label="t('web.common.edit')"
+                    @click="editing = true" />
                 <slot name="actions"></slot>
             </div>
         </div>
@@ -222,6 +207,28 @@ const onProtoChange = (newProto: string) => {
 </template>
 
 <style scoped>
+.url-input-container {
+    container-type: inline-size;
+}
+
+.url-input-full {
+    display: none;
+}
+
+.url-input-compact {
+    display: flex;
+}
+
+@container (min-width: 400px) {
+    .url-input-full {
+        display: flex;
+    }
+
+    .url-input-compact {
+        display: none;
+    }
+}
+
 .proto-autocomplete-in-group,
 .proto-autocomplete-in-group :deep(.p-autocomplete-input),
 .proto-autocomplete-in-group :deep(.p-autocomplete-dropdown) {


### PR DESCRIPTION
# 修复当主机名过长时，UrlInput反复闪烁的问题

## 摘要

- 将 `UrlInput` 原本基于 `ResizeObserver` 的响应式切换改为原生 CSS container query。
- 限制紧凑模式下 URL 文本的宽度，避免长主机名（包括中文域名）撑开页面并触发布局闪烁。
- 为紧凑模式下的图标编辑按钮补充明确的可访问性标签。
- close #2169

## 背景与原因

此前 `UrlInput` 会通过 `ResizeObserver` 测量自身宽度，并根据测量结果在完整输入模式和紧凑展示模式之间切换 Vue 分支。当长 URL 内容影响组件固有宽度且宽度接近断点时，组件可能反复触发“测量宽度 → 切换分支 → 布局变化 → 再次测量”的反馈循环，导致页面闪烁和横向溢出。

本次改为 CSS container query 后，响应式切换由浏览器布局系统根据容器宽度完成，不再依赖 JavaScript 测量和 Vue 分支重建，从而避免该反馈循环。

## 主要改动

- 移除 `UrlInput.vue` 中的 `ResizeObserver`、`internalCompact` 以及相关生命周期逻辑。
- 为 `UrlInput` 添加 container query 容器，默认使用紧凑模式，容器宽度达到 `400px` 后切换到完整输入模式。
- 增加 `min-w-0`、`overflow-hidden`、`truncate` 等约束，确保长 URL 在组件内部裁切，不再撑开外层布局。
- 为响应式双分支中的 `actions` slot 添加说明，避免后续插入带副作用或重复 DOM id 的内容。
- 为紧凑模式编辑按钮添加 `aria-label`，提升可访问性。

## 验证
- 在 `/#/config_generator` 页面使用长中文主机名进行浏览器手工验证：
  - `470px` 宽度：无横向溢出，采样期间 full/compact 显示状态无抖动。
  - `430px` 宽度：无横向溢出，采样期间 full/compact 显示状态无抖动。
<img width="495" height="701" alt="image" src="https://github.com/user-attachments/assets/b12b0a70-5db6-4405-aea9-b4900795e7ca" />
<img width="306" height="726" alt="image" src="https://github.com/user-attachments/assets/3331a235-8ff7-4546-843e-dc95c0854244" />

