### PR TITLE
feat(vpn-portal): multi-client WG portal with per-client NAT

### DIFF
--- a/easytier/src/common/config.rs
+++ b/easytier/src/common/config.rs
@@ -1,6 +1,6 @@
 use std::{
     hash::Hasher,
-    net::{IpAddr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, SocketAddr},
     path::PathBuf,
     sync::{Arc, Mutex},
 };
@@ -208,6 +208,10 @@ pub trait ConfigLoader: Send + Sync {
 
     fn get_vpn_portal_config(&self) -> Option<VpnPortalConfig>;
     fn set_vpn_portal_config(&self, config: VpnPortalConfig);
+
+    fn add_vpn_portal_client(&self, client: VpnPortalClientConfig) -> Result<(), anyhow::Error>;
+    fn remove_vpn_portal_client(&self, name: &str);
+    fn get_vpn_portal_clients(&self) -> Vec<VpnPortalClientConfig>;
 
     fn get_flags(&self) -> Flags;
     fn set_flags(&self, flags: Flags);
@@ -445,9 +449,21 @@ impl LoggingConfigLoader for &LoggingConfig {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct VpnPortalClientConfig {
+    pub name: String,
+    pub client_public_key: String, // base64 encoded x25519 public key
+    #[serde(default)]
+    pub assigned_ip: Option<Ipv4Addr>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct VpnPortalConfig {
     pub client_cidr: cidr::Ipv4Cidr,
     pub wireguard_listen: SocketAddr,
+    #[serde(default)]
+    pub wireguard_private_key: Option<String>, // base64 encoded. if None, derive from network identity for backward compat
+    #[serde(default)]
+    pub clients: Vec<VpnPortalClientConfig>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
@@ -891,6 +907,33 @@ impl ConfigLoader for TomlConfigLoader {
     }
     fn set_vpn_portal_config(&self, config: VpnPortalConfig) {
         self.config.lock().unwrap().vpn_portal_config = Some(config);
+    }
+
+    fn add_vpn_portal_client(&self, client: VpnPortalClientConfig) -> Result<(), anyhow::Error> {
+        let mut locked_config = self.config.lock().unwrap();
+        let portal = locked_config.vpn_portal_config.as_mut().ok_or_else(|| anyhow::anyhow!("vpn portal config is not set"))?;
+        if portal.clients.iter().any(|c| c.name == client.name) {
+            return Err(anyhow::anyhow!("vpn portal client with name '{}' already exists", client.name));
+        }
+        portal.clients.push(client);
+        Ok(())
+    }
+
+    fn remove_vpn_portal_client(&self, name: &str) {
+        let mut locked_config = self.config.lock().unwrap();
+        if let Some(portal) = locked_config.vpn_portal_config.as_mut() {
+            portal.clients.retain(|c| c.name != name);
+        }
+    }
+
+    fn get_vpn_portal_clients(&self) -> Vec<VpnPortalClientConfig> {
+        self.config
+            .lock()
+            .unwrap()
+            .vpn_portal_config
+            .as_ref()
+            .map(|p| p.clients.clone())
+            .unwrap_or_default()
     }
 
     fn get_flags(&self) -> Flags {

--- a/easytier/src/common/config.rs
+++ b/easytier/src/common/config.rs
@@ -454,6 +454,8 @@ pub struct VpnPortalClientConfig {
     pub client_public_key: String, // base64 encoded x25519 public key
     #[serde(default)]
     pub assigned_ip: Option<Ipv4Addr>,
+    #[serde(default)]
+    pub tunnel_ip: Option<Ipv4Addr>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
@@ -911,9 +913,15 @@ impl ConfigLoader for TomlConfigLoader {
 
     fn add_vpn_portal_client(&self, client: VpnPortalClientConfig) -> Result<(), anyhow::Error> {
         let mut locked_config = self.config.lock().unwrap();
-        let portal = locked_config.vpn_portal_config.as_mut().ok_or_else(|| anyhow::anyhow!("vpn portal config is not set"))?;
+        let portal = locked_config
+            .vpn_portal_config
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("vpn portal config is not set"))?;
         if portal.clients.iter().any(|c| c.name == client.name) {
-            return Err(anyhow::anyhow!("vpn portal client with name '{}' already exists", client.name));
+            return Err(anyhow::anyhow!(
+                "vpn portal client with name '{}' already exists",
+                client.name
+            ));
         }
         portal.clients.push(client);
         Ok(())

--- a/easytier/src/common/mod.rs
+++ b/easytier/src/common/mod.rs
@@ -24,6 +24,7 @@ pub mod log;
 pub mod netns;
 pub mod network;
 pub mod os_info;
+pub mod packet_checksum;
 pub mod stats_manager;
 pub mod stun;
 pub mod stun_codec_ext;

--- a/easytier/src/common/packet_checksum.rs
+++ b/easytier/src/common/packet_checksum.rs
@@ -1,0 +1,45 @@
+use std::net::Ipv4Addr;
+
+use pnet::packet::{
+    ipv4::{self, MutableIpv4Packet},
+    tcp::{self, MutableTcpPacket},
+    udp::{self, MutableUdpPacket},
+};
+
+pub fn update_ip_packet_checksum(ip_packet: &mut MutableIpv4Packet) {
+    ip_packet.set_checksum(ipv4::checksum(&ip_packet.to_immutable()));
+}
+
+pub fn update_tcp_packet_checksum(
+    tcp_packet: &mut MutableTcpPacket,
+    ipv4_src: &Ipv4Addr,
+    ipv4_dst: &Ipv4Addr,
+) {
+    tcp_packet.set_checksum(tcp::ipv4_checksum(
+        &tcp_packet.to_immutable(),
+        ipv4_src,
+        ipv4_dst,
+    ));
+}
+
+pub fn update_udp_packet_checksum(
+    udp_packet: &mut MutableUdpPacket,
+    ipv4_src: &Ipv4Addr,
+    ipv4_dst: &Ipv4Addr,
+) {
+    udp_packet.set_checksum(udp::ipv4_checksum(
+        &udp_packet.to_immutable(),
+        ipv4_src,
+        ipv4_dst,
+    ));
+}
+
+pub fn update_udp_packet_checksum_if_present(
+    udp_packet: &mut MutableUdpPacket,
+    ipv4_src: &Ipv4Addr,
+    ipv4_dst: &Ipv4Addr,
+) {
+    if udp_packet.get_checksum() != 0 {
+        update_udp_packet_checksum(udp_packet, ipv4_src, ipv4_dst);
+    }
+}

--- a/easytier/src/core.rs
+++ b/easytier/src/core.rs
@@ -985,6 +985,8 @@ impl NetworkOptions {
             cfg.set_vpn_portal_config(VpnPortalConfig {
                 wireguard_listen,
                 client_cidr,
+                wireguard_private_key: None,
+                clients: vec![],
             });
         }
 

--- a/easytier/src/gateway/tcp_proxy.rs
+++ b/easytier/src/gateway/tcp_proxy.rs
@@ -7,7 +7,7 @@ use pnet::packet::MutablePacket;
 use pnet::packet::Packet;
 use pnet::packet::ip::IpNextHeaderProtocols;
 use pnet::packet::ipv4::{Ipv4Packet, MutableIpv4Packet};
-use pnet::packet::tcp::{MutableTcpPacket, TcpPacket, ipv4_checksum};
+use pnet::packet::tcp::{MutableTcpPacket, TcpPacket};
 use socket2::{SockRef, TcpKeepalive};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::sync::atomic::{AtomicBool, AtomicU16};
@@ -24,6 +24,7 @@ use crate::common::error::Result;
 use crate::common::global_ctx::{ArcGlobalCtx, GlobalCtx};
 use crate::common::join_joinset_background;
 use crate::common::log;
+use crate::common::packet_checksum::{update_ip_packet_checksum, update_tcp_packet_checksum};
 use crate::common::stats_manager::{LabelSet, LabelType, MetricName};
 use crate::peers::peer_manager::PeerManager;
 use crate::peers::{NicPacketFilter, PeerPacketFilter};
@@ -429,9 +430,9 @@ impl<C: NatDstConnector> NicPacketFilter for TcpProxy<C> {
         let mut tcp_packet = MutableTcpPacket::new(ip_packet.payload_mut()).unwrap();
         tcp_packet.set_source(nat_entry.real_dst.port());
 
-        Self::update_tcp_packet_checksum(&mut tcp_packet, &ip, &dst);
+        update_tcp_packet_checksum(&mut tcp_packet, &ip, &dst);
         drop(tcp_packet);
-        Self::update_ip_packet_checksum(&mut ip_packet);
+        update_ip_packet_checksum(&mut ip_packet);
 
         tracing::trace!(dst_addr = ?dst_addr, nat_entry = ?nat_entry, packet = ?ip_packet, "tcp packet after modified");
 
@@ -473,22 +474,6 @@ impl<C: NatDstConnector> TcpProxy<C> {
 
     pub fn get_peer_manager(&self) -> Option<Arc<PeerManager>> {
         self.peer_manager.upgrade()
-    }
-
-    fn update_tcp_packet_checksum(
-        tcp_packet: &mut MutableTcpPacket,
-        ipv4_src: &Ipv4Addr,
-        ipv4_dst: &Ipv4Addr,
-    ) {
-        tcp_packet.set_checksum(ipv4_checksum(
-            &tcp_packet.to_immutable(),
-            ipv4_src,
-            ipv4_dst,
-        ));
-    }
-
-    fn update_ip_packet_checksum(ip_packet: &mut MutableIpv4Packet) {
-        ip_packet.set_checksum(pnet::packet::ipv4::checksum(&ip_packet.to_immutable()));
     }
 
     pub async fn start(self: &Arc<Self>, add_pipeline: bool) -> Result<()> {
@@ -976,9 +961,9 @@ impl<C: NatDstConnector> TcpProxy<C> {
         let mut tcp_packet = MutableTcpPacket::new(ip_packet.payload_mut()).unwrap();
         tcp_packet.set_destination(self.get_local_port());
 
-        Self::update_tcp_packet_checksum(&mut tcp_packet, &source, &ipv4_addr);
+        update_tcp_packet_checksum(&mut tcp_packet, &source, &ipv4_addr);
         drop(tcp_packet);
-        Self::update_ip_packet_checksum(&mut ip_packet);
+        update_ip_packet_checksum(&mut ip_packet);
 
         tracing::trace!(?source, ?ipv4_addr, ?packet, "tcp packet after modified");
 

--- a/easytier/src/launcher.rs
+++ b/easytier/src/launcher.rs
@@ -637,6 +637,8 @@ impl NetworkConfig {
                         self.vpn_portal_listen_port
                     )
                 })?,
+                wireguard_private_key: None,
+                clients: vec![],
             });
         }
 
@@ -1168,6 +1170,8 @@ mod tests {
                 config.set_vpn_portal_config(crate::common::config::VpnPortalConfig {
                     client_cidr: vpn_network.parse().unwrap(),
                     wireguard_listen: format!("0.0.0.0:{}", vpn_port).parse().unwrap(),
+                    wireguard_private_key: None,
+                    clients: vec![],
                 });
             }
 

--- a/easytier/src/peers/peer_manager.rs
+++ b/easytier/src/peers/peer_manager.rs
@@ -1404,6 +1404,27 @@ impl PeerManager {
         self.get_route().get_foreign_network_summary().await
     }
 
+    pub fn add_virtual_peer(&self, peer_id: PeerId, ipv4_addr: Ipv4Addr) -> bool {
+        match &self.route_algo_inst {
+            RouteAlgoInst::Ospf(route) => route.add_virtual_peer(peer_id, ipv4_addr),
+            RouteAlgoInst::None => false,
+        }
+    }
+
+    pub fn remove_virtual_peer(&self, peer_id: PeerId) {
+        match &self.route_algo_inst {
+            RouteAlgoInst::Ospf(route) => route.remove_virtual_peer(peer_id),
+            RouteAlgoInst::None => {}
+        }
+    }
+
+    pub fn refresh_virtual_peer(&self, peer_id: PeerId) -> bool {
+        match &self.route_algo_inst {
+            RouteAlgoInst::Ospf(route) => route.refresh_virtual_peer(peer_id),
+            RouteAlgoInst::None => false,
+        }
+    }
+
     async fn run_nic_packet_process_pipeline(&self, data: &mut ZCPacket) -> bool {
         // Enforce ACL for outbound (NIC-originated) packets. If ACL denies, stop processing.
         if !self.global_ctx.get_acl_filter().process_packet_with_acl(

--- a/easytier/src/peers/peer_manager.rs
+++ b/easytier/src/peers/peer_manager.rs
@@ -1001,7 +1001,9 @@ impl PeerManager {
                 let to_peer_id = hdr.to_peer_id.get();
                 let packet_type = hdr.packet_type;
                 let is_encrypted = hdr.is_encrypted();
-                if to_peer_id != my_peer_id {
+                let is_local_destination =
+                    to_peer_id == my_peer_id || route.is_local_virtual_peer(to_peer_id).await;
+                if !is_local_destination {
                     if disable_relay_data && is_relay_data_packet {
                         tracing::debug!(
                             ?from_peer_id,
@@ -1425,6 +1427,16 @@ impl PeerManager {
         }
     }
 
+    pub fn refresh_virtual_peers<I>(&self, peer_ids: I) -> bool
+    where
+        I: IntoIterator<Item = PeerId>,
+    {
+        match &self.route_algo_inst {
+            RouteAlgoInst::Ospf(route) => route.refresh_virtual_peers(peer_ids),
+            RouteAlgoInst::None => false,
+        }
+    }
+
     async fn run_nic_packet_process_pipeline(&self, data: &mut ZCPacket) -> bool {
         // Enforce ACL for outbound (NIC-originated) packets. If ACL denies, stop processing.
         if !self.global_ctx.get_acl_filter().process_packet_with_acl(
@@ -1524,6 +1536,8 @@ impl PeerManager {
         let msg_len = msg.buf_len() as u64;
         let send_result = if peers.has_peer(dst_peer_id) {
             peers.send_msg_directly(msg, dst_peer_id).await
+        } else if peers.is_local_virtual_peer(dst_peer_id).await {
+            peers.send_msg_directly(msg, peers.my_peer_id()).await
         } else if foreign_network_client.has_next_hop(dst_peer_id) {
             foreign_network_client.send_msg(msg, dst_peer_id).await
         } else if let Some(gateway) = peers.get_gateway_peer_id(dst_peer_id, policy.clone()).await {

--- a/easytier/src/peers/peer_map.rs
+++ b/easytier/src/peers/peer_map.rs
@@ -190,6 +190,16 @@ impl PeerMap {
         None
     }
 
+    pub async fn is_local_virtual_peer(&self, peer_id: PeerId) -> bool {
+        for route in self.routes.read().await.iter() {
+            if route.is_local_virtual_peer(peer_id).await {
+                return true;
+            }
+        }
+
+        false
+    }
+
     pub async fn list_peers_own_foreign_network(
         &self,
         network_identity: &NetworkIdentity,

--- a/easytier/src/peers/peer_ospf_route.rs
+++ b/easytier/src/peers/peer_ospf_route.rs
@@ -42,7 +42,7 @@ use crate::{
     peers::route_trait::{Route, RouteInterfaceBox},
     proto::{
         acl::GroupIdentity,
-        common::{Ipv4Inet, NatType, StunInfo},
+        common::{Ipv4Inet, NatType, StunInfo, is_virtual_peer_id},
         peer_rpc::{
             ForeignNetworkRouteInfoEntry, ForeignNetworkRouteInfoKey, OspfRouteRpc,
             OspfRouteRpcClientFactory, OspfRouteRpcServer, PeerGroupInfo, PeerIdVersion,
@@ -146,7 +146,8 @@ fn route_peer_inst_id(info: &RoutePeerInfo) -> Option<uuid::Uuid> {
 }
 
 fn is_virtual_peer_info(peer_id: PeerId, info: &RoutePeerInfo) -> bool {
-    info.peer_id == peer_id
+    is_virtual_peer_id(peer_id)
+        && info.peer_id == peer_id
         && info.version > 0
         && info.peer_route_id == 0
         && info.feature_flag.is_none()
@@ -314,6 +315,14 @@ impl RoutePeerInfo {
         }
     }
 
+    fn new_virtual_peer(peer_id: PeerId, ipv4_addr: Ipv4Addr) -> Self {
+        let mut info = Self::new();
+        info.peer_id = peer_id;
+        info.ipv4_addr = Some(ipv4_addr.into());
+        info.network_length = 32;
+        info
+    }
+
     /// Attempts to update the `new` RoutePeerInfo based on the `old` RoutePeerInfo.
     ///
     /// An update is triggered if any fields in `new` differ from `old`, or if the time since
@@ -429,6 +438,52 @@ impl Default for RouteConnInfo {
             version: AtomicVersion::new(),
             last_update: SystemTime::now(),
         }
+    }
+}
+
+impl RouteConnInfo {
+    fn new(connected_peers: BTreeSet<PeerId>, version: Version, last_update: SystemTime) -> Self {
+        Self {
+            connected_peers,
+            version: version.into(),
+            last_update,
+        }
+    }
+
+    fn update_connected_peers(
+        &mut self,
+        connected_peers: BTreeSet<PeerId>,
+        last_update: SystemTime,
+    ) -> bool {
+        if self.connected_peers == connected_peers {
+            self.last_update = last_update;
+            return false;
+        }
+
+        self.connected_peers = connected_peers;
+        self.version.inc();
+        self.last_update = last_update;
+        true
+    }
+
+    fn ensure_connected_peer(&mut self, peer_id: PeerId, last_update: SystemTime) -> bool {
+        if !self.connected_peers.insert(peer_id) {
+            return false;
+        }
+
+        self.version.inc();
+        self.last_update = last_update;
+        true
+    }
+
+    fn remove_connected_peer(&mut self, peer_id: PeerId, last_update: SystemTime) -> bool {
+        if !self.connected_peers.remove(&peer_id) {
+            return false;
+        }
+
+        self.version.inc();
+        self.last_update = last_update;
+        true
     }
 }
 
@@ -1093,6 +1148,125 @@ impl SyncedRouteInfo {
         } else {
             false
         }
+    }
+
+    fn update_virtual_peer_info(&self, peer_id: PeerId, ipv4_addr: Ipv4Addr) -> bool {
+        if !is_virtual_peer_id(peer_id) {
+            return false;
+        }
+
+        let now = SystemTime::now();
+        let mut new = RoutePeerInfo::new_virtual_peer(peer_id, ipv4_addr);
+        let mut guard = self.peer_infos.write();
+        let old = guard.get(&peer_id).cloned();
+        let new_version = old.as_ref().map(|x| x.version).unwrap_or(0) + 1;
+        let need_insert_new = if let Some(old) = old.as_ref() {
+            if !is_virtual_peer_info(peer_id, old) {
+                return false;
+            }
+            RoutePeerInfo::try_update_new_peer_info(old, &mut new)
+        } else {
+            true
+        };
+
+        if need_insert_new {
+            new.last_update = Some(now.into());
+            new.version = new_version;
+            guard.insert(peer_id, new);
+            drop(guard);
+            self.version.inc();
+            true
+        } else {
+            if let Some(info) = guard.get_mut(&peer_id) {
+                info.last_update = Some(now.into());
+            }
+            false
+        }
+    }
+
+    fn refresh_virtual_peer_infos<I>(&self, peer_ids: I) -> (Vec<PeerId>, bool)
+    where
+        I: IntoIterator<Item = PeerId>,
+    {
+        let now = SystemTime::now();
+        let mut refreshed_peer_ids = Vec::new();
+        let mut peer_info_changed = false;
+        let mut guard = self.peer_infos.write();
+
+        for peer_id in BTreeSet::from_iter(peer_ids) {
+            let Some(old) = guard.get(&peer_id).cloned() else {
+                continue;
+            };
+            if !is_virtual_peer_info(peer_id, &old) {
+                continue;
+            }
+
+            let Some(ipv4_addr) = old.ipv4_addr.map(Into::into) else {
+                continue;
+            };
+            let mut new = RoutePeerInfo::new_virtual_peer(peer_id, ipv4_addr);
+            if RoutePeerInfo::try_update_new_peer_info(&old, &mut new) {
+                new.last_update = Some(now.into());
+                new.version = old.version + 1;
+                guard.insert(peer_id, new);
+                peer_info_changed = true;
+            } else if let Some(info) = guard.get_mut(&peer_id) {
+                info.last_update = Some(now.into());
+            }
+            refreshed_peer_ids.push(peer_id);
+        }
+        drop(guard);
+
+        if peer_info_changed {
+            self.version.inc();
+        }
+        (refreshed_peer_ids, peer_info_changed)
+    }
+
+    fn ensure_conn_edge(
+        conn_map: &mut OrderedHashMap<PeerId, RouteConnInfo>,
+        peer_id: PeerId,
+        connected_peer_id: PeerId,
+        now: SystemTime,
+    ) -> bool {
+        if let Some(conn) = conn_map.get_mut(&peer_id) {
+            return conn.ensure_connected_peer(connected_peer_id, now);
+        }
+
+        conn_map.insert(
+            peer_id,
+            RouteConnInfo::new(BTreeSet::from([connected_peer_id]), 1, now),
+        );
+        true
+    }
+
+    fn refresh_virtual_peer_conns<I>(&self, my_peer_id: PeerId, peer_ids: I) -> bool
+    where
+        I: IntoIterator<Item = PeerId>,
+    {
+        let now = SystemTime::now();
+        let mut route_changed = false;
+        let expected_connected_peers = BTreeSet::from([my_peer_id]);
+        let mut guard = self.conn_map.write();
+
+        for peer_id in peer_ids {
+            if let Some(conn) = guard.get_mut(&peer_id) {
+                route_changed |= conn.update_connected_peers(expected_connected_peers.clone(), now);
+            } else {
+                guard.insert(
+                    peer_id,
+                    RouteConnInfo::new(expected_connected_peers.clone(), 1, now),
+                );
+                route_changed = true;
+            }
+            route_changed |= Self::ensure_conn_edge(&mut guard, my_peer_id, peer_id, now);
+        }
+        drop(guard);
+
+        if route_changed {
+            self.version.inc();
+        }
+        route_changed
     }
 
     fn update_my_foreign_network(
@@ -4202,64 +4376,19 @@ impl Route for PeerRoute {
 }
 
 impl PeerRoute {
-    fn ensure_portal_to_virtual_edge(
-        conn_map: &mut OrderedHashMap<PeerId, RouteConnInfo>,
-        portal_peer_id: PeerId,
-        virtual_peer_id: PeerId,
-        now: SystemTime,
-    ) -> bool {
-        if let Some(conn) = conn_map.get_mut(&portal_peer_id) {
-            if conn.connected_peers.insert(virtual_peer_id) {
-                let new_version = conn.version.inc();
-                conn.version.set(new_version);
-                conn.last_update = now;
-                return true;
-            }
-            return false;
-        }
-
-        conn_map.insert(
-            portal_peer_id,
-            RouteConnInfo {
-                connected_peers: BTreeSet::from([virtual_peer_id]),
-                version: 1.into(),
-                last_update: now,
-            },
-        );
-        true
-    }
-
     pub fn add_virtual_peer(&self, peer_id: PeerId, ipv4_addr: Ipv4Addr) -> bool {
-        let mut info = RoutePeerInfo::new();
-        info.peer_id = peer_id;
-        info.ipv4_addr = Some(ipv4_addr.into());
-        info.network_length = 32;
+        let synced = &self.service_impl.synced_route_info;
+        synced.update_virtual_peer_info(peer_id, ipv4_addr);
+
         let now = SystemTime::now();
-        info.last_update = Some(now.into());
-        info.version = 1;
-
-        let mut guard = self.service_impl.synced_route_info.peer_infos.write();
-        let old = guard.get(&peer_id);
-        let new_version = old.map(|x| x.version).unwrap_or(0) + 1;
-        info.version = new_version;
-        guard.insert(peer_id, info);
-        drop(guard);
-
-        let mut guard = self.service_impl.synced_route_info.conn_map.write();
-        let mut connected_peers = BTreeSet::new();
-        connected_peers.insert(self.my_peer_id);
+        let mut guard = synced.conn_map.write();
         guard.insert(
             peer_id,
-            RouteConnInfo {
-                connected_peers,
-                version: new_version.into(),
-                last_update: now,
-            },
+            RouteConnInfo::new(BTreeSet::from([self.my_peer_id]), 1, now),
         );
-        Self::ensure_portal_to_virtual_edge(&mut guard, self.my_peer_id, peer_id, now);
+        SyncedRouteInfo::ensure_conn_edge(&mut guard, self.my_peer_id, peer_id, now);
         drop(guard);
 
-        self.service_impl.synced_route_info.version.inc();
         self.service_impl
             .update_route_table_and_cached_local_conn_bitmap();
         self.session_mgr.sync_now("add_virtual_peer");
@@ -4267,18 +4396,15 @@ impl PeerRoute {
     }
 
     pub fn remove_virtual_peer(&self, peer_id: PeerId) {
-        let mut removed_portal_edge = false;
-        {
+        let now = SystemTime::now();
+        let removed_portal_edge = {
             let mut guard = self.service_impl.synced_route_info.conn_map.write();
-            if let Some(conn) = guard.get_mut(&self.my_peer_id)
-                && conn.connected_peers.remove(&peer_id)
-            {
-                let new_version = conn.version.inc();
-                conn.version.set(new_version);
-                conn.last_update = SystemTime::now();
-                removed_portal_edge = true;
+            if let Some(conn) = guard.get_mut(&self.my_peer_id) {
+                conn.remove_connected_peer(peer_id, now)
+            } else {
+                false
             }
-        }
+        };
         if removed_portal_edge {
             self.service_impl.synced_route_info.version.inc();
         }
@@ -4296,53 +4422,16 @@ impl PeerRoute {
     where
         I: IntoIterator<Item = PeerId>,
     {
-        let now = SystemTime::now();
-        let mut existing_peer_ids = Vec::new();
-
-        let mut guard = self.service_impl.synced_route_info.peer_infos.write();
-        for peer_id in peer_ids {
-            let Some(info) = guard.get_mut(&peer_id) else {
-                continue;
-            };
-            info.last_update = Some(now.into());
-            existing_peer_ids.push(peer_id);
-        }
-        drop(guard);
+        let synced = &self.service_impl.synced_route_info;
+        let (existing_peer_ids, _peer_info_changed) = synced.refresh_virtual_peer_infos(peer_ids);
 
         if existing_peer_ids.is_empty() {
             return false;
         }
 
-        let mut guard = self.service_impl.synced_route_info.conn_map.write();
-        let mut route_changed = false;
-        let expected_connected_peers = BTreeSet::from([self.my_peer_id]);
-        for peer_id in existing_peer_ids {
-            if let Some(conn) = guard.get_mut(&peer_id) {
-                if conn.connected_peers != expected_connected_peers {
-                    conn.connected_peers = expected_connected_peers.clone();
-                    let new_version = conn.version.inc();
-                    conn.version.set(new_version);
-                    route_changed = true;
-                }
-                conn.last_update = now;
-            } else {
-                guard.insert(
-                    peer_id,
-                    RouteConnInfo {
-                        connected_peers: expected_connected_peers.clone(),
-                        version: 1.into(),
-                        last_update: now,
-                    },
-                );
-                route_changed = true;
-            }
-            route_changed |=
-                Self::ensure_portal_to_virtual_edge(&mut guard, self.my_peer_id, peer_id, now);
-        }
-        drop(guard);
+        let route_changed = synced.refresh_virtual_peer_conns(self.my_peer_id, existing_peer_ids);
 
         if route_changed {
-            self.service_impl.synced_route_info.version.inc();
             self.service_impl
                 .update_route_table_and_cached_local_conn_bitmap();
             self.session_mgr.sync_now("refresh_virtual_peers");

--- a/easytier/src/peers/peer_ospf_route.rs
+++ b/easytier/src/peers/peer_ospf_route.rs
@@ -145,6 +145,14 @@ fn route_peer_inst_id(info: &RoutePeerInfo) -> Option<uuid::Uuid> {
     info.inst_id.map(Into::into)
 }
 
+fn is_virtual_peer_info(peer_id: PeerId, info: &RoutePeerInfo) -> bool {
+    info.peer_id == peer_id
+        && info.version > 0
+        && info.peer_route_id == 0
+        && info.feature_flag.is_none()
+        && route_peer_inst_id(info).is_some_and(|inst_id| inst_id.is_nil())
+}
+
 #[derive(Debug, Clone)]
 struct AtomicVersion(Arc<AtomicU32>);
 
@@ -716,6 +724,25 @@ impl SyncedRouteInfo {
             .map(|x| x.connected_peers.iter().copied().collect())
     }
 
+    fn get_local_virtual_peers(&self, my_peer_id: PeerId) -> BTreeSet<PeerId> {
+        let peer_infos = self.peer_infos.read();
+        self.conn_map
+            .read()
+            .iter()
+            .filter_map(|(peer_id, conn_info)| {
+                if peer_infos
+                    .get(peer_id)
+                    .is_some_and(|info| is_virtual_peer_info(*peer_id, info))
+                    && conn_info.connected_peers.contains(&my_peer_id)
+                {
+                    Some(*peer_id)
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
     fn remove_peer(&self, peer_id: PeerId) {
         self.remove_peers([peer_id]);
     }
@@ -758,7 +785,7 @@ impl SyncedRouteInfo {
         self.version.inc();
     }
 
-    fn fill_empty_peer_info(&self, peer_ids: &BTreeSet<PeerId>) {
+    fn fill_empty_peer_info(&self, peer_ids: &BTreeSet<PeerId>) -> bool {
         let mut need_inc_version = false;
         for peer_id in peer_ids {
             let guard = self.peer_infos.upgradable_read();
@@ -784,6 +811,7 @@ impl SyncedRouteInfo {
         if need_inc_version {
             self.version.inc();
         }
+        need_inc_version
     }
 
     fn get_peer_info_version_with_default(&self, peer_id: PeerId) -> Version {
@@ -845,7 +873,7 @@ impl SyncedRouteInfo {
         dst_peer_id: PeerId,
         peer_infos: &[RoutePeerInfo],
         raw_peer_infos: &[DynamicMessage],
-    ) -> Result<(), Error> {
+    ) -> Result<bool, Error> {
         let mut need_inc_version = false;
         for (idx, route_info) in peer_infos.iter().enumerate() {
             let mut route_info = route_info.clone();
@@ -889,7 +917,7 @@ impl SyncedRouteInfo {
         if need_inc_version {
             self.version.inc();
         }
-        Ok(())
+        Ok(need_inc_version)
     }
 
     fn update_conn_info_one_peer(
@@ -916,22 +944,25 @@ impl SyncedRouteInfo {
         false
     }
 
-    fn update_conn_info_with_bitmap(&self, conn_bitmap: &RouteConnBitmap) {
-        self.fill_empty_peer_info(&conn_bitmap.peer_ids.iter().map(|x| x.peer_id).collect());
+    fn update_conn_info_with_bitmap(&self, conn_bitmap: &RouteConnBitmap) -> bool {
+        let mut changed =
+            self.fill_empty_peer_info(&conn_bitmap.peer_ids.iter().map(|x| x.peer_id).collect());
 
         let mut need_inc_version = false;
 
         for (peer_idx, peer_id_version) in conn_bitmap.peer_ids.iter().enumerate() {
             let connceted_peers = conn_bitmap.get_connected_peers(peer_idx);
-            self.fill_empty_peer_info(&connceted_peers);
+            changed |= self.fill_empty_peer_info(&connceted_peers);
             need_inc_version |= self.update_conn_info_one_peer(peer_id_version, connceted_peers);
         }
         if need_inc_version {
             self.version.inc();
         }
+        changed || need_inc_version
     }
 
-    fn update_conn_info_with_list(&self, conn_peer_list: &RouteConnPeerList) {
+    fn update_conn_info_with_list(&self, conn_peer_list: &RouteConnPeerList) -> bool {
+        let mut changed = false;
         let mut need_inc_version = false;
 
         for peer_conn_info in &conn_peer_list.peer_conn_infos {
@@ -941,21 +972,21 @@ impl SyncedRouteInfo {
             let connected_peers: BTreeSet<PeerId> =
                 peer_conn_info.connected_peer_ids.iter().copied().collect();
 
-            self.fill_empty_peer_info(&connected_peers);
+            changed |= self.fill_empty_peer_info(&BTreeSet::from([peer_id_version.peer_id]));
+            changed |= self.fill_empty_peer_info(&connected_peers);
             need_inc_version |= self.update_conn_info_one_peer(&peer_id_version, connected_peers);
         }
         if need_inc_version {
             self.version.inc();
         }
+        changed || need_inc_version
     }
 
-    fn update_conn_info(&self, conn_info: &ConnInfo) {
+    fn update_conn_info(&self, conn_info: &ConnInfo) -> bool {
         match conn_info {
-            ConnInfo::ConnBitmap(conn_bitmap) => {
-                self.update_conn_info_with_bitmap(conn_bitmap);
-            }
+            ConnInfo::ConnBitmap(conn_bitmap) => self.update_conn_info_with_bitmap(conn_bitmap),
             ConnInfo::ConnPeerList(conn_peer_list) => {
-                self.update_conn_info_with_list(conn_peer_list);
+                self.update_conn_info_with_list(conn_peer_list)
             }
         }
     }
@@ -1035,7 +1066,12 @@ impl SyncedRouteInfo {
         }
     }
 
-    fn update_my_conn_info(&self, my_peer_id: PeerId, connected_peers: BTreeSet<PeerId>) -> bool {
+    fn update_my_conn_info(
+        &self,
+        my_peer_id: PeerId,
+        mut connected_peers: BTreeSet<PeerId>,
+    ) -> bool {
+        connected_peers.extend(self.get_local_virtual_peers(my_peer_id));
         self.fill_empty_peer_info(&connected_peers);
 
         let guard = self.conn_map.upgradable_read();
@@ -2546,16 +2582,7 @@ impl PeerRouteServiceImpl {
         let mut route_infos = Vec::new();
         let peer_infos = self.synced_route_info.peer_infos.read();
         let mut unreachable_peers_for_peer_info = session.unreachable_peers_for_peer_info.lock();
-        let last_sync_succ_timestamp = session.last_sync_succ_timestamp.load();
         for (peer_id, peer_info) in peer_infos.iter().rev() {
-            // stop iter if last_update of peer info is older than session.last_sync_succ_timestamp
-            if let Some(last_update) = peer_info.last_update {
-                let last_update = TryInto::<SystemTime>::try_into(last_update).unwrap();
-                if last_sync_succ_timestamp.is_some_and(|t| last_update < t) {
-                    break;
-                }
-            }
-
             if session.check_saved_peer_info_update_to_date(peer_info.peer_id, peer_info.version) {
                 continue;
             }
@@ -2599,7 +2626,6 @@ impl PeerRouteServiceImpl {
         session: &SyncRouteSession,
         estimated_size: &mut usize,
     ) -> Option<RouteConnPeerList> {
-        let last_sync_succ_timestamp = session.last_sync_succ_timestamp.load();
         let mut peer_conn_infos = Vec::new();
         *estimated_size = 0;
 
@@ -2619,12 +2645,6 @@ impl PeerRouteServiceImpl {
         };
 
         for (peer_id, conn_info) in conn_map.iter().rev() {
-            // stop iter if last_update of conn info is older than session.last_sync_succ_timestamp
-            let last_update = TryInto::<SystemTime>::try_into(conn_info.last_update).unwrap();
-            if last_sync_succ_timestamp.is_some_and(|t| last_update < t) {
-                break;
-            }
-
             if session.check_saved_conn_version_update_to_date(*peer_id, conn_info.version.get()) {
                 continue;
             }
@@ -2870,7 +2890,7 @@ impl PeerRouteServiceImpl {
         let mut to_remove = Vec::new();
         for (peer_id, peer_info) in self.synced_route_info.peer_infos.read().iter() {
             if let Ok(d) = now.duration_since(peer_info.last_update.unwrap().try_into().unwrap())
-                && (d > REMOVE_DEAD_PEER_INFO_AFTER
+                && ((!is_virtual_peer_info(*peer_id, peer_info) && d > REMOVE_DEAD_PEER_INFO_AFTER)
                     || (d > REMOVE_UNREACHABLE_PEER_INFO_AFTER
                         && !self.route_table.peer_reachable(*peer_id)))
             {
@@ -3524,6 +3544,7 @@ impl RouteSessionManager {
         session.update_dst_session_id(from_session_id);
 
         let mut need_update_route_table = false;
+        let mut need_rebuild_route_table = false;
         let mut untrusted_peers = Vec::new();
 
         if let Some(peer_infos) = &peer_infos {
@@ -3549,22 +3570,25 @@ impl RouteSessionManager {
                     .get_network_identity()
                     .network_secret
                     .is_none();
-                service_impl.synced_route_info.update_peer_infos(
+                let peer_info_changed = service_impl.synced_route_info.update_peer_infos(
                     my_peer_id,
                     service_impl.my_peer_route_id,
                     from_peer_id,
                     pi,
                     rpi,
                 )?;
-                service_impl
-                    .synced_route_info
-                    .verify_and_update_group_trusts(
-                        pi,
-                        &service_impl.global_ctx.get_acl_group_declarations(),
-                        trust_admin_groups_without_proof,
-                    );
+                if peer_info_changed {
+                    service_impl
+                        .synced_route_info
+                        .verify_and_update_group_trusts(
+                            pi,
+                            &service_impl.global_ctx.get_acl_group_declarations(),
+                            trust_admin_groups_without_proof,
+                        );
+                }
                 session.update_dst_saved_peer_info_version(pi, from_peer_id);
-                need_update_route_table = true;
+                need_update_route_table |= peer_info_changed;
+                need_rebuild_route_table = true;
             }
         }
 
@@ -3573,9 +3597,10 @@ impl RouteSessionManager {
             let accept_conn_info =
                 !from_is_credential || credential_info.map(|tc| tc.allow_relay).unwrap_or(false);
             if accept_conn_info {
-                service_impl.synced_route_info.update_conn_info(conn_info);
+                let conn_info_changed = service_impl.synced_route_info.update_conn_info(conn_info);
                 session.update_dst_saved_conn_info_version(conn_info, from_peer_id);
-                need_update_route_table = true;
+                need_update_route_table |= conn_info_changed;
+                need_rebuild_route_table = true;
             }
         }
 
@@ -3594,7 +3619,7 @@ impl RouteSessionManager {
             }
         }
 
-        if need_update_route_table || foreign_network_changed {
+        if need_rebuild_route_table || foreign_network_changed {
             service_impl.update_route_table_and_cached_local_conn_bitmap();
             service_impl.update_foreign_network_owner_map();
             if need_update_route_table
@@ -3928,6 +3953,24 @@ impl Route for PeerRoute {
             .map(|x| x.next_hop_peer_id)
     }
 
+    async fn is_local_virtual_peer(&self, peer_id: PeerId) -> bool {
+        let peer_infos = self.service_impl.synced_route_info.peer_infos.read();
+        if !peer_infos
+            .get(&peer_id)
+            .is_some_and(|info| is_virtual_peer_info(peer_id, info))
+        {
+            return false;
+        }
+        drop(peer_infos);
+
+        self.service_impl
+            .synced_route_info
+            .conn_map
+            .read()
+            .get(&peer_id)
+            .is_some_and(|conn| conn.connected_peers.contains(&self.my_peer_id))
+    }
+
     async fn list_routes(&self) -> Vec<crate::proto::api::instance::Route> {
         let route_table = &self.service_impl.route_table;
         let route_table_with_cost = &self.service_impl.route_table_with_cost;
@@ -4159,12 +4202,40 @@ impl Route for PeerRoute {
 }
 
 impl PeerRoute {
+    fn ensure_portal_to_virtual_edge(
+        conn_map: &mut OrderedHashMap<PeerId, RouteConnInfo>,
+        portal_peer_id: PeerId,
+        virtual_peer_id: PeerId,
+        now: SystemTime,
+    ) -> bool {
+        if let Some(conn) = conn_map.get_mut(&portal_peer_id) {
+            if conn.connected_peers.insert(virtual_peer_id) {
+                let new_version = conn.version.inc();
+                conn.version.set(new_version);
+                conn.last_update = now;
+                return true;
+            }
+            return false;
+        }
+
+        conn_map.insert(
+            portal_peer_id,
+            RouteConnInfo {
+                connected_peers: BTreeSet::from([virtual_peer_id]),
+                version: 1.into(),
+                last_update: now,
+            },
+        );
+        true
+    }
+
     pub fn add_virtual_peer(&self, peer_id: PeerId, ipv4_addr: Ipv4Addr) -> bool {
         let mut info = RoutePeerInfo::new();
         info.peer_id = peer_id;
         info.ipv4_addr = Some(ipv4_addr.into());
         info.network_length = 32;
-        info.last_update = Some(SystemTime::now().into());
+        let now = SystemTime::now();
+        info.last_update = Some(now.into());
         info.version = 1;
 
         let mut guard = self.service_impl.synced_route_info.peer_infos.write();
@@ -4182,38 +4253,101 @@ impl PeerRoute {
             RouteConnInfo {
                 connected_peers,
                 version: new_version.into(),
-                last_update: SystemTime::now(),
+                last_update: now,
             },
         );
+        Self::ensure_portal_to_virtual_edge(&mut guard, self.my_peer_id, peer_id, now);
         drop(guard);
 
         self.service_impl.synced_route_info.version.inc();
+        self.service_impl
+            .update_route_table_and_cached_local_conn_bitmap();
+        self.session_mgr.sync_now("add_virtual_peer");
         true
     }
 
     pub fn remove_virtual_peer(&self, peer_id: PeerId) {
+        let mut removed_portal_edge = false;
+        {
+            let mut guard = self.service_impl.synced_route_info.conn_map.write();
+            if let Some(conn) = guard.get_mut(&self.my_peer_id)
+                && conn.connected_peers.remove(&peer_id)
+            {
+                let new_version = conn.version.inc();
+                conn.version.set(new_version);
+                conn.last_update = SystemTime::now();
+                removed_portal_edge = true;
+            }
+        }
+        if removed_portal_edge {
+            self.service_impl.synced_route_info.version.inc();
+        }
         self.service_impl.synced_route_info.remove_peer(peer_id);
+        self.service_impl
+            .update_route_table_and_cached_local_conn_bitmap();
+        self.session_mgr.sync_now("remove_virtual_peer");
     }
 
     pub fn refresh_virtual_peer(&self, peer_id: PeerId) -> bool {
-        let mut guard = self.service_impl.synced_route_info.peer_infos.write();
-        let Some(info) = guard.get_mut(&peer_id) else {
-            return false;
-        };
-        info.version += 1;
-        info.last_update = Some(SystemTime::now().into());
-        drop(guard);
+        self.refresh_virtual_peers(std::iter::once(peer_id))
+    }
 
-        let mut guard = self.service_impl.synced_route_info.conn_map.write();
-        if let Some(conn) = guard.get_mut(&peer_id) {
-            let new_version = conn.version.inc();
-            conn.version.set(new_version);
-            conn.last_update = SystemTime::now();
+    pub fn refresh_virtual_peers<I>(&self, peer_ids: I) -> bool
+    where
+        I: IntoIterator<Item = PeerId>,
+    {
+        let now = SystemTime::now();
+        let mut existing_peer_ids = Vec::new();
+
+        let mut guard = self.service_impl.synced_route_info.peer_infos.write();
+        for peer_id in peer_ids {
+            let Some(info) = guard.get_mut(&peer_id) else {
+                continue;
+            };
+            info.last_update = Some(now.into());
+            existing_peer_ids.push(peer_id);
         }
         drop(guard);
 
-        self.service_impl.synced_route_info.version.inc();
-        true
+        if existing_peer_ids.is_empty() {
+            return false;
+        }
+
+        let mut guard = self.service_impl.synced_route_info.conn_map.write();
+        let mut route_changed = false;
+        let expected_connected_peers = BTreeSet::from([self.my_peer_id]);
+        for peer_id in existing_peer_ids {
+            if let Some(conn) = guard.get_mut(&peer_id) {
+                if conn.connected_peers != expected_connected_peers {
+                    conn.connected_peers = expected_connected_peers.clone();
+                    let new_version = conn.version.inc();
+                    conn.version.set(new_version);
+                    route_changed = true;
+                }
+                conn.last_update = now;
+            } else {
+                guard.insert(
+                    peer_id,
+                    RouteConnInfo {
+                        connected_peers: expected_connected_peers.clone(),
+                        version: 1.into(),
+                        last_update: now,
+                    },
+                );
+                route_changed = true;
+            }
+            route_changed |=
+                Self::ensure_portal_to_virtual_edge(&mut guard, self.my_peer_id, peer_id, now);
+        }
+        drop(guard);
+
+        if route_changed {
+            self.service_impl.synced_route_info.version.inc();
+            self.service_impl
+                .update_route_table_and_cached_local_conn_bitmap();
+            self.session_mgr.sync_now("refresh_virtual_peers");
+        }
+        route_changed
     }
 }
 
@@ -6766,7 +6900,19 @@ mod tests {
         assert!(conn.contains_key(&virtual_peer_id));
         let conn_info = conn.get(&virtual_peer_id).unwrap();
         assert!(conn_info.connected_peers.contains(&peer_mgr.my_peer_id()));
+        let portal_conn_info = conn.get(&peer_mgr.my_peer_id()).unwrap();
+        assert!(portal_conn_info.connected_peers.contains(&virtual_peer_id));
         drop(conn);
+
+        route
+            .service_impl
+            .update_route_table_and_cached_local_conn_bitmap();
+        assert!(
+            route
+                .service_impl
+                .route_table
+                .peer_reachable(virtual_peer_id)
+        );
 
         // Refresh virtual peer
         let old_version = route
@@ -6777,30 +6923,65 @@ mod tests {
             .get(&virtual_peer_id)
             .unwrap()
             .version;
-        assert!(route.refresh_virtual_peer(virtual_peer_id));
-        let new_version = route
+        let old_last_update: SystemTime = route
             .service_impl
             .synced_route_info
             .peer_infos
             .read()
             .get(&virtual_peer_id)
             .unwrap()
-            .version;
-        assert!(new_version > old_version);
+            .last_update
+            .clone()
+            .unwrap()
+            .try_into()
+            .unwrap();
+        assert!(!route.refresh_virtual_peer(virtual_peer_id));
+        {
+            let guard = route.service_impl.synced_route_info.peer_infos.read();
+            let refreshed_peer_info = guard.get(&virtual_peer_id).unwrap();
+            assert_eq!(refreshed_peer_info.version, old_version);
+            let refreshed_last_update: SystemTime = refreshed_peer_info
+                .last_update
+                .clone()
+                .unwrap()
+                .try_into()
+                .unwrap();
+            assert!(refreshed_last_update > old_last_update);
+        }
+
+        route.service_impl.mark_interface_peers_dirty();
+        route.service_impl.update_my_conn_info().await;
+        let conn = route.service_impl.synced_route_info.conn_map.read();
+        let portal_conn_info = conn.get(&peer_mgr.my_peer_id()).unwrap();
+        assert!(portal_conn_info.connected_peers.contains(&virtual_peer_id));
+        drop(conn);
 
         // Remove virtual peer
         route.remove_virtual_peer(virtual_peer_id);
-        assert!(!route
-            .service_impl
-            .synced_route_info
-            .peer_infos
-            .read()
-            .contains_key(&virtual_peer_id));
-        assert!(!route
-            .service_impl
-            .synced_route_info
-            .conn_map
-            .read()
-            .contains_key(&virtual_peer_id));
+        assert!(
+            !route
+                .service_impl
+                .synced_route_info
+                .peer_infos
+                .read()
+                .contains_key(&virtual_peer_id)
+        );
+        assert!(
+            !route
+                .service_impl
+                .synced_route_info
+                .conn_map
+                .read()
+                .contains_key(&virtual_peer_id)
+        );
+        assert!(
+            !route
+                .service_impl
+                .synced_route_info
+                .conn_map
+                .read()
+                .get(&peer_mgr.my_peer_id())
+                .is_some_and(|conn| conn.connected_peers.contains(&virtual_peer_id))
+        );
     }
 }

--- a/easytier/src/peers/peer_ospf_route.rs
+++ b/easytier/src/peers/peer_ospf_route.rs
@@ -245,14 +245,22 @@ impl RoutePeerInfo {
             inst_id: Some(global_ctx.get_id().into()),
             cost: 0,
             ipv4_addr: global_ctx.get_ipv4().map(|x| x.address().into()),
-            proxy_cidrs: global_ctx
-                .config
-                .get_proxy_cidrs()
-                .iter()
-                .map(|x| x.mapped_cidr.unwrap_or(x.cidr))
-                .chain(global_ctx.get_vpn_portal_cidr())
-                .map(|x| x.to_string())
-                .collect(),
+            proxy_cidrs: {
+                let mut cidrs: Vec<String> = global_ctx
+                    .config
+                    .get_proxy_cidrs()
+                    .iter()
+                    .map(|x| x.mapped_cidr.unwrap_or(x.cidr).to_string())
+                    .collect();
+                // Only advertise client_cidr as proxy when in legacy single-key mode.
+                // In multi-client mode, each online WG client is advertised as a virtual peer.
+                if let Some(vpn_cfg) = global_ctx.config.get_vpn_portal_config() {
+                    if vpn_cfg.clients.is_empty() {
+                        cidrs.push(vpn_cfg.client_cidr.to_string());
+                    }
+                }
+                cidrs
+            },
             hostname: Some(global_ctx.get_hostname()),
             udp_nat_type: stun_info.udp_nat_type,
             tcp_nat_type: stun_info.tcp_nat_type,
@@ -4150,6 +4158,65 @@ impl Route for PeerRoute {
     }
 }
 
+impl PeerRoute {
+    pub fn add_virtual_peer(&self, peer_id: PeerId, ipv4_addr: Ipv4Addr) -> bool {
+        let mut info = RoutePeerInfo::new();
+        info.peer_id = peer_id;
+        info.ipv4_addr = Some(ipv4_addr.into());
+        info.network_length = 32;
+        info.last_update = Some(SystemTime::now().into());
+        info.version = 1;
+
+        let mut guard = self.service_impl.synced_route_info.peer_infos.write();
+        let old = guard.get(&peer_id);
+        let new_version = old.map(|x| x.version).unwrap_or(0) + 1;
+        info.version = new_version;
+        guard.insert(peer_id, info);
+        drop(guard);
+
+        let mut guard = self.service_impl.synced_route_info.conn_map.write();
+        let mut connected_peers = BTreeSet::new();
+        connected_peers.insert(self.my_peer_id);
+        guard.insert(
+            peer_id,
+            RouteConnInfo {
+                connected_peers,
+                version: new_version.into(),
+                last_update: SystemTime::now(),
+            },
+        );
+        drop(guard);
+
+        self.service_impl.synced_route_info.version.inc();
+        true
+    }
+
+    pub fn remove_virtual_peer(&self, peer_id: PeerId) {
+        self.service_impl.synced_route_info.remove_peer(peer_id);
+    }
+
+    pub fn refresh_virtual_peer(&self, peer_id: PeerId) -> bool {
+        let mut guard = self.service_impl.synced_route_info.peer_infos.write();
+        let Some(info) = guard.get_mut(&peer_id) else {
+            return false;
+        };
+        info.version += 1;
+        info.last_update = Some(SystemTime::now().into());
+        drop(guard);
+
+        let mut guard = self.service_impl.synced_route_info.conn_map.write();
+        if let Some(conn) = guard.get_mut(&peer_id) {
+            let new_version = conn.version.inc();
+            conn.version.set(new_version);
+            conn.last_update = SystemTime::now();
+        }
+        drop(guard);
+
+        self.service_impl.synced_route_info.version.inc();
+        true
+    }
+}
+
 impl PeerPacketFilter for Arc<PeerRoute> {}
 
 #[cfg(test)]
@@ -6672,5 +6739,68 @@ mod tests {
                 .get_peer_id_for_proxy(&"10.11.0.1".parse::<IpAddr>().unwrap()),
             Some(from_peer_id)
         );
+    }
+
+    #[tokio::test]
+    async fn test_virtual_peer_lifecycle() {
+        let peer_mgr = create_mock_peer_manager().await;
+        let route = create_mock_route(peer_mgr.clone()).await;
+
+        let virtual_peer_id: PeerId = 0x80000001;
+        let virtual_ip: std::net::Ipv4Addr = "10.99.99.1".parse().unwrap();
+
+        // Add virtual peer
+        assert!(route.add_virtual_peer(virtual_peer_id, virtual_ip));
+
+        // Verify peer info exists
+        let info = route.service_impl.synced_route_info.peer_infos.read();
+        assert!(info.contains_key(&virtual_peer_id));
+        let peer_info = info.get(&virtual_peer_id).unwrap();
+        assert_eq!(peer_info.peer_id, virtual_peer_id);
+        assert_eq!(peer_info.ipv4_addr, Some(virtual_ip.into()));
+        assert_eq!(peer_info.network_length, 32);
+        drop(info);
+
+        // Verify conn map exists and connects to my_peer_id
+        let conn = route.service_impl.synced_route_info.conn_map.read();
+        assert!(conn.contains_key(&virtual_peer_id));
+        let conn_info = conn.get(&virtual_peer_id).unwrap();
+        assert!(conn_info.connected_peers.contains(&peer_mgr.my_peer_id()));
+        drop(conn);
+
+        // Refresh virtual peer
+        let old_version = route
+            .service_impl
+            .synced_route_info
+            .peer_infos
+            .read()
+            .get(&virtual_peer_id)
+            .unwrap()
+            .version;
+        assert!(route.refresh_virtual_peer(virtual_peer_id));
+        let new_version = route
+            .service_impl
+            .synced_route_info
+            .peer_infos
+            .read()
+            .get(&virtual_peer_id)
+            .unwrap()
+            .version;
+        assert!(new_version > old_version);
+
+        // Remove virtual peer
+        route.remove_virtual_peer(virtual_peer_id);
+        assert!(!route
+            .service_impl
+            .synced_route_info
+            .peer_infos
+            .read()
+            .contains_key(&virtual_peer_id));
+        assert!(!route
+            .service_impl
+            .synced_route_info
+            .conn_map
+            .read()
+            .contains_key(&virtual_peer_id));
     }
 }

--- a/easytier/src/peers/route_trait.rs
+++ b/easytier/src/peers/route_trait.rs
@@ -89,6 +89,10 @@ pub trait Route {
         self.get_next_hop(peer_id).await
     }
 
+    async fn is_local_virtual_peer(&self, _peer_id: PeerId) -> bool {
+        false
+    }
+
     async fn list_routes(&self) -> Vec<crate::proto::api::instance::Route>;
 
     // TODO: rewrite route management, remove this

--- a/easytier/src/proto/common.rs
+++ b/easytier/src/proto/common.rs
@@ -11,6 +11,16 @@ use crate::tunnel::{IpScheme, packet_def::CompressorAlgo};
 
 include!(concat!(env!("OUT_DIR"), "/common.rs"));
 
+pub const VIRTUAL_PEER_ID_FLAG: u32 = 0x8000_0000;
+
+pub fn is_virtual_peer_id(peer_id: u32) -> bool {
+    peer_id & VIRTUAL_PEER_ID_FLAG != 0
+}
+
+pub fn to_virtual_peer_id(peer_id: u32) -> u32 {
+    peer_id | VIRTUAL_PEER_ID_FLAG
+}
+
 impl From<uuid::Uuid> for Uuid {
     fn from(uuid: uuid::Uuid) -> Self {
         let (high, low) = uuid.as_u64_pair();

--- a/easytier/src/tests/three_node.rs
+++ b/easytier/src/tests/three_node.rs
@@ -38,7 +38,7 @@ use crate::{
 
 #[cfg(feature = "wireguard")]
 use crate::{
-    common::config::VpnPortalConfig,
+    common::config::{VpnPortalClientConfig, VpnPortalConfig},
     tunnel::wireguard::{WgConfig, WgTunnelConnector},
     vpn_portal::wireguard::get_wg_config_for_portal,
 };
@@ -190,7 +190,7 @@ async fn init_three_node_ex_with_inst3<F: Fn(TomlConfigLoader) -> TomlConfigLoad
                     == 1
             }
         },
-        Duration::from_secs(5),
+        Duration::from_secs(20),
     )
     .await;
 
@@ -200,7 +200,7 @@ async fn init_three_node_ex_with_inst3<F: Fn(TomlConfigLoader) -> TomlConfigLoad
             println!("routes: {:?}", routes);
             routes.len() == 2
         },
-        Duration::from_secs(5),
+        Duration::from_secs(20),
     )
     .await;
 
@@ -210,7 +210,7 @@ async fn init_three_node_ex_with_inst3<F: Fn(TomlConfigLoader) -> TomlConfigLoad
             println!("routes: {:?}", routes);
             routes.len() == 2
         },
-        Duration::from_secs(5),
+        Duration::from_secs(20),
     )
     .await;
 
@@ -1649,7 +1649,28 @@ fn run_wireguard_client(
     } else {
         "utun3".into()
     };
-    let wgapi = WGApi::new(ifname.clone(), false)?;
+
+    run_wireguard_client_on_interface(
+        &ifname,
+        endpoint,
+        peer_public_key,
+        client_private_key,
+        allowed_ips,
+        client_ip,
+        12345,
+    )
+}
+
+fn run_wireguard_client_on_interface(
+    ifname: &str,
+    endpoint: SocketAddr,
+    peer_public_key: Key,
+    client_private_key: Key,
+    allowed_ips: Vec<String>,
+    client_ip: String,
+    listen_port: u16,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let wgapi = WGApi::new(ifname.to_string(), false)?;
 
     // create interface
     wgapi.create_interface()?;
@@ -1667,10 +1688,10 @@ fn run_wireguard_client(
 
     // interface configuration
     let interface_config = InterfaceConfiguration {
-        name: ifname.clone(),
+        name: ifname.to_string(),
         prvkey: client_private_key.to_string(),
         address: client_ip,
-        port: 12345,
+        port: listen_port.into(),
         peers: vec![peer],
     };
 
@@ -1680,6 +1701,259 @@ fn run_wireguard_client(
     wgapi.configure_interface(&interface_config, &[])?;
     wgapi.configure_peer_routing(&interface_config.peers)?;
     Ok(())
+}
+
+#[cfg(feature = "wireguard")]
+struct WireGuardNatClient {
+    name: &'static str,
+    netns: &'static str,
+    ifname: &'static str,
+    assigned_ip: &'static str,
+    tunnel_ip: &'static str,
+    private_key: [u8; 32],
+    public_key: [u8; 32],
+}
+
+#[cfg(feature = "wireguard")]
+impl WireGuardNatClient {
+    fn new(
+        name: &'static str,
+        netns: &'static str,
+        ifname: &'static str,
+        assigned_ip: &'static str,
+        tunnel_ip: &'static str,
+    ) -> Self {
+        let private = StaticSecret::random_from_rng(OsRng);
+        let public = x25519_dalek::PublicKey::from(&private);
+
+        Self {
+            name,
+            netns,
+            ifname,
+            assigned_ip,
+            tunnel_ip,
+            private_key: *private.as_bytes(),
+            public_key: *public.as_bytes(),
+        }
+    }
+
+    fn portal_config(&self) -> VpnPortalClientConfig {
+        use base64::{Engine, prelude::BASE64_STANDARD};
+
+        VpnPortalClientConfig {
+            name: self.name.to_string(),
+            client_public_key: BASE64_STANDARD.encode(self.public_key),
+            assigned_ip: Some(self.assigned_ip.parse().unwrap()),
+            tunnel_ip: Some(self.tunnel_ip.parse().unwrap()),
+        }
+    }
+
+    fn private_key(&self) -> Key {
+        Key::try_from(self.private_key.as_slice()).unwrap()
+    }
+}
+
+#[cfg(feature = "wireguard")]
+struct WireGuardClientCleanup {
+    interfaces: Vec<(&'static str, &'static str)>,
+}
+
+#[cfg(feature = "wireguard")]
+impl WireGuardClientCleanup {
+    fn new(clients: &[WireGuardNatClient]) -> Self {
+        Self {
+            interfaces: clients
+                .iter()
+                .map(|client| (client.netns, client.ifname))
+                .collect(),
+        }
+    }
+}
+
+#[cfg(feature = "wireguard")]
+impl Drop for WireGuardClientCleanup {
+    fn drop(&mut self) {
+        for (netns, ifname) in self.interfaces.drain(..) {
+            remove_wireguard_client_interface(netns, ifname);
+        }
+    }
+}
+
+#[cfg(feature = "wireguard")]
+fn remove_wireguard_client_interface(netns: &str, ifname: &str) {
+    let net_ns = NetNS::new(Some(netns.to_string()));
+    let _g = net_ns.guard();
+
+    if let Ok(wgapi) = WGApi::new(ifname.to_string(), false) {
+        let _ = wgapi.remove_interface();
+    }
+    let _ = std::process::Command::new("ip")
+        .args(["link", "del", ifname])
+        .status();
+}
+
+#[cfg(feature = "wireguard")]
+fn setup_net_e_portal_link() {
+    connect_ns_to_bridge("net_e", "wge0", "veth_wge0", "br_b");
+    run_ip_in_ns("net_e", &["addr", "add", "10.1.2.5/24", "dev", "wge0"]);
+}
+
+#[cfg(feature = "wireguard")]
+async fn start_wg_nat_portal(
+    inst: &mut Instance,
+    clients: &[WireGuardNatClient],
+    listen_port: u16,
+) -> SocketAddr {
+    inst.get_global_ctx()
+        .config
+        .set_vpn_portal_config(VpnPortalConfig {
+            wireguard_listen: format!("0.0.0.0:{listen_port}").parse().unwrap(),
+            client_cidr: "10.14.14.0/24".parse().unwrap(),
+            wireguard_private_key: None,
+            clients: clients
+                .iter()
+                .map(|client| client.portal_config())
+                .collect(),
+        });
+    inst.run_vpn_portal().await.unwrap();
+
+    format!("10.1.2.3:{listen_port}").parse().unwrap()
+}
+
+#[cfg(feature = "wireguard")]
+fn wg_nat_allowed_ips() -> Vec<String> {
+    vec!["10.14.14.0/24".to_string(), "10.144.144.0/24".to_string()]
+}
+
+#[cfg(feature = "wireguard")]
+fn start_wg_nat_client(
+    endpoint: SocketAddr,
+    server_public_key: Key,
+    client: &WireGuardNatClient,
+    listen_port: u16,
+) {
+    remove_wireguard_client_interface(client.netns, client.ifname);
+
+    let net_ns = NetNS::new(Some(client.netns.to_string()));
+    let _g = net_ns.guard();
+    run_wireguard_client_on_interface(
+        client.ifname,
+        endpoint,
+        server_public_key,
+        client.private_key(),
+        wg_nat_allowed_ips(),
+        client.tunnel_ip.to_string(),
+        listen_port,
+    )
+    .unwrap();
+}
+
+#[cfg(feature = "wireguard")]
+async fn wait_for_wg_nat_routes(insts: &[Instance], clients: &[WireGuardNatClient]) {
+    let assigned_ips: Vec<crate::proto::common::Ipv4Inet> = clients
+        .iter()
+        .map(|client| client.assigned_ip.parse().unwrap())
+        .collect();
+
+    wait_for_condition(
+        || async {
+            for client in clients {
+                let _ = ping_test(client.netns, "10.144.144.1", None).await;
+            }
+
+            for inst in insts {
+                let routes = inst.get_peer_manager().list_routes().await;
+                if !assigned_ips
+                    .iter()
+                    .all(|ip| routes.iter().any(|route| route.ipv4_addr.as_ref() == Some(ip)))
+                {
+                    println!(
+                        "wg nat route wait missing inst={}, assigned_ips={assigned_ips:?}, routes={routes:?}",
+                        inst.get_global_ctx().inst_name,
+                    );
+                    return false;
+                }
+            }
+            true
+        },
+        Duration::from_secs(20),
+    )
+    .await;
+}
+
+#[cfg(feature = "wireguard")]
+async fn wait_for_ping_from(netns: &'static str, target_ip: &'static str) {
+    println!("wait_for_ping_from start {netns} -> {target_ip}");
+    wait_for_condition(
+        || async move { ping_test(netns, target_ip, None).await },
+        Duration::from_secs(10),
+    )
+    .await;
+    println!("wait_for_ping_from done {netns} -> {target_ip}");
+}
+
+#[cfg(feature = "wireguard")]
+async fn wait_for_ping_to_fail(netns: &'static str, target_ip: &'static str) {
+    wait_for_condition(
+        || async move { !ping_test(netns, target_ip, None).await },
+        Duration::from_secs(5),
+    )
+    .await;
+}
+
+#[cfg(feature = "wireguard")]
+async fn assert_tcp_echo_and_source(
+    server_netns: &'static str,
+    connect_netns: &'static str,
+    connect_addr: &'static str,
+    port: u16,
+    expected_source_ip: &'static str,
+    payload: Vec<u8>,
+) {
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::{TcpListener, TcpStream},
+        sync::oneshot,
+    };
+
+    let expected_payload = payload.clone();
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let server_task = tokio::spawn(async move {
+        let net_ns = NetNS::new(Some(server_netns.to_string()));
+        let _g = net_ns.guard();
+        let listener = TcpListener::bind(format!("0.0.0.0:{port}")).await.unwrap();
+        let _ = ready_tx.send(());
+
+        let (mut stream, addr) = tokio::time::timeout(Duration::from_secs(5), listener.accept())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(addr.ip().to_string(), expected_source_ip);
+
+        let mut received = vec![0u8; expected_payload.len()];
+        stream.read_exact(&mut received).await.unwrap();
+        assert_eq!(received, expected_payload);
+        stream.write_all(&received).await.unwrap();
+    });
+
+    ready_rx.await.unwrap();
+    {
+        let net_ns = NetNS::new(Some(connect_netns.to_string()));
+        let _g = net_ns.guard();
+        let mut stream = tokio::time::timeout(
+            Duration::from_secs(5),
+            TcpStream::connect(format!("{connect_addr}:{port}")),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        stream.write_all(&payload).await.unwrap();
+        let mut received = vec![0u8; payload.len()];
+        stream.read_exact(&mut received).await.unwrap();
+        assert_eq!(received, payload);
+    }
+
+    server_task.await.unwrap();
 }
 
 #[cfg(feature = "wireguard")]
@@ -1742,6 +2016,201 @@ pub async fn wireguard_vpn_portal(#[values(true, false)] test_v6: bool) {
     wait_for_condition(
         || async { ping_test("net_d", "10.144.144.3", None).await },
         Duration::from_secs(5),
+    )
+    .await;
+
+    drop_insts(insts).await;
+}
+
+#[cfg(feature = "wireguard")]
+#[tokio::test]
+#[serial_test::serial]
+pub async fn test_multi_wg_client_basic_nat() {
+    let mut insts = init_three_node("tcp").await;
+    setup_net_e_portal_link();
+
+    let clients = vec![
+        WireGuardNatClient::new(
+            "nat-client-1",
+            "net_d",
+            "wg1",
+            "10.144.144.201",
+            "10.14.14.101",
+        ),
+        WireGuardNatClient::new(
+            "nat-client-2",
+            "net_e",
+            "wg2",
+            "10.144.144.202",
+            "10.14.14.102",
+        ),
+    ];
+    let _cleanup = WireGuardClientCleanup::new(&clients);
+    let endpoint = start_wg_nat_portal(&mut insts[2], &clients, 22131).await;
+    let wg_cfg = get_wg_config_for_portal(&insts[2].get_global_ctx().get_network_identity());
+    let server_public_key = Key::try_from(wg_cfg.my_public_key()).unwrap();
+
+    start_wg_nat_client(endpoint, server_public_key.clone(), &clients[0], 12351);
+    start_wg_nat_client(endpoint, server_public_key, &clients[1], 12352);
+    wait_for_wg_nat_routes(&insts, &clients).await;
+
+    wait_for_ping_from("net_d", "10.144.144.1").await;
+    wait_for_ping_from("net_e", "10.144.144.2").await;
+    wait_for_ping_from("net_d", "10.144.144.202").await;
+    wait_for_ping_from("net_e", "10.144.144.201").await;
+
+    assert_tcp_echo_and_source(
+        "net_a",
+        "net_d",
+        "10.144.144.1",
+        23031,
+        clients[0].assigned_ip,
+        b"client-1-source".to_vec(),
+    )
+    .await;
+
+    drop_insts(insts).await;
+}
+
+#[cfg(feature = "wireguard")]
+#[tokio::test]
+#[serial_test::serial]
+pub async fn test_multi_wg_client_same_tunnel_ip() {
+    let mut insts = init_three_node("tcp").await;
+    setup_net_e_portal_link();
+
+    let clients = vec![
+        WireGuardNatClient::new(
+            "same-tunnel-client-1",
+            "net_d",
+            "wg3",
+            "10.144.144.211",
+            "10.14.14.111",
+        ),
+        WireGuardNatClient::new(
+            "same-tunnel-client-2",
+            "net_e",
+            "wg4",
+            "10.144.144.212",
+            "10.14.14.111",
+        ),
+    ];
+    let _cleanup = WireGuardClientCleanup::new(&clients);
+    let endpoint = start_wg_nat_portal(&mut insts[2], &clients, 22132).await;
+    let wg_cfg = get_wg_config_for_portal(&insts[2].get_global_ctx().get_network_identity());
+    let server_public_key = Key::try_from(wg_cfg.my_public_key()).unwrap();
+
+    start_wg_nat_client(endpoint, server_public_key.clone(), &clients[0], 12353);
+    start_wg_nat_client(endpoint, server_public_key, &clients[1], 12354);
+    wait_for_wg_nat_routes(&insts, &clients).await;
+
+    wait_for_ping_from("net_d", "10.144.144.1").await;
+    wait_for_ping_from("net_e", "10.144.144.2").await;
+    wait_for_ping_from("net_d", "10.144.144.212").await;
+    wait_for_ping_from("net_e", "10.144.144.211").await;
+
+    assert_tcp_echo_and_source(
+        "net_a",
+        "net_d",
+        "10.144.144.1",
+        23032,
+        clients[0].assigned_ip,
+        b"same-tunnel-client-1".to_vec(),
+    )
+    .await;
+    assert_tcp_echo_and_source(
+        "net_a",
+        "net_e",
+        "10.144.144.1",
+        23033,
+        clients[1].assigned_ip,
+        b"same-tunnel-client-2".to_vec(),
+    )
+    .await;
+
+    drop_insts(insts).await;
+}
+
+#[cfg(feature = "wireguard")]
+#[tokio::test]
+#[serial_test::serial]
+pub async fn test_wg_client_nat_disconnect_reconnect() {
+    let mut insts = init_three_node("tcp").await;
+    let clients = vec![WireGuardNatClient::new(
+        "reconnect-client",
+        "net_d",
+        "wg5",
+        "10.144.144.221",
+        "10.14.14.121",
+    )];
+    let _cleanup = WireGuardClientCleanup::new(&clients);
+    let endpoint = start_wg_nat_portal(&mut insts[2], &clients, 22133).await;
+    let wg_cfg = get_wg_config_for_portal(&insts[2].get_global_ctx().get_network_identity());
+    let server_public_key = Key::try_from(wg_cfg.my_public_key()).unwrap();
+
+    start_wg_nat_client(endpoint, server_public_key.clone(), &clients[0], 12355);
+    wait_for_wg_nat_routes(&insts, &clients).await;
+    wait_for_ping_from("net_d", "10.144.144.1").await;
+    assert_tcp_echo_and_source(
+        "net_a",
+        "net_d",
+        "10.144.144.1",
+        23034,
+        clients[0].assigned_ip,
+        b"before-reconnect".to_vec(),
+    )
+    .await;
+
+    remove_wireguard_client_interface(clients[0].netns, clients[0].ifname);
+    wait_for_ping_to_fail("net_d", "10.144.144.1").await;
+    tokio::time::sleep(Duration::from_secs(65)).await;
+
+    start_wg_nat_client(endpoint, server_public_key, &clients[0], 12356);
+    wait_for_wg_nat_routes(&insts, &clients).await;
+    wait_for_ping_from("net_d", "10.144.144.2").await;
+    assert_tcp_echo_and_source(
+        "net_a",
+        "net_d",
+        "10.144.144.1",
+        23035,
+        clients[0].assigned_ip,
+        b"after-reconnect".to_vec(),
+    )
+    .await;
+
+    drop_insts(insts).await;
+}
+
+#[cfg(feature = "wireguard")]
+#[tokio::test]
+#[serial_test::serial]
+pub async fn test_wg_client_nat_tcp_connectivity() {
+    let mut insts = init_three_node("tcp").await;
+    let clients = vec![WireGuardNatClient::new(
+        "tcp-client",
+        "net_d",
+        "wg6",
+        "10.144.144.231",
+        "10.14.14.131",
+    )];
+    let _cleanup = WireGuardClientCleanup::new(&clients);
+    let endpoint = start_wg_nat_portal(&mut insts[2], &clients, 22134).await;
+    let wg_cfg = get_wg_config_for_portal(&insts[2].get_global_ctx().get_network_identity());
+    let server_public_key = Key::try_from(wg_cfg.my_public_key()).unwrap();
+
+    start_wg_nat_client(endpoint, server_public_key, &clients[0], 12357);
+    wait_for_wg_nat_routes(&insts, &clients).await;
+    wait_for_ping_from("net_d", "10.144.144.1").await;
+
+    let mut payload = vec![0u8; 1024];
+    rand::thread_rng().fill(&mut payload[..]);
+    assert_tcp_echo_and_source(
+        "net_a",
+        "net_d",
+        "10.144.144.1",
+        23036,
+        clients[0].assigned_ip,
+        payload,
     )
     .await;
 

--- a/easytier/src/tests/three_node.rs
+++ b/easytier/src/tests/three_node.rs
@@ -1703,6 +1703,8 @@ pub async fn wireguard_vpn_portal(#[values(true, false)] test_v6: bool) {
         .set_vpn_portal_config(VpnPortalConfig {
             wireguard_listen: "0.0.0.0:22121".parse().unwrap(),
             client_cidr: "10.14.14.0/24".parse().unwrap(),
+            wireguard_private_key: None,
+            clients: vec![],
         });
     insts[2].run_vpn_portal().await.unwrap();
 

--- a/easytier/src/tunnel/common.rs
+++ b/easytier/src/tunnel/common.rs
@@ -66,6 +66,13 @@ where
     fn info(&self) -> Option<TunnelInfo> {
         self.info.clone()
     }
+
+    fn get_associate_data(&self) -> Option<&dyn std::any::Any> {
+        self.associate_data.as_ref().map(|d| {
+            let r: &dyn std::any::Any = d.as_ref();
+            r
+        })
+    }
 }
 
 // a length delimited codec for async reader

--- a/easytier/src/tunnel/mod.rs
+++ b/easytier/src/tunnel/mod.rs
@@ -102,6 +102,9 @@ pub type SplitTunnel = (Pin<Box<dyn ZCPacketStream>>, Pin<Box<dyn ZCPacketSink>>
 pub trait Tunnel: Send {
     fn split(&self) -> SplitTunnel;
     fn info(&self) -> Option<TunnelInfo>;
+    fn get_associate_data(&self) -> Option<&dyn std::any::Any> {
+        None
+    }
 }
 
 #[auto_impl::auto_impl(Arc)]

--- a/easytier/src/tunnel/wireguard.rs
+++ b/easytier/src/tunnel/wireguard.rs
@@ -369,7 +369,12 @@ impl WgPeer {
         Self::new_with_index(udp, config, endpoint, rand::thread_rng().next_u32())
     }
 
-    fn new_with_index(udp: Arc<UdpSocket>, config: WgConfig, endpoint: SocketAddr, tunn_index: u32) -> Self {
+    fn new_with_index(
+        udp: Arc<UdpSocket>,
+        config: WgConfig,
+        endpoint: SocketAddr,
+        tunn_index: u32,
+    ) -> Self {
         WgPeer {
             tunn: Some(Mutex::new(Tunn::new(
                 config.my_secret_key.clone(),
@@ -604,8 +609,12 @@ impl WgTunnelListener {
                                         srv_cfg.server_public_key.clone(),
                                         client_pubkey,
                                     );
-                                    let mut wg =
-                                        WgPeer::new_with_index(socket.clone(), client_config, addr, idx);
+                                    let mut wg = WgPeer::new_with_index(
+                                        socket.clone(),
+                                        client_config,
+                                        addr,
+                                        idx,
+                                    );
                                     let (stream, sink) = wg.start_and_get_tunnel().split();
                                     let client_info = WgClientInfo {
                                         name: client_name.value().clone(),
@@ -635,13 +644,19 @@ impl WgTunnelListener {
                                         Some(Box::new(client_info)),
                                     ));
                                     if let Err(e) = conn_sender.send(tunnel) {
-                                        tracing::error!("Failed to send tunnel to conn_sender: {}", e);
+                                        tracing::error!(
+                                            "Failed to send tunnel to conn_sender: {}",
+                                            e
+                                        );
                                     }
                                     let wg = Arc::new(wg);
                                     peer_map.insert(addr, wg.clone());
                                     peer_by_idx.insert(idx, wg);
                                 } else {
-                                    tracing::debug!(?client_pubkey, "Unknown wireguard client pubkey");
+                                    tracing::debug!(
+                                        ?client_pubkey,
+                                        "Unknown wireguard client pubkey"
+                                    );
                                 }
                             }
                         }
@@ -1166,11 +1181,12 @@ pub mod tests {
         };
         let mut unreg_connector =
             WgTunnelConnector::new("wg://127.0.0.1:5588".parse().unwrap(), unreg_cfg);
-        let result = tokio::time::timeout(
-            std::time::Duration::from_secs(2),
-            unreg_connector.connect(),
-        )
-        .await;
-        assert!(result.is_err() || result.unwrap().is_err(), "unregistered client should fail");
+        let result =
+            tokio::time::timeout(std::time::Duration::from_secs(2), unreg_connector.connect())
+                .await;
+        assert!(
+            result.is_err() || result.unwrap().is_err(),
+            "unregistered client should fail"
+        );
     }
 }

--- a/easytier/src/tunnel/wireguard.rs
+++ b/easytier/src/tunnel/wireguard.rs
@@ -27,7 +27,7 @@ use anyhow::Context;
 use async_recursion::async_recursion;
 use async_trait::async_trait;
 use boringtun::{
-    noise::{Tunn, TunnResult, errors::WireGuardError},
+    noise::{Packet, Tunn, TunnResult, errors::WireGuardError, handshake::parse_handshake_anon},
     x25519::{PublicKey, StaticSecret},
 };
 use bytes::BytesMut;
@@ -87,6 +87,20 @@ impl WgConfig {
             peer_secret_key: client_cfg.my_secret_key,
             peer_public_key: client_cfg.my_public_key,
 
+            wg_type: WgType::ExternalUse,
+        }
+    }
+
+    pub fn new_for_portal_server(
+        server_secret_key: StaticSecret,
+        server_public_key: PublicKey,
+        peer_public_key: PublicKey,
+    ) -> Self {
+        Self {
+            my_secret_key: server_secret_key,
+            my_public_key: server_public_key,
+            peer_secret_key: StaticSecret::from([0u8; 32]),
+            peer_public_key,
             wg_type: WgType::ExternalUse,
         }
     }
@@ -347,17 +361,22 @@ struct WgPeer {
     tasks: JoinSet<()>,
 
     access_time: AtomicCell<std::time::Instant>,
+    tunn_index: u32,
 }
 
 impl WgPeer {
     fn new(udp: Arc<UdpSocket>, config: WgConfig, endpoint: SocketAddr) -> Self {
+        Self::new_with_index(udp, config, endpoint, rand::thread_rng().next_u32())
+    }
+
+    fn new_with_index(udp: Arc<UdpSocket>, config: WgConfig, endpoint: SocketAddr, tunn_index: u32) -> Self {
         WgPeer {
             tunn: Some(Mutex::new(Tunn::new(
                 config.my_secret_key.clone(),
                 config.peer_public_key,
                 None,
                 None,
-                rand::thread_rng().next_u32(),
+                tunn_index,
                 None,
             ))),
 
@@ -370,6 +389,7 @@ impl WgPeer {
             tasks: JoinSet::new(),
 
             access_time: AtomicCell::new(std::time::Instant::now()),
+            tunn_index,
         }
     }
 
@@ -452,15 +472,31 @@ impl WgPeer {
 type ConnSender = tokio::sync::mpsc::UnboundedSender<Box<dyn Tunnel>>;
 type ConnReceiver = tokio::sync::mpsc::UnboundedReceiver<Box<dyn Tunnel>>;
 
+#[derive(Clone)]
+pub struct WgPortalServerConfig {
+    pub server_secret_key: StaticSecret,
+    pub server_public_key: PublicKey,
+    pub clients: Arc<DashMap<PublicKey, String>>, // pubkey -> client name
+    pub next_index: Arc<std::sync::atomic::AtomicU32>,
+}
+
+#[derive(Clone, Debug)]
+pub struct WgClientInfo {
+    pub name: String,
+    pub pubkey: [u8; 32],
+}
+
 pub struct WgTunnelListener {
     addr: url::Url,
-    config: WgConfig,
+    config: Option<WgConfig>,
+    server_config: Option<WgPortalServerConfig>,
 
     udp: Option<Arc<UdpSocket>>,
     conn_recv: ConnReceiver,
     conn_send: Option<ConnSender>,
 
     wg_peer_map: Arc<DashMap<SocketAddr, Arc<WgPeer>>>,
+    wg_peer_by_idx: Arc<DashMap<u32, Arc<WgPeer>>>,
 
     tasks: JoinSet<()>,
 }
@@ -470,13 +506,33 @@ impl WgTunnelListener {
         let (conn_send, conn_recv) = tokio::sync::mpsc::unbounded_channel();
         WgTunnelListener {
             addr,
-            config,
+            config: Some(config),
+            server_config: None,
 
             udp: None,
             conn_recv,
             conn_send: Some(conn_send),
 
             wg_peer_map: Arc::new(DashMap::new()),
+            wg_peer_by_idx: Arc::new(DashMap::new()),
+
+            tasks: JoinSet::new(),
+        }
+    }
+
+    pub fn new_for_portal(addr: url::Url, server_config: WgPortalServerConfig) -> Self {
+        let (conn_send, conn_recv) = tokio::sync::mpsc::unbounded_channel();
+        WgTunnelListener {
+            addr,
+            config: None,
+            server_config: Some(server_config),
+
+            udp: None,
+            conn_recv,
+            conn_send: Some(conn_send),
+
+            wg_peer_map: Arc::new(DashMap::new()),
+            wg_peer_by_idx: Arc::new(DashMap::new()),
 
             tasks: JoinSet::new(),
         }
@@ -488,19 +544,26 @@ impl WgTunnelListener {
 
     async fn handle_udp_incoming(
         socket: Arc<UdpSocket>,
-        config: WgConfig,
+        config: Option<WgConfig>,
+        server_config: Option<WgPortalServerConfig>,
         conn_sender: ConnSender,
         peer_map: Arc<DashMap<SocketAddr, Arc<WgPeer>>>,
+        peer_by_idx: Arc<DashMap<u32, Arc<WgPeer>>>,
     ) {
         let mut tasks = JoinSet::new();
 
         let peer_map_clone: Arc<DashMap<SocketAddr, Arc<WgPeer>>> = peer_map.clone();
+        let peer_by_idx_clone = peer_by_idx.clone();
         tasks.spawn(async move {
             loop {
                 peer_map_clone.retain(|_, peer| {
                     peer.access_time.load().elapsed().as_secs() < 61 && !peer.stopped()
                 });
                 shrink_dashmap(&peer_map_clone, None);
+                peer_by_idx_clone.retain(|_, peer| {
+                    peer.access_time.load().elapsed().as_secs() < 61 && !peer.stopped()
+                });
+                shrink_dashmap(&peer_by_idx_clone, None);
                 tokio::time::sleep(Duration::from_secs(1)).await;
             }
         });
@@ -515,38 +578,140 @@ impl WgTunnelListener {
             let data = &buf[..n];
             tracing::trace!(?n, ?addr, "Received bytes from peer");
 
-            if !peer_map.contains_key(&addr) {
-                tracing::info!("New peer: {}", addr);
-                let mut wg = WgPeer::new(socket.clone(), config.clone(), addr);
-                let (stream, sink) = wg.start_and_get_tunnel().split();
-                let tunnel = Box::new(TunnelWrapper::new(
-                    stream,
-                    sink,
-                    Some(TunnelInfo {
-                        tunnel_type: "wg".to_owned(),
-                        local_addr: Some(
-                            build_url_from_socket_addr(
-                                &socket.local_addr().unwrap().to_string(),
-                                "wg",
-                            )
-                            .into(),
-                        ),
-                        remote_addr: Some(
-                            build_url_from_socket_addr(&addr.to_string(), "wg").into(),
-                        ),
-                        resolved_remote_addr: Some(
-                            build_url_from_socket_addr(&addr.to_string(), "wg").into(),
-                        ),
-                    }),
-                ));
-                if let Err(e) = conn_sender.send(tunnel) {
-                    tracing::error!("Failed to send tunnel to conn_sender: {}", e);
+            if let Some(ref srv_cfg) = server_config {
+                // Multi-client portal mode
+                match Tunn::parse_incoming_packet(data) {
+                    Ok(Packet::HandshakeInit(p)) => {
+                        if !peer_map.contains_key(&addr) {
+                            if let Ok(hh) = parse_handshake_anon(
+                                &srv_cfg.server_secret_key,
+                                &srv_cfg.server_public_key,
+                                &p,
+                            ) {
+                                let client_pubkey = PublicKey::from(hh.peer_static_public);
+                                if let Some(client_name) = srv_cfg.clients.get(&client_pubkey) {
+                                    tracing::info!(
+                                        "New wireguard peer: {}, client: {}, pubkey: {:?}",
+                                        addr,
+                                        client_name.value(),
+                                        client_pubkey
+                                    );
+                                    let idx = srv_cfg
+                                        .next_index
+                                        .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                                    let client_config = WgConfig::new_for_portal_server(
+                                        srv_cfg.server_secret_key.clone(),
+                                        srv_cfg.server_public_key.clone(),
+                                        client_pubkey,
+                                    );
+                                    let mut wg =
+                                        WgPeer::new_with_index(socket.clone(), client_config, addr, idx);
+                                    let (stream, sink) = wg.start_and_get_tunnel().split();
+                                    let client_info = WgClientInfo {
+                                        name: client_name.value().clone(),
+                                        pubkey: hh.peer_static_public,
+                                    };
+                                    let tunnel = Box::new(TunnelWrapper::new_with_associate_data(
+                                        stream,
+                                        sink,
+                                        Some(TunnelInfo {
+                                            tunnel_type: "wg".to_owned(),
+                                            local_addr: Some(
+                                                build_url_from_socket_addr(
+                                                    &socket.local_addr().unwrap().to_string(),
+                                                    "wg",
+                                                )
+                                                .into(),
+                                            ),
+                                            remote_addr: Some(
+                                                build_url_from_socket_addr(&addr.to_string(), "wg")
+                                                    .into(),
+                                            ),
+                                            resolved_remote_addr: Some(
+                                                build_url_from_socket_addr(&addr.to_string(), "wg")
+                                                    .into(),
+                                            ),
+                                        }),
+                                        Some(Box::new(client_info)),
+                                    ));
+                                    if let Err(e) = conn_sender.send(tunnel) {
+                                        tracing::error!("Failed to send tunnel to conn_sender: {}", e);
+                                    }
+                                    let wg = Arc::new(wg);
+                                    peer_map.insert(addr, wg.clone());
+                                    peer_by_idx.insert(idx, wg);
+                                } else {
+                                    tracing::debug!(?client_pubkey, "Unknown wireguard client pubkey");
+                                }
+                            }
+                        }
+                        if let Some(peer) = peer_map.get(&addr) {
+                            peer.handle_packet_from_peer(data).await;
+                        }
+                    }
+                    Ok(Packet::HandshakeResponse(p)) => {
+                        let idx = p.receiver_idx >> 8;
+                        if let Some(peer) = peer_by_idx.get(&idx) {
+                            peer.handle_packet_from_peer(data).await;
+                        } else {
+                            tracing::trace!(?idx, "No peer found for receiver_idx");
+                        }
+                    }
+                    Ok(Packet::PacketCookieReply(p)) => {
+                        let idx = p.receiver_idx >> 8;
+                        if let Some(peer) = peer_by_idx.get(&idx) {
+                            peer.handle_packet_from_peer(data).await;
+                        } else {
+                            tracing::trace!(?idx, "No peer found for receiver_idx");
+                        }
+                    }
+                    Ok(Packet::PacketData(p)) => {
+                        let idx = p.receiver_idx >> 8;
+                        if let Some(peer) = peer_by_idx.get(&idx) {
+                            peer.handle_packet_from_peer(data).await;
+                        } else {
+                            tracing::trace!(?idx, "No peer found for receiver_idx");
+                        }
+                    }
+                    Err(e) => {
+                        tracing::debug!("Failed to parse wireguard packet: {:?}", e);
+                    }
                 }
-                peer_map.insert(addr, Arc::new(wg));
-            }
+            } else if let Some(ref cfg) = config {
+                // Single-peer legacy mode
+                if !peer_map.contains_key(&addr) {
+                    tracing::info!("New peer: {}", addr);
+                    let mut wg = WgPeer::new(socket.clone(), cfg.clone(), addr);
+                    let (stream, sink) = wg.start_and_get_tunnel().split();
+                    let tunnel = Box::new(TunnelWrapper::new(
+                        stream,
+                        sink,
+                        Some(TunnelInfo {
+                            tunnel_type: "wg".to_owned(),
+                            local_addr: Some(
+                                build_url_from_socket_addr(
+                                    &socket.local_addr().unwrap().to_string(),
+                                    "wg",
+                                )
+                                .into(),
+                            ),
+                            remote_addr: Some(
+                                build_url_from_socket_addr(&addr.to_string(), "wg").into(),
+                            ),
+                            resolved_remote_addr: Some(
+                                build_url_from_socket_addr(&addr.to_string(), "wg").into(),
+                            ),
+                        }),
+                    ));
+                    if let Err(e) = conn_sender.send(tunnel) {
+                        tracing::error!("Failed to send tunnel to conn_sender: {}", e);
+                    }
+                    peer_map.insert(addr, Arc::new(wg));
+                }
 
-            let peer = peer_map.get(&addr).unwrap().clone();
-            peer.handle_packet_from_peer(data).await;
+                let peer = peer_map.get(&addr).unwrap().clone();
+                peer.handle_packet_from_peer(data).await;
+            }
         }
     }
 }
@@ -570,8 +735,10 @@ impl TunnelListener for WgTunnelListener {
         self.tasks.spawn(Self::handle_udp_incoming(
             self.get_udp_socket(),
             self.config.clone(),
+            self.server_config.clone(),
             self.conn_send.take().unwrap(),
             self.wg_peer_map.clone(),
+            self.wg_peer_by_idx.clone(),
         ));
 
         Ok(())
@@ -919,5 +1086,91 @@ pub mod tests {
         listener.listen().await.unwrap();
         let port = listener.local_url().port().unwrap();
         assert!(port > 0);
+    }
+
+    #[tokio::test]
+    async fn wg_multi_client_portal() {
+        use std::sync::atomic::AtomicU32;
+
+        let server_secret = x25519::StaticSecret::random_from_rng(rand::thread_rng());
+        let server_public = x25519::PublicKey::from(&server_secret);
+
+        let client1_secret = x25519::StaticSecret::random_from_rng(rand::thread_rng());
+        let client1_public = x25519::PublicKey::from(&client1_secret);
+
+        let client2_secret = x25519::StaticSecret::random_from_rng(rand::thread_rng());
+        let client2_public = x25519::PublicKey::from(&client2_secret);
+
+        let clients = Arc::new(DashMap::new());
+        clients.insert(client1_public, "client1".to_string());
+        clients.insert(client2_public, "client2".to_string());
+
+        let server_config = WgPortalServerConfig {
+            server_secret_key: server_secret.clone(),
+            server_public_key: server_public.clone(),
+            clients,
+            next_index: Arc::new(AtomicU32::new(1)),
+        };
+
+        let mut listener =
+            WgTunnelListener::new_for_portal("wg://127.0.0.1:5588".parse().unwrap(), server_config);
+        listener.listen().await.unwrap();
+
+        let client1_wg_cfg = WgConfig {
+            my_secret_key: client1_secret,
+            my_public_key: client1_public,
+            peer_secret_key: server_secret.clone(),
+            peer_public_key: server_public.clone(),
+            wg_type: WgType::ExternalUse,
+        };
+
+        let client2_wg_cfg = WgConfig {
+            my_secret_key: client2_secret,
+            my_public_key: client2_public,
+            peer_secret_key: server_secret.clone(),
+            peer_public_key: server_public.clone(),
+            wg_type: WgType::ExternalUse,
+        };
+
+        // Client 1 connects
+        let mut connector1 =
+            WgTunnelConnector::new("wg://127.0.0.1:5588".parse().unwrap(), client1_wg_cfg);
+        let t1 = connector1.connect().await;
+        assert!(t1.is_ok(), "client1 should connect");
+
+        // Client 2 connects
+        let mut connector2 =
+            WgTunnelConnector::new("wg://127.0.0.1:5588".parse().unwrap(), client2_wg_cfg);
+        let t2 = connector2.connect().await;
+        assert!(t2.is_ok(), "client2 should connect");
+
+        // Verify listener accepted both
+        let accepted1 = listener.accept().await;
+        assert!(accepted1.is_ok());
+
+        let accepted2 = listener.accept().await;
+        assert!(accepted2.is_ok());
+
+        // Verify peer_by_idx has both peers
+        assert_eq!(listener.wg_peer_by_idx.len(), 2);
+
+        // Unregistered client should fail to connect (timeout)
+        let unreg_secret = x25519::StaticSecret::random_from_rng(rand::thread_rng());
+        let unreg_public = x25519::PublicKey::from(&unreg_secret);
+        let unreg_cfg = WgConfig {
+            my_secret_key: unreg_secret,
+            my_public_key: unreg_public,
+            peer_secret_key: server_secret.clone(),
+            peer_public_key: server_public.clone(),
+            wg_type: WgType::ExternalUse,
+        };
+        let mut unreg_connector =
+            WgTunnelConnector::new("wg://127.0.0.1:5588".parse().unwrap(), unreg_cfg);
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            unreg_connector.connect(),
+        )
+        .await;
+        assert!(result.is_err() || result.unwrap().is_err(), "unregistered client should fail");
     }
 }

--- a/easytier/src/vpn_portal/wireguard.rs
+++ b/easytier/src/vpn_portal/wireguard.rs
@@ -1,4 +1,6 @@
 use std::{
+    collections::{HashMap, hash_map::DefaultHasher},
+    hash::{Hash, Hasher},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV6},
     sync::Arc,
 };
@@ -14,7 +16,7 @@ use tracing::Level;
 
 use crate::{
     common::{
-        config::NetworkIdentity,
+        config::{NetworkIdentity, VpnPortalClientConfig},
         global_ctx::{ArcGlobalCtx, GlobalCtxEvent},
         join_joinset_background, shrink_dashmap,
     },
@@ -23,7 +25,7 @@ use crate::{
         Tunnel, TunnelListener,
         mpsc::{MpscTunnel, MpscTunnelSender},
         packet_def::{PacketType, ZCPacket, ZCPacketType},
-        wireguard::{WgConfig, WgTunnelListener},
+        wireguard::{WgClientInfo, WgConfig, WgPortalServerConfig, WgTunnelListener},
     },
 };
 
@@ -43,32 +45,150 @@ pub(crate) fn get_wg_config_for_portal(nid: &NetworkIdentity) -> WgConfig {
 struct ClientEntry {
     endpoint_addr: Option<url::Url>,
     sink: MpscTunnelSender,
+    name: String,
+    assigned_ip: Ipv4Addr,
+    virtual_peer_id: u32,
+}
+
+struct IpAllocator {
+    cidr: cidr::Ipv4Cidr,
+    allocated: DashMap<Ipv4Addr, String>,
+}
+
+impl IpAllocator {
+    fn new(cidr: cidr::Ipv4Cidr) -> Self {
+        Self {
+            cidr,
+            allocated: DashMap::new(),
+        }
+    }
+
+    fn allocate(&self, client_name: &str, preferred: Option<Ipv4Addr>) -> Option<Ipv4Addr> {
+        if let Some(ip) = preferred {
+            if self.cidr.contains(&ip) && !self.allocated.contains_key(&ip) {
+                self.allocated.insert(ip, client_name.to_string());
+                return Some(ip);
+            }
+        }
+
+        for ip in self.cidr.iter() {
+            let addr = ip.address();
+            if addr == self.cidr.first_address() || addr == self.cidr.last_address() {
+                continue;
+            }
+            if !self.allocated.contains_key(&addr) {
+                self.allocated.insert(addr, client_name.to_string());
+                return Some(addr);
+            }
+        }
+        None
+    }
+
+    fn release(&self, ip: &Ipv4Addr) {
+        self.allocated.remove(ip);
+        shrink_dashmap(&self.allocated, None);
+    }
+}
+
+fn virtual_peer_id_from_pubkey(pubkey: &[u8]) -> u32 {
+    let mut hasher = DefaultHasher::new();
+    pubkey.hash(&mut hasher);
+    let hash = hasher.finish();
+    (hash as u32) | 0x80000000
 }
 
 struct WireGuardImpl {
     global_ctx: ArcGlobalCtx,
     peer_mgr: Arc<PeerManager>,
-    wg_config: WgConfig,
+    wg_config: Option<WgConfig>,
+    server_config: Option<WgPortalServerConfig>,
     listener_addr: SocketAddr,
-
+    ip_allocator: Option<Arc<IpAllocator>>,
+    client_configs: HashMap<String, VpnPortalClientConfig>,
     wg_peer_ip_table: WgPeerIpTable,
-
     tasks: Arc<std::sync::Mutex<JoinSet<()>>>,
 }
 
 impl WireGuardImpl {
     fn new(global_ctx: ArcGlobalCtx, peer_mgr: Arc<PeerManager>) -> Self {
-        let nid = global_ctx.get_network_identity();
-        let wg_config = get_wg_config_for_portal(&nid);
-
         let vpn_cfg = global_ctx.config.get_vpn_portal_config().unwrap();
         let listener_addr = vpn_cfg.wireguard_listen;
+
+        let mut client_configs = HashMap::new();
+        for c in &vpn_cfg.clients {
+            client_configs.insert(c.name.clone(), c.clone());
+        }
+
+        let (wg_config, server_config, ip_allocator) = if vpn_cfg.clients.is_empty() {
+            let nid = global_ctx.get_network_identity();
+            let wg_config = get_wg_config_for_portal(&nid);
+            (Some(wg_config), None, None)
+        } else {
+            let server_secret_key = if let Some(ref key_b64) = vpn_cfg.wireguard_private_key {
+                let key_bytes = BASE64_STANDARD
+                    .decode(key_b64)
+                    .expect("invalid wireguard private key");
+                boringtun::x25519::StaticSecret::from(
+                    <[u8; 32]>::try_from(key_bytes.as_slice()).expect("invalid key length"),
+                )
+            } else {
+                let nid = global_ctx.get_network_identity();
+                let key_seed = format!(
+                    "{}{}",
+                    nid.network_name,
+                    nid.network_secret.as_ref().unwrap_or(&"".to_string())
+                );
+                let mut my_sec = [0u8; 32];
+                crate::tunnel::generate_digest_from_str("server", &key_seed, &mut my_sec);
+                boringtun::x25519::StaticSecret::from(my_sec)
+            };
+            let server_public_key = boringtun::x25519::PublicKey::from(&server_secret_key);
+
+            let clients = Arc::new(DashMap::new());
+            for client in &vpn_cfg.clients {
+                if let Ok(pubkey_bytes) = BASE64_STANDARD.decode(&client.client_public_key) {
+                    if let Ok(pubkey_arr) = <[u8; 32]>::try_from(pubkey_bytes.as_slice()) {
+                        let pubkey = boringtun::x25519::PublicKey::from(pubkey_arr);
+                        clients.insert(pubkey, client.name.clone());
+                    }
+                }
+            }
+
+            let server_config = WgPortalServerConfig {
+                server_secret_key,
+                server_public_key,
+                clients,
+                next_index: Arc::new(std::sync::atomic::AtomicU32::new(1)),
+            };
+
+            let ip_allocator = {
+                let cidr = if let Some(ipv4) = global_ctx.get_ipv4() {
+                    cidr::Ipv4Cidr::new(ipv4.address(), ipv4.network_length())
+                        .unwrap_or(vpn_cfg.client_cidr)
+                } else {
+                    vpn_cfg.client_cidr
+                };
+                let allocator = IpAllocator::new(cidr);
+                // Reserve the server's own IP if it falls within the allocation range
+                if let Some(ipv4) = global_ctx.get_ipv4() {
+                    if cidr.contains(&ipv4.address()) {
+                        allocator.allocated.insert(ipv4.address(), "server".to_string());
+                    }
+                }
+                Some(Arc::new(allocator))
+            };
+
+            (None, Some(server_config), ip_allocator)
+        };
 
         Self {
             global_ctx,
             peer_mgr,
             wg_config,
+            server_config,
             listener_addr,
+            ip_allocator,
+            client_configs,
             wg_peer_ip_table: Arc::new(DashMap::new()),
             tasks: Arc::new(std::sync::Mutex::new(JoinSet::new())),
         }
@@ -78,6 +198,10 @@ impl WireGuardImpl {
         t: Box<dyn Tunnel>,
         peer_mgr: Arc<PeerManager>,
         wg_peer_ip_table: WgPeerIpTable,
+        ip_allocator: Option<Arc<IpAllocator>>,
+        client_name: Option<String>,
+        client_pubkey: Option<Vec<u8>>,
+        client_configs: HashMap<String, VpnPortalClientConfig>,
     ) {
         let info = t.info().unwrap_or_default();
         let mut mpsc_tunnel = MpscTunnel::new(t, None);
@@ -86,12 +210,43 @@ impl WireGuardImpl {
 
         let remote_addr = info.remote_addr.clone();
         let endpoint_addr = remote_addr.clone().map(Into::into);
-        peer_mgr
-            .get_global_ctx()
-            .issue_event(GlobalCtxEvent::VpnPortalClientConnected(
-                info.local_addr.clone().unwrap_or_default().to_string(),
-                info.remote_addr.clone().unwrap_or_default().to_string(),
-            ));
+
+        let assigned = if let (Some(allocator), Some(name), Some(pubkey)) =
+            (&ip_allocator, &client_name, &client_pubkey)
+        {
+            let preferred = client_configs.get(name).and_then(|c| c.assigned_ip);
+            let ip = allocator
+                .allocate(name, preferred)
+                .unwrap_or_else(|| {
+                    tracing::error!("Failed to allocate IP for client: {}", name);
+                    Ipv4Addr::new(0, 0, 0, 0)
+                });
+
+            let virtual_peer_id = virtual_peer_id_from_pubkey(pubkey);
+            peer_mgr.add_virtual_peer(virtual_peer_id, ip);
+
+            peer_mgr.get_global_ctx().issue_event(
+                GlobalCtxEvent::VpnPortalClientConnected(
+                    info.local_addr.clone().unwrap_or_default().to_string(),
+                    format!(
+                        "{} ({} / {})",
+                        info.remote_addr.clone().unwrap_or_default(),
+                        name,
+                        ip
+                    ),
+                ),
+            );
+
+            Some((ip, virtual_peer_id, name.clone()))
+        } else {
+            peer_mgr.get_global_ctx().issue_event(
+                GlobalCtxEvent::VpnPortalClientConnected(
+                    info.local_addr.clone().unwrap_or_default().to_string(),
+                    info.remote_addr.clone().unwrap_or_default().to_string(),
+                ),
+            );
+            None
+        };
 
         let mut map_key = None;
 
@@ -118,10 +273,11 @@ impl WireGuardImpl {
                 let client_entry = Arc::new(ClientEntry {
                     endpoint_addr: endpoint_addr.clone(),
                     sink: mpsc_tunnel.get_sink(),
+                    name: assigned.as_ref().map(|a| a.2.clone()).unwrap_or_default(),
+                    assigned_ip: assigned.as_ref().map(|a| a.0).unwrap_or_else(|| i.get_source()),
+                    virtual_peer_id: assigned.as_ref().map(|a| a.1).unwrap_or(0),
                 });
                 map_key = Some(i.get_source());
-                // Be careful here: we may overwrite an existing entry if the client IP is reused,
-                // which is common when clients are behind NAT.
                 wg_peer_ip_table.insert(i.get_source(), client_entry.clone());
                 ip_registered = true;
             }
@@ -137,12 +293,20 @@ impl WireGuardImpl {
         }
 
         if let Some(map_key) = map_key {
-            // Remove the client from the wg_peer_ip_table only when its endpoint address is unchanged,
-            // or we may break clients behind NAT.
             match wg_peer_ip_table
                 .remove_if(&map_key, |_, entry| entry.endpoint_addr == endpoint_addr)
             {
-                Some(_) => tracing::info!(?map_key, "Removed wg client from table"),
+                Some((_, entry)) => {
+                    tracing::info!(?map_key, "Removed wg client from table");
+                    if let Some((ip, virtual_peer_id, _)) = assigned {
+                        if entry.assigned_ip == ip {
+                            if let Some(ref allocator) = ip_allocator {
+                                allocator.release(&ip);
+                            }
+                            peer_mgr.remove_virtual_peer(virtual_peer_id);
+                        }
+                    }
+                }
                 None => tracing::info!(
                     ?map_key,
                     "The wg client changed its endpoint address, not removing from table"
@@ -218,7 +382,12 @@ impl WireGuardImpl {
         let mut listener_url = url::Url::parse("wg://0.0.0.0:0").unwrap();
         listener_url.set_port(Some(listener_addr.port())).unwrap();
         listener_url.set_ip_host(listener_addr.ip()).unwrap();
-        let mut l = WgTunnelListener::new(listener_url.clone(), self.wg_config.clone());
+
+        let mut l = if let Some(ref srv_cfg) = self.server_config {
+            WgTunnelListener::new_for_portal(listener_url.clone(), srv_cfg.clone())
+        } else {
+            WgTunnelListener::new(listener_url.clone(), self.wg_config.clone().unwrap())
+        };
 
         tracing::info!("Wireguard VPN Portal Starting");
 
@@ -231,15 +400,33 @@ impl WireGuardImpl {
         let tasks = Arc::downgrade(&self.tasks.clone());
         let peer_mgr = self.peer_mgr.clone();
         let wg_peer_ip_table = self.wg_peer_ip_table.clone();
+        let ip_allocator = self.ip_allocator.clone();
+        let client_configs = self.client_configs.clone();
         self.tasks.lock().unwrap().spawn(async move {
             while let Ok(t) = l.accept().await {
                 let Some(tasks) = tasks.upgrade() else {
                     break;
                 };
+
+                let (client_name, client_pubkey) =
+                    if let Some(data) = t.get_associate_data() {
+                        if let Some(info) = data.downcast_ref::<WgClientInfo>() {
+                            (Some(info.name.clone()), Some(info.pubkey.to_vec()))
+                        } else {
+                            (None, None)
+                        }
+                    } else {
+                        (None, None)
+                    };
+
                 tasks.lock().unwrap().spawn(Self::handle_incoming_conn(
                     t,
                     peer_mgr.clone(),
                     wg_peer_ip_table.clone(),
+                    ip_allocator.clone(),
+                    client_name,
+                    client_pubkey,
+                    client_configs.clone(),
                 ));
             }
         });
@@ -250,12 +437,27 @@ impl WireGuardImpl {
         Ok(())
     }
 
+    async fn run_virtual_peer_refresh(
+        peer_mgr: Arc<PeerManager>,
+        wg_peer_ip_table: WgPeerIpTable,
+    ) {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
+        loop {
+            interval.tick().await;
+            for entry in wg_peer_ip_table.iter() {
+                let virtual_peer_id = entry.value().virtual_peer_id;
+                if virtual_peer_id != 0 {
+                    peer_mgr.refresh_virtual_peer(virtual_peer_id);
+                }
+            }
+        }
+    }
+
     #[tracing::instrument(skip(self), err(level = Level::WARN))]
     async fn start(&self) -> anyhow::Result<()> {
         tracing::info!("Wireguard VPN Portal Starting");
 
         self.start_listener(&self.listener_addr).await?;
-        // if binding to v4 unspecified, also start a listener on v6 unspecified
         if let SocketAddr::V4(v4) = &self.listener_addr
             && v4.ip().is_unspecified()
         {
@@ -268,6 +470,15 @@ impl WireGuardImpl {
                 )))
                 .await;
         };
+
+        if self.server_config.is_some() {
+            let peer_mgr = self.peer_mgr.clone();
+            let wg_peer_ip_table = self.wg_peer_ip_table.clone();
+            self.tasks.lock().unwrap().spawn(Self::run_virtual_peer_refresh(
+                peer_mgr,
+                wg_peer_ip_table,
+            ));
+        }
 
         join_joinset_background(self.tasks.clone(), "wireguard".to_string());
         self.start_pipeline_processor().await;
@@ -310,6 +521,7 @@ impl VpnPortal for WireGuard {
             return "ERROR: VPN Portal Config Not Set".to_string();
         }
 
+        let vpn_cfg = global_ctx.config.get_vpn_portal_config().unwrap();
         let routes = peer_mgr.list_routes().await;
         let mut allow_ips = routes
             .iter()
@@ -325,34 +537,57 @@ impl VpnPortal for WireGuard {
             allow_ips.push(inet.network().to_string());
         }
 
-        let vpn_cfg = global_ctx.config.get_vpn_portal_config().unwrap();
-        let client_cidr = vpn_cfg.client_cidr;
-
-        allow_ips.push(client_cidr.to_string());
-
+        allow_ips.push(vpn_cfg.client_cidr.to_string());
         let allow_ips = allow_ips.into_iter().collect::<Vec<_>>().join(",");
 
-        let cfg = self.inner.as_ref().unwrap().wg_config.clone();
-        let cfg_str = format!(
-            r#"
-[Interface]
-PrivateKey = {peer_secret_key}
-Address = {address} # should assign an ip from this cidr manually
+        let listener_addr = self.inner.as_ref().unwrap().listener_addr;
+
+        if let Some(ref srv_cfg) = self.inner.as_ref().unwrap().server_config {
+            // Multi-client mode: generate config for each registered client
+            let mut output = String::new();
+            for client in &vpn_cfg.clients {
+                output.push_str(&format!("\n# Client: {}\n", client.name));
+                let assigned_ip = client
+                    .assigned_ip
+                    .map(|ip| ip.to_string() + "/32")
+                    .unwrap_or_else(|| "auto".to_string());
+                output.push_str(&format!(
+                    r#"[Interface]
+PrivateKey = <your private key>
+Address = {assigned_ip}
 
 [Peer]
 PublicKey = {my_public_key}
 AllowedIPs = {allow_ips}
-Endpoint = {listenr_addr} # should be the public ip(or domain) of the vpn server
+Endpoint = {listener_addr}
 PersistentKeepalive = 25
 "#,
-            peer_secret_key = BASE64_STANDARD.encode(cfg.peer_secret_key()),
-            my_public_key = BASE64_STANDARD.encode(cfg.my_public_key()),
-            listenr_addr = self.inner.as_ref().unwrap().listener_addr,
-            allow_ips = allow_ips,
-            address = client_cidr.first_address().to_string() + "/32",
-        );
+                    my_public_key = BASE64_STANDARD.encode(srv_cfg.server_public_key.as_bytes()),
+                ));
+            }
+            output
+        } else {
+            // Legacy single-key mode
+            let cfg = self.inner.as_ref().unwrap().wg_config.clone().unwrap();
+            format!(
+                r#"
+[Interface]
+PrivateKey = {peer_secret_key}
+Address = {address}
 
-        cfg_str
+[Peer]
+PublicKey = {my_public_key}
+AllowedIPs = {allow_ips}
+Endpoint = {listener_addr}
+PersistentKeepalive = 25
+"#,
+                peer_secret_key = BASE64_STANDARD.encode(cfg.peer_secret_key()),
+                my_public_key = BASE64_STANDARD.encode(cfg.my_public_key()),
+                listener_addr = listener_addr,
+                allow_ips = allow_ips,
+                address = vpn_cfg.client_cidr.first_address().to_string() + "/32",
+            )
+        }
     }
 
     fn name(&self) -> String {
@@ -366,14 +601,138 @@ PersistentKeepalive = 25
                 w.wg_peer_ip_table
                     .iter()
                     .map(|x| {
-                        x.value()
-                            .endpoint_addr
-                            .as_ref()
-                            .map(|x| x.to_string())
-                            .unwrap_or_default()
+                        let entry = x.value();
+                        format!(
+                            "{}: {} (ip: {})",
+                            entry.name,
+                            entry
+                                .endpoint_addr
+                                .as_ref()
+                                .map(|x| x.to_string())
+                                .unwrap_or_default(),
+                            entry.assigned_ip
+                        )
                     })
                     .collect()
             })
             .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::config::ConfigLoader;
+
+    #[test]
+    fn test_ip_allocator_basic() {
+        let cidr = "10.14.14.0/24".parse().unwrap();
+        let allocator = IpAllocator::new(cidr);
+
+        let ip1 = allocator.allocate("client1", None).unwrap();
+        assert!(cidr.contains(&ip1));
+        assert_ne!(ip1, cidr.first_address());
+        assert_ne!(ip1, cidr.last_address());
+
+        let ip2 = allocator.allocate("client2", None).unwrap();
+        assert_ne!(ip1, ip2);
+
+        allocator.release(&ip1);
+        let ip3 = allocator.allocate("client3", None).unwrap();
+        assert_eq!(ip1, ip3); // should reuse released ip
+    }
+
+    #[test]
+    fn test_ip_allocator_preferred() {
+        let cidr = "10.14.14.0/24".parse().unwrap();
+        let allocator = IpAllocator::new(cidr);
+
+        let preferred = "10.14.14.100".parse().unwrap();
+        let ip = allocator.allocate("client1", Some(preferred)).unwrap();
+        assert_eq!(ip, preferred);
+    }
+
+    #[test]
+    fn test_ip_allocator_preferred_conflict() {
+        let cidr = "10.14.14.0/24".parse().unwrap();
+        let allocator = IpAllocator::new(cidr);
+
+        let preferred = "10.14.14.100".parse().unwrap();
+        allocator.allocate("client1", Some(preferred)).unwrap();
+
+        // preferred ip already taken, should allocate another one
+        let ip2 = allocator.allocate("client2", Some(preferred)).unwrap();
+        assert_ne!(ip2, preferred);
+    }
+
+    #[test]
+    fn test_ip_allocator_reserve_server_ip() {
+        let cidr = "10.14.14.0/24".parse().unwrap();
+        let allocator = IpAllocator::new(cidr);
+        let server_ip: Ipv4Addr = "10.14.14.1".parse().unwrap();
+        allocator.allocated.insert(server_ip, "server".to_string());
+
+        let ip = allocator.allocate("client1", None).unwrap();
+        assert_ne!(ip, server_ip);
+    }
+
+    #[test]
+    fn test_virtual_peer_id_deterministic() {
+        let pubkey1 = [1u8; 32];
+        let pubkey2 = [2u8; 32];
+
+        let id1a = virtual_peer_id_from_pubkey(&pubkey1);
+        let id1b = virtual_peer_id_from_pubkey(&pubkey1);
+        let id2 = virtual_peer_id_from_pubkey(&pubkey2);
+
+        assert_eq!(id1a, id1b);
+        assert_ne!(id1a, id2);
+        assert!(id1a >= 0x80000000);
+    }
+
+    #[test]
+    fn test_wireguard_impl_mode_selection_legacy() {
+        use crate::common::config::TomlConfigLoader;
+        let cfg_str = r#"
+            [network_identity]
+            network_name = "test"
+            network_secret = "secret"
+
+            [vpn_portal_config]
+            client_cidr = "10.14.14.0/24"
+            wireguard_listen = "0.0.0.0:12345"
+        "#;
+        let loader = TomlConfigLoader::new_from_str(cfg_str).unwrap();
+        let vpn_cfg = loader.get_vpn_portal_config().unwrap();
+        assert!(vpn_cfg.clients.is_empty());
+        assert_eq!(vpn_cfg.wireguard_private_key, None);
+    }
+
+    #[test]
+    fn test_wireguard_impl_mode_selection_multi_client() {
+        use crate::common::config::TomlConfigLoader;
+        let cfg_str = r#"
+            [network_identity]
+            network_name = "test"
+            network_secret = "secret"
+
+            [[vpn_portal_config.clients]]
+            name = "client1"
+            client_public_key = "YZT/1P/7IjvKkNA3yq5+1xyn1SQT0p+2eEaL7gSFg0="
+
+            [[vpn_portal_config.clients]]
+            name = "client2"
+            client_public_key = "YZT/1P/7IjvKkNA3yq5+1xyn1SQT0p+2eEaL7gSFg1="
+            assigned_ip = "10.14.14.10"
+
+            [vpn_portal_config]
+            client_cidr = "10.14.14.0/24"
+            wireguard_listen = "0.0.0.0:12345"
+        "#;
+        let loader = TomlConfigLoader::new_from_str(cfg_str).unwrap();
+        let vpn_cfg = loader.get_vpn_portal_config().unwrap();
+        assert_eq!(vpn_cfg.clients.len(), 2);
+        assert_eq!(vpn_cfg.clients[0].name, "client1");
+        assert_eq!(vpn_cfg.clients[1].assigned_ip, Some("10.14.14.10".parse().unwrap()));
     }
 }

--- a/easytier/src/vpn_portal/wireguard.rs
+++ b/easytier/src/vpn_portal/wireguard.rs
@@ -1,16 +1,27 @@
 use std::{
-    collections::{HashMap, hash_map::DefaultHasher},
+    collections::{HashMap, HashSet, hash_map::DefaultHasher},
     hash::{Hash, Hasher},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV6},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
 };
 
 use anyhow::Context;
 use base64::{Engine, prelude::BASE64_STANDARD};
+use bytes::BytesMut;
 use cidr::Ipv4Inet;
-use dashmap::DashMap;
+use dashmap::{DashMap, mapref::entry::Entry};
 use futures::StreamExt;
-use pnet::packet::ipv4::Ipv4Packet;
+use pnet::packet::{MutablePacket, Packet};
+use pnet::packet::{
+    icmp::{IcmpPacket, IcmpTypes},
+    ip::{IpNextHeaderProtocol, IpNextHeaderProtocols},
+    ipv4::{self, Ipv4Flags, Ipv4Packet, MutableIpv4Packet},
+    tcp::{self, MutableTcpPacket},
+    udp::{self, MutableUdpPacket},
+};
 use tokio::task::JoinSet;
 use tracing::Level;
 
@@ -32,6 +43,7 @@ use crate::{
 use super::VpnPortal;
 
 type WgPeerIpTable = Arc<DashMap<Ipv4Addr, Arc<ClientEntry>>>;
+static NEXT_CLIENT_CONNECTION_ID: AtomicU64 = AtomicU64::new(1);
 
 pub(crate) fn get_wg_config_for_portal(nid: &NetworkIdentity) -> WgConfig {
     let key_seed = format!(
@@ -43,11 +55,37 @@ pub(crate) fn get_wg_config_for_portal(nid: &NetworkIdentity) -> WgConfig {
 }
 
 struct ClientEntry {
+    connection_id: u64,
     endpoint_addr: Option<url::Url>,
     sink: MpscTunnelSender,
     name: String,
     assigned_ip: Ipv4Addr,
+    tunnel_ip: Ipv4Addr,
     virtual_peer_id: u32,
+}
+
+#[derive(Debug, Clone)]
+struct AssignedClient {
+    assigned_ip: Ipv4Addr,
+    tunnel_ip: Ipv4Addr,
+    virtual_peer_id: u32,
+    name: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Ipv4NatError {
+    InvalidPacket,
+    InvalidTransportPacket,
+    UnexpectedSource {
+        actual: Ipv4Addr,
+        expected: Ipv4Addr,
+    },
+    UnexpectedDestination {
+        actual: Ipv4Addr,
+        expected: Ipv4Addr,
+    },
+    UnsupportedFragment,
+    UnsupportedProtocol(IpNextHeaderProtocol),
 }
 
 struct IpAllocator {
@@ -63,21 +101,34 @@ impl IpAllocator {
         }
     }
 
+    fn is_assignable(&self, ip: Ipv4Addr) -> bool {
+        is_assignable_client_ip(self.cidr, ip)
+    }
+
+    fn try_claim(&self, ip: Ipv4Addr, client_name: &str) -> bool {
+        match self.allocated.entry(ip) {
+            Entry::Vacant(entry) => {
+                entry.insert(client_name.to_string());
+                true
+            }
+            Entry::Occupied(_) => false,
+        }
+    }
+
     fn allocate(&self, client_name: &str, preferred: Option<Ipv4Addr>) -> Option<Ipv4Addr> {
         if let Some(ip) = preferred {
-            if self.cidr.contains(&ip) && !self.allocated.contains_key(&ip) {
-                self.allocated.insert(ip, client_name.to_string());
+            if self.try_claim(ip, client_name) {
                 return Some(ip);
             }
+            return None;
         }
 
         for ip in self.cidr.iter() {
             let addr = ip.address();
-            if addr == self.cidr.first_address() || addr == self.cidr.last_address() {
+            if !self.is_assignable(addr) {
                 continue;
             }
-            if !self.allocated.contains_key(&addr) {
-                self.allocated.insert(addr, client_name.to_string());
+            if self.try_claim(addr, client_name) {
                 return Some(addr);
             }
         }
@@ -97,6 +148,198 @@ fn virtual_peer_id_from_pubkey(pubkey: &[u8]) -> u32 {
     (hash as u32) | 0x80000000
 }
 
+fn is_assignable_client_ip(cidr: cidr::Ipv4Cidr, ip: Ipv4Addr) -> bool {
+    cidr.contains(&ip) && ip != cidr.first_address() && ip != cidr.last_address()
+}
+
+fn ipv4_packet_total_len(packet: &[u8]) -> Result<usize, Ipv4NatError> {
+    let ipv4_packet = Ipv4Packet::new(packet).ok_or(Ipv4NatError::InvalidPacket)?;
+    if ipv4_packet.get_version() != 4 {
+        return Err(Ipv4NatError::InvalidPacket);
+    }
+
+    let header_len = ipv4_packet.get_header_length() as usize * 4;
+    let total_len = ipv4_packet.get_total_length() as usize;
+    if header_len < Ipv4Packet::minimum_packet_size()
+        || total_len < header_len
+        || total_len > packet.len()
+    {
+        return Err(Ipv4NatError::InvalidPacket);
+    }
+
+    Ok(total_len)
+}
+
+fn update_ipv4_checksum(ipv4_packet: &mut MutableIpv4Packet) {
+    ipv4_packet.set_checksum(ipv4::checksum(&ipv4_packet.to_immutable()));
+}
+
+fn update_transport_checksum(ipv4_packet: &mut MutableIpv4Packet) -> Result<(), Ipv4NatError> {
+    let source = ipv4_packet.get_source();
+    let destination = ipv4_packet.get_destination();
+    let protocol = ipv4_packet.get_next_level_protocol();
+
+    match protocol {
+        IpNextHeaderProtocols::Tcp => {
+            let mut tcp_packet = MutableTcpPacket::new(ipv4_packet.payload_mut())
+                .ok_or(Ipv4NatError::InvalidTransportPacket)?;
+            tcp_packet.set_checksum(tcp::ipv4_checksum(
+                &tcp_packet.to_immutable(),
+                &source,
+                &destination,
+            ));
+        }
+        IpNextHeaderProtocols::Udp => {
+            let mut udp_packet = MutableUdpPacket::new(ipv4_packet.payload_mut())
+                .ok_or(Ipv4NatError::InvalidTransportPacket)?;
+            if udp_packet.get_checksum() != 0 {
+                udp_packet.set_checksum(udp::ipv4_checksum(
+                    &udp_packet.to_immutable(),
+                    &source,
+                    &destination,
+                ));
+            }
+        }
+        IpNextHeaderProtocols::Icmp => {
+            let icmp_packet = IcmpPacket::new(ipv4_packet.payload())
+                .ok_or(Ipv4NatError::InvalidTransportPacket)?;
+            let icmp_type = icmp_packet.get_icmp_type();
+            if icmp_type != IcmpTypes::EchoRequest && icmp_type != IcmpTypes::EchoReply {
+                return Err(Ipv4NatError::UnsupportedProtocol(protocol));
+            }
+        }
+        _ => return Err(Ipv4NatError::UnsupportedProtocol(protocol)),
+    }
+
+    Ok(())
+}
+
+fn reject_fragmented_packet(ipv4_packet: &MutableIpv4Packet) -> Result<(), Ipv4NatError> {
+    if ipv4_packet.get_fragment_offset() != 0
+        || ipv4_packet.get_flags() & Ipv4Flags::MoreFragments != 0
+    {
+        return Err(Ipv4NatError::UnsupportedFragment);
+    }
+
+    Ok(())
+}
+
+fn rewrite_ipv4_source(
+    packet: &mut BytesMut,
+    expected_source: Ipv4Addr,
+    new_source: Ipv4Addr,
+) -> Result<(), Ipv4NatError> {
+    let total_len = ipv4_packet_total_len(packet.as_ref())?;
+    let mut ipv4_packet =
+        MutableIpv4Packet::new(&mut packet[..total_len]).ok_or(Ipv4NatError::InvalidPacket)?;
+    let actual_source = ipv4_packet.get_source();
+    if actual_source != expected_source {
+        return Err(Ipv4NatError::UnexpectedSource {
+            actual: actual_source,
+            expected: expected_source,
+        });
+    }
+    if actual_source == new_source {
+        return Ok(());
+    }
+
+    reject_fragmented_packet(&ipv4_packet)?;
+    ipv4_packet.set_source(new_source);
+    update_transport_checksum(&mut ipv4_packet)?;
+    update_ipv4_checksum(&mut ipv4_packet);
+
+    Ok(())
+}
+
+fn rewrite_ipv4_destination(
+    packet: &mut BytesMut,
+    expected_destination: Ipv4Addr,
+    new_destination: Ipv4Addr,
+) -> Result<(), Ipv4NatError> {
+    let total_len = ipv4_packet_total_len(packet.as_ref())?;
+    let mut ipv4_packet =
+        MutableIpv4Packet::new(&mut packet[..total_len]).ok_or(Ipv4NatError::InvalidPacket)?;
+    let actual_destination = ipv4_packet.get_destination();
+    if actual_destination != expected_destination {
+        return Err(Ipv4NatError::UnexpectedDestination {
+            actual: actual_destination,
+            expected: expected_destination,
+        });
+    }
+    if actual_destination == new_destination {
+        return Ok(());
+    }
+
+    reject_fragmented_packet(&ipv4_packet)?;
+    ipv4_packet.set_destination(new_destination);
+    update_transport_checksum(&mut ipv4_packet)?;
+    update_ipv4_checksum(&mut ipv4_packet);
+
+    Ok(())
+}
+
+fn build_client_config_map(
+    clients: &[VpnPortalClientConfig],
+    cidr: cidr::Ipv4Cidr,
+    server_ip: Option<Ipv4Addr>,
+) -> HashMap<String, VpnPortalClientConfig> {
+    let mut used_ips = HashSet::new();
+    if let Some(server_ip) = server_ip {
+        used_ips.insert(server_ip);
+    }
+
+    let mut client_configs = HashMap::new();
+    for client in clients {
+        let mut config = client.clone();
+        if let Some(ip) = config.assigned_ip
+            && !used_ips.insert(ip)
+        {
+            tracing::warn!(
+                client = %config.name,
+                %ip,
+                "Configured WireGuard virtual client IP is already reserved"
+            );
+            config.assigned_ip = None;
+        }
+        client_configs.insert(config.name.clone(), config);
+    }
+
+    for client in clients {
+        let Some(config) = client_configs.get_mut(&client.name) else {
+            continue;
+        };
+        if config.assigned_ip.is_some() {
+            continue;
+        }
+
+        let next_ip = cidr
+            .iter()
+            .map(|ip| ip.address())
+            .find(|ip| is_assignable_client_ip(cidr, *ip) && !used_ips.contains(ip));
+        if let Some(ip) = next_ip {
+            used_ips.insert(ip);
+            config.assigned_ip = Some(ip);
+        } else {
+            tracing::error!(
+                client = %config.name,
+                %cidr,
+                "No assignable WireGuard client IP is available"
+            );
+        }
+    }
+
+    for client in clients {
+        let Some(config) = client_configs.get_mut(&client.name) else {
+            continue;
+        };
+        if config.tunnel_ip.is_none() {
+            config.tunnel_ip = config.assigned_ip;
+        }
+    }
+
+    client_configs
+}
+
 struct WireGuardImpl {
     global_ctx: ArcGlobalCtx,
     peer_mgr: Arc<PeerManager>,
@@ -114,15 +357,11 @@ impl WireGuardImpl {
         let vpn_cfg = global_ctx.config.get_vpn_portal_config().unwrap();
         let listener_addr = vpn_cfg.wireguard_listen;
 
-        let mut client_configs = HashMap::new();
-        for c in &vpn_cfg.clients {
-            client_configs.insert(c.name.clone(), c.clone());
-        }
-
-        let (wg_config, server_config, ip_allocator) = if vpn_cfg.clients.is_empty() {
+        let (wg_config, server_config, ip_allocator, client_configs) = if vpn_cfg.clients.is_empty()
+        {
             let nid = global_ctx.get_network_identity();
             let wg_config = get_wg_config_for_portal(&nid);
-            (Some(wg_config), None, None)
+            (Some(wg_config), None, None, HashMap::new())
         } else {
             let server_secret_key = if let Some(ref key_b64) = vpn_cfg.wireguard_private_key {
                 let key_bytes = BASE64_STANDARD
@@ -146,11 +385,11 @@ impl WireGuardImpl {
 
             let clients = Arc::new(DashMap::new());
             for client in &vpn_cfg.clients {
-                if let Ok(pubkey_bytes) = BASE64_STANDARD.decode(&client.client_public_key) {
-                    if let Ok(pubkey_arr) = <[u8; 32]>::try_from(pubkey_bytes.as_slice()) {
-                        let pubkey = boringtun::x25519::PublicKey::from(pubkey_arr);
-                        clients.insert(pubkey, client.name.clone());
-                    }
+                if let Ok(pubkey_bytes) = BASE64_STANDARD.decode(&client.client_public_key)
+                    && let Ok(pubkey_arr) = <[u8; 32]>::try_from(pubkey_bytes.as_slice())
+                {
+                    let pubkey = boringtun::x25519::PublicKey::from(pubkey_arr);
+                    clients.insert(pubkey, client.name.clone());
                 }
             }
 
@@ -161,24 +400,27 @@ impl WireGuardImpl {
                 next_index: Arc::new(std::sync::atomic::AtomicU32::new(1)),
             };
 
-            let ip_allocator = {
-                let cidr = if let Some(ipv4) = global_ctx.get_ipv4() {
-                    cidr::Ipv4Cidr::new(ipv4.address(), ipv4.network_length())
-                        .unwrap_or(vpn_cfg.client_cidr)
-                } else {
-                    vpn_cfg.client_cidr
-                };
-                let allocator = IpAllocator::new(cidr);
-                // Reserve the server's own IP if it falls within the allocation range
-                if let Some(ipv4) = global_ctx.get_ipv4() {
-                    if cidr.contains(&ipv4.address()) {
-                        allocator.allocated.insert(ipv4.address(), "server".to_string());
-                    }
-                }
-                Some(Arc::new(allocator))
-            };
+            let local_ipv4 = global_ctx.get_ipv4();
+            let cidr = local_ipv4
+                .map(|ipv4| ipv4.network())
+                .unwrap_or(vpn_cfg.client_cidr);
+            let client_configs =
+                build_client_config_map(&vpn_cfg.clients, cidr, local_ipv4.map(|ip| ip.address()));
 
-            (None, Some(server_config), ip_allocator)
+            let allocator = IpAllocator::new(cidr);
+            // Reserve the server's own IP if it falls within the allocation range.
+            if let Some(ipv4) = local_ipv4 {
+                allocator
+                    .allocated
+                    .insert(ipv4.address(), "server".to_string());
+            }
+
+            (
+                None,
+                Some(server_config),
+                Some(Arc::new(allocator)),
+                client_configs,
+            )
         };
 
         Self {
@@ -214,19 +456,30 @@ impl WireGuardImpl {
         let assigned = if let (Some(allocator), Some(name), Some(pubkey)) =
             (&ip_allocator, &client_name, &client_pubkey)
         {
-            let preferred = client_configs.get(name).and_then(|c| c.assigned_ip);
-            let ip = allocator
-                .allocate(name, preferred)
-                .unwrap_or_else(|| {
-                    tracing::error!("Failed to allocate IP for client: {}", name);
-                    Ipv4Addr::new(0, 0, 0, 0)
-                });
+            let Some(config) = client_configs.get(name) else {
+                tracing::error!(client = %name, "No config is available for client");
+                return;
+            };
+            let Some(preferred) = config.assigned_ip else {
+                tracing::error!("No configured IP is available for client: {}", name);
+                return;
+            };
+            let tunnel_ip = config.tunnel_ip.unwrap_or(preferred);
+            let Some(ip) = allocator.allocate(name, Some(preferred)) else {
+                tracing::error!(
+                    client = %name,
+                    %preferred,
+                    "Failed to allocate configured virtual IP for WireGuard client"
+                );
+                return;
+            };
 
             let virtual_peer_id = virtual_peer_id_from_pubkey(pubkey);
             peer_mgr.add_virtual_peer(virtual_peer_id, ip);
 
-            peer_mgr.get_global_ctx().issue_event(
-                GlobalCtxEvent::VpnPortalClientConnected(
+            peer_mgr
+                .get_global_ctx()
+                .issue_event(GlobalCtxEvent::VpnPortalClientConnected(
                     info.local_addr.clone().unwrap_or_default().to_string(),
                     format!(
                         "{} ({} / {})",
@@ -234,21 +487,40 @@ impl WireGuardImpl {
                         name,
                         ip
                     ),
-                ),
-            );
+                ));
 
-            Some((ip, virtual_peer_id, name.clone()))
+            Some(AssignedClient {
+                assigned_ip: ip,
+                tunnel_ip,
+                virtual_peer_id,
+                name: name.clone(),
+            })
         } else {
-            peer_mgr.get_global_ctx().issue_event(
-                GlobalCtxEvent::VpnPortalClientConnected(
+            peer_mgr
+                .get_global_ctx()
+                .issue_event(GlobalCtxEvent::VpnPortalClientConnected(
                     info.local_addr.clone().unwrap_or_default().to_string(),
                     info.remote_addr.clone().unwrap_or_default().to_string(),
-                ),
-            );
+                ));
             None
         };
 
         let mut map_key = None;
+        if let Some(assigned) = &assigned {
+            let connection_id = NEXT_CLIENT_CONNECTION_ID.fetch_add(1, Ordering::Relaxed);
+            let client_entry = Arc::new(ClientEntry {
+                connection_id,
+                endpoint_addr: endpoint_addr.clone(),
+                sink: mpsc_tunnel.get_sink(),
+                name: assigned.name.clone(),
+                assigned_ip: assigned.assigned_ip,
+                tunnel_ip: assigned.tunnel_ip,
+                virtual_peer_id: assigned.virtual_peer_id,
+            });
+            map_key = Some((assigned.assigned_ip, connection_id));
+            wg_peer_ip_table.insert(assigned.assigned_ip, client_entry);
+            ip_registered = true;
+        }
 
         loop {
             let msg = match stream.next().await {
@@ -264,25 +536,67 @@ impl WireGuardImpl {
             };
 
             assert_eq!(msg.packet_type(), ZCPacketType::WG);
-            let inner = msg.inner();
-            let Some(i) = Ipv4Packet::new(&inner) else {
+            let mut inner = msg.inner();
+            let Some((src, dst)) = Ipv4Packet::new(&inner).and_then(|i| {
+                (i.get_version() == 4).then_some((i.get_source(), i.get_destination()))
+            }) else {
                 tracing::error!(?inner, "Failed to parse ipv4 packet");
                 continue;
             };
+
+            if let Some(assigned) = &assigned {
+                match rewrite_ipv4_source(&mut inner, assigned.tunnel_ip, assigned.assigned_ip) {
+                    Ok(()) => {}
+                    Err(Ipv4NatError::UnexpectedSource { actual, expected }) => {
+                        tracing::warn!(
+                            client = %assigned.name,
+                            src = %actual,
+                            expected = %expected,
+                            "Rejecting WireGuard client packet with unexpected source IP"
+                        );
+                        break;
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            client = %assigned.name,
+                            ?err,
+                            "Dropping WireGuard client packet unsupported by VPN portal NAT"
+                        );
+                        continue;
+                    }
+                }
+            }
+
             if !ip_registered {
+                let assigned_ip = assigned
+                    .as_ref()
+                    .map(|assigned| assigned.assigned_ip)
+                    .unwrap_or(src);
+                let tunnel_ip = assigned
+                    .as_ref()
+                    .map(|assigned| assigned.tunnel_ip)
+                    .unwrap_or(src);
+                let connection_id = NEXT_CLIENT_CONNECTION_ID.fetch_add(1, Ordering::Relaxed);
                 let client_entry = Arc::new(ClientEntry {
+                    connection_id,
                     endpoint_addr: endpoint_addr.clone(),
                     sink: mpsc_tunnel.get_sink(),
-                    name: assigned.as_ref().map(|a| a.2.clone()).unwrap_or_default(),
-                    assigned_ip: assigned.as_ref().map(|a| a.0).unwrap_or_else(|| i.get_source()),
-                    virtual_peer_id: assigned.as_ref().map(|a| a.1).unwrap_or(0),
+                    name: assigned
+                        .as_ref()
+                        .map(|assigned| assigned.name.clone())
+                        .unwrap_or_default(),
+                    assigned_ip,
+                    tunnel_ip,
+                    virtual_peer_id: assigned
+                        .as_ref()
+                        .map(|assigned| assigned.virtual_peer_id)
+                        .unwrap_or(0),
                 });
-                map_key = Some(i.get_source());
-                wg_peer_ip_table.insert(i.get_source(), client_entry.clone());
+                map_key = Some((assigned_ip, connection_id));
+                wg_peer_ip_table.insert(assigned_ip, client_entry.clone());
                 ip_registered = true;
             }
-            tracing::trace!(?i, "Received from wg client");
-            let dst = i.get_destination();
+            tracing::trace!(?inner, "Received from wg client");
             let _ = peer_mgr
                 .send_msg_by_ip(
                     ZCPacket::new_with_payload(inner.as_ref()),
@@ -294,17 +608,17 @@ impl WireGuardImpl {
 
         if let Some(map_key) = map_key {
             match wg_peer_ip_table
-                .remove_if(&map_key, |_, entry| entry.endpoint_addr == endpoint_addr)
+                .remove_if(&map_key.0, |_, entry| entry.connection_id == map_key.1)
             {
                 Some((_, entry)) => {
                     tracing::info!(?map_key, "Removed wg client from table");
-                    if let Some((ip, virtual_peer_id, _)) = assigned {
-                        if entry.assigned_ip == ip {
-                            if let Some(ref allocator) = ip_allocator {
-                                allocator.release(&ip);
-                            }
-                            peer_mgr.remove_virtual_peer(virtual_peer_id);
+                    if let Some(assigned) = assigned
+                        && entry.assigned_ip == assigned.assigned_ip
+                    {
+                        if let Some(ref allocator) = ip_allocator {
+                            allocator.release(&assigned.assigned_ip);
                         }
+                        peer_mgr.remove_virtual_peer(assigned.virtual_peer_id);
                     }
                 }
                 None => tracing::info!(
@@ -313,6 +627,11 @@ impl WireGuardImpl {
                 ),
             }
             shrink_dashmap(&wg_peer_ip_table, None);
+        } else if let Some(assigned) = assigned {
+            if let Some(ref allocator) = ip_allocator {
+                allocator.release(&assigned.assigned_ip);
+            }
+            peer_mgr.remove_virtual_peer(assigned.virtual_peer_id);
         }
 
         peer_mgr
@@ -341,22 +660,30 @@ impl WireGuardImpl {
                 if ipv4.get_version() != 4 {
                     return Some(packet);
                 }
+                let destination = ipv4.get_destination();
 
-                let Some(entry) = self
-                    .wg_peer_ip_table
-                    .get(&ipv4.get_destination())
-                    .map(|f| f.clone())
-                else {
+                let Some(entry) = self.wg_peer_ip_table.get(&destination).map(|f| f.clone()) else {
                     return Some(packet);
                 };
 
                 tracing::trace!(?ipv4, "Packet filter for vpn portal");
 
                 let payload_offset = packet.packet_type().get_packet_offsets().payload_offset;
-                let packet = ZCPacket::new_from_buf(
-                    packet.inner().split_off(payload_offset),
-                    ZCPacketType::WG,
-                );
+                let mut inner = packet.inner().split_off(payload_offset);
+                if let Err(err) =
+                    rewrite_ipv4_destination(&mut inner, entry.assigned_ip, entry.tunnel_ip)
+                {
+                    tracing::warn!(
+                        client = %entry.name,
+                        assigned_ip = %entry.assigned_ip,
+                        tunnel_ip = %entry.tunnel_ip,
+                        ?err,
+                        "Dropping peer packet unsupported by VPN portal NAT"
+                    );
+                    return None;
+                }
+
+                let packet = ZCPacket::new_from_buf(inner, ZCPacketType::WG);
 
                 match entry.sink.try_send(packet) {
                     Ok(_) => {
@@ -408,16 +735,15 @@ impl WireGuardImpl {
                     break;
                 };
 
-                let (client_name, client_pubkey) =
-                    if let Some(data) = t.get_associate_data() {
-                        if let Some(info) = data.downcast_ref::<WgClientInfo>() {
-                            (Some(info.name.clone()), Some(info.pubkey.to_vec()))
-                        } else {
-                            (None, None)
-                        }
+                let (client_name, client_pubkey) = if let Some(data) = t.get_associate_data() {
+                    if let Some(info) = data.downcast_ref::<WgClientInfo>() {
+                        (Some(info.name.clone()), Some(info.pubkey.to_vec()))
                     } else {
                         (None, None)
-                    };
+                    }
+                } else {
+                    (None, None)
+                };
 
                 tasks.lock().unwrap().spawn(Self::handle_incoming_conn(
                     t,
@@ -437,19 +763,18 @@ impl WireGuardImpl {
         Ok(())
     }
 
-    async fn run_virtual_peer_refresh(
-        peer_mgr: Arc<PeerManager>,
-        wg_peer_ip_table: WgPeerIpTable,
-    ) {
+    async fn run_virtual_peer_refresh(peer_mgr: Arc<PeerManager>, wg_peer_ip_table: WgPeerIpTable) {
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
         loop {
             interval.tick().await;
-            for entry in wg_peer_ip_table.iter() {
-                let virtual_peer_id = entry.value().virtual_peer_id;
-                if virtual_peer_id != 0 {
-                    peer_mgr.refresh_virtual_peer(virtual_peer_id);
-                }
-            }
+            let virtual_peer_ids: Vec<_> = wg_peer_ip_table
+                .iter()
+                .filter_map(|entry| {
+                    let virtual_peer_id = entry.value().virtual_peer_id;
+                    (virtual_peer_id != 0).then_some(virtual_peer_id)
+                })
+                .collect();
+            peer_mgr.refresh_virtual_peers(virtual_peer_ids);
         }
     }
 
@@ -474,10 +799,10 @@ impl WireGuardImpl {
         if self.server_config.is_some() {
             let peer_mgr = self.peer_mgr.clone();
             let wg_peer_ip_table = self.wg_peer_ip_table.clone();
-            self.tasks.lock().unwrap().spawn(Self::run_virtual_peer_refresh(
-                peer_mgr,
-                wg_peer_ip_table,
-            ));
+            self.tasks
+                .lock()
+                .unwrap()
+                .spawn(Self::run_virtual_peer_refresh(peer_mgr, wg_peer_ip_table));
         }
 
         join_joinset_background(self.tasks.clone(), "wireguard".to_string());
@@ -546,15 +871,33 @@ impl VpnPortal for WireGuard {
             // Multi-client mode: generate config for each registered client
             let mut output = String::new();
             for client in &vpn_cfg.clients {
+                let config = self
+                    .inner
+                    .as_ref()
+                    .unwrap()
+                    .client_configs
+                    .get(&client.name)
+                    .cloned();
+                let Some(config) = config else {
+                    output.push_str(&format!(
+                        "\n# Client: {}\n# ERROR: no available WireGuard client address\n",
+                        client.name
+                    ));
+                    continue;
+                };
+                let Some(tunnel_ip) = config.tunnel_ip.or(config.assigned_ip) else {
+                    output.push_str(&format!(
+                        "\n# Client: {}\n# ERROR: no available WireGuard client address\n",
+                        client.name
+                    ));
+                    continue;
+                };
+                let address = tunnel_ip.to_string() + "/32";
                 output.push_str(&format!("\n# Client: {}\n", client.name));
-                let assigned_ip = client
-                    .assigned_ip
-                    .map(|ip| ip.to_string() + "/32")
-                    .unwrap_or_else(|| "auto".to_string());
                 output.push_str(&format!(
                     r#"[Interface]
 PrivateKey = <your private key>
-Address = {assigned_ip}
+Address = {address}
 
 [Peer]
 PublicKey = {my_public_key}
@@ -603,14 +946,15 @@ PersistentKeepalive = 25
                     .map(|x| {
                         let entry = x.value();
                         format!(
-                            "{}: {} (ip: {})",
+                            "{}: {} (ip: {}, tunnel_ip: {})",
                             entry.name,
                             entry
                                 .endpoint_addr
                                 .as_ref()
                                 .map(|x| x.to_string())
                                 .unwrap_or_default(),
-                            entry.assigned_ip
+                            entry.assigned_ip,
+                            entry.tunnel_ip
                         )
                     })
                     .collect()
@@ -623,6 +967,88 @@ PersistentKeepalive = 25
 mod tests {
     use super::*;
     use crate::common::config::ConfigLoader;
+    use pnet::packet::icmp::{self, MutableIcmpPacket};
+    use pnet::packet::tcp::TcpPacket;
+    use pnet::packet::udp::UdpPacket;
+
+    fn build_tcp_packet(src: Ipv4Addr, dst: Ipv4Addr) -> BytesMut {
+        let mut packet = BytesMut::new();
+        packet.resize(44, 0);
+        let mut ipv4_packet = MutableIpv4Packet::new(&mut packet).unwrap();
+        ipv4_packet.set_version(4);
+        ipv4_packet.set_header_length(5);
+        ipv4_packet.set_total_length(44);
+        ipv4_packet.set_ttl(64);
+        ipv4_packet.set_next_level_protocol(IpNextHeaderProtocols::Tcp);
+        ipv4_packet.set_source(src);
+        ipv4_packet.set_destination(dst);
+
+        let mut tcp_packet = MutableTcpPacket::new(ipv4_packet.payload_mut()).unwrap();
+        tcp_packet.set_source(12345);
+        tcp_packet.set_destination(80);
+        tcp_packet.set_data_offset(5);
+        tcp_packet.payload_mut().copy_from_slice(&[1, 2, 3, 4]);
+        tcp_packet.set_checksum(tcp::ipv4_checksum(&tcp_packet.to_immutable(), &src, &dst));
+        drop(tcp_packet);
+
+        update_ipv4_checksum(&mut ipv4_packet);
+        packet
+    }
+
+    fn build_udp_packet(src: Ipv4Addr, dst: Ipv4Addr, checksum_enabled: bool) -> BytesMut {
+        let mut packet = BytesMut::new();
+        packet.resize(32, 0);
+        let mut ipv4_packet = MutableIpv4Packet::new(&mut packet).unwrap();
+        ipv4_packet.set_version(4);
+        ipv4_packet.set_header_length(5);
+        ipv4_packet.set_total_length(32);
+        ipv4_packet.set_ttl(64);
+        ipv4_packet.set_next_level_protocol(IpNextHeaderProtocols::Udp);
+        ipv4_packet.set_source(src);
+        ipv4_packet.set_destination(dst);
+
+        let mut udp_packet = MutableUdpPacket::new(ipv4_packet.payload_mut()).unwrap();
+        udp_packet.set_source(12345);
+        udp_packet.set_destination(53);
+        udp_packet.set_length(12);
+        udp_packet.payload_mut().copy_from_slice(&[1, 2, 3, 4]);
+        if checksum_enabled {
+            udp_packet.set_checksum(udp::ipv4_checksum(&udp_packet.to_immutable(), &src, &dst));
+        }
+        drop(udp_packet);
+
+        update_ipv4_checksum(&mut ipv4_packet);
+        packet
+    }
+
+    fn build_icmp_packet(src: Ipv4Addr, dst: Ipv4Addr, icmp_type: icmp::IcmpType) -> BytesMut {
+        let mut packet = BytesMut::new();
+        packet.resize(32, 0);
+        let mut ipv4_packet = MutableIpv4Packet::new(&mut packet).unwrap();
+        ipv4_packet.set_version(4);
+        ipv4_packet.set_header_length(5);
+        ipv4_packet.set_total_length(32);
+        ipv4_packet.set_ttl(64);
+        ipv4_packet.set_next_level_protocol(IpNextHeaderProtocols::Icmp);
+        ipv4_packet.set_source(src);
+        ipv4_packet.set_destination(dst);
+
+        let mut icmp_packet = MutableIcmpPacket::new(ipv4_packet.payload_mut()).unwrap();
+        icmp_packet.set_icmp_type(icmp_type);
+        icmp_packet
+            .payload_mut()
+            .copy_from_slice(&[0, 0, 0, 0, 1, 2, 3, 4]);
+        icmp_packet.set_checksum(icmp::checksum(&icmp_packet.to_immutable()));
+        drop(icmp_packet);
+
+        update_ipv4_checksum(&mut ipv4_packet);
+        packet
+    }
+
+    fn assert_ipv4_checksum(packet: &BytesMut) {
+        let ipv4_packet = Ipv4Packet::new(packet).unwrap();
+        assert_eq!(ipv4_packet.get_checksum(), ipv4::checksum(&ipv4_packet));
+    }
 
     #[test]
     fn test_ip_allocator_basic() {
@@ -660,9 +1086,35 @@ mod tests {
         let preferred = "10.14.14.100".parse().unwrap();
         allocator.allocate("client1", Some(preferred)).unwrap();
 
-        // preferred ip already taken, should allocate another one
-        let ip2 = allocator.allocate("client2", Some(preferred)).unwrap();
-        assert_ne!(ip2, preferred);
+        // preferred ip already taken, should reject the claim
+        assert_eq!(allocator.allocate("client2", Some(preferred)), None);
+    }
+
+    #[test]
+    fn test_ip_allocator_preferred_claim_is_atomic() {
+        use std::sync::Barrier;
+
+        let cidr = "10.14.14.0/30".parse().unwrap();
+        let allocator = Arc::new(IpAllocator::new(cidr));
+        let barrier = Arc::new(Barrier::new(16));
+        let preferred = "10.14.14.1".parse().unwrap();
+
+        let handles = (0..16)
+            .map(|idx| {
+                let allocator = allocator.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    allocator.allocate(&format!("client{idx}"), Some(preferred))
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let allocated = handles
+            .into_iter()
+            .filter_map(|handle| handle.join().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(allocated, vec![preferred]);
     }
 
     #[test]
@@ -674,6 +1126,154 @@ mod tests {
 
         let ip = allocator.allocate("client1", None).unwrap();
         assert_ne!(ip, server_ip);
+    }
+
+    #[test]
+    fn test_build_client_config_map_assigns_missing_ips() {
+        let cidr = "10.14.14.0/24".parse().unwrap();
+        let clients = vec![
+            VpnPortalClientConfig {
+                name: "client1".to_string(),
+                client_public_key: "key1".to_string(),
+                assigned_ip: None,
+                tunnel_ip: None,
+            },
+            VpnPortalClientConfig {
+                name: "client2".to_string(),
+                client_public_key: "key2".to_string(),
+                assigned_ip: Some("10.14.14.10".parse().unwrap()),
+                tunnel_ip: None,
+            },
+        ];
+
+        let configs = build_client_config_map(&clients, cidr, Some("10.14.14.1".parse().unwrap()));
+
+        assert_eq!(
+            configs.get("client1").and_then(|c| c.assigned_ip),
+            Some("10.14.14.2".parse().unwrap())
+        );
+        assert_eq!(
+            configs.get("client2").and_then(|c| c.assigned_ip),
+            Some("10.14.14.10".parse().unwrap())
+        );
+        assert_eq!(
+            configs.get("client1").and_then(|c| c.tunnel_ip),
+            Some("10.14.14.2".parse().unwrap())
+        );
+        assert_eq!(
+            configs.get("client2").and_then(|c| c.tunnel_ip),
+            Some("10.14.14.10".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn test_build_client_config_map_preserves_tunnel_ip() {
+        let cidr = "10.14.14.0/24".parse().unwrap();
+        let clients = vec![VpnPortalClientConfig {
+            name: "client1".to_string(),
+            client_public_key: "key1".to_string(),
+            assigned_ip: Some("10.144.144.10".parse().unwrap()),
+            tunnel_ip: Some("10.14.14.10".parse().unwrap()),
+        }];
+
+        let configs = build_client_config_map(&clients, cidr, Some("10.14.14.1".parse().unwrap()));
+
+        assert_eq!(
+            configs.get("client1").and_then(|c| c.assigned_ip),
+            Some("10.144.144.10".parse().unwrap())
+        );
+        assert_eq!(
+            configs.get("client1").and_then(|c| c.tunnel_ip),
+            Some("10.14.14.10".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_ipv4_source_updates_tcp_checksum() {
+        let tunnel_ip = "10.14.14.10".parse().unwrap();
+        let assigned_ip = "10.144.144.10".parse().unwrap();
+        let destination = "10.1.1.1".parse().unwrap();
+        let mut packet = build_tcp_packet(tunnel_ip, destination);
+
+        rewrite_ipv4_source(&mut packet, tunnel_ip, assigned_ip).unwrap();
+
+        let ipv4_packet = Ipv4Packet::new(&packet).unwrap();
+        assert_eq!(ipv4_packet.get_source(), assigned_ip);
+        assert_eq!(ipv4_packet.get_destination(), destination);
+        assert_ipv4_checksum(&packet);
+        let tcp_packet = TcpPacket::new(ipv4_packet.payload()).unwrap();
+        assert_eq!(
+            tcp_packet.get_checksum(),
+            tcp::ipv4_checksum(&tcp_packet, &assigned_ip, &destination)
+        );
+    }
+
+    #[test]
+    fn test_rewrite_ipv4_destination_updates_udp_checksum() {
+        let source = "10.1.1.1".parse().unwrap();
+        let assigned_ip = "10.144.144.10".parse().unwrap();
+        let tunnel_ip = "10.14.14.10".parse().unwrap();
+        let mut packet = build_udp_packet(source, assigned_ip, true);
+
+        rewrite_ipv4_destination(&mut packet, assigned_ip, tunnel_ip).unwrap();
+
+        let ipv4_packet = Ipv4Packet::new(&packet).unwrap();
+        assert_eq!(ipv4_packet.get_source(), source);
+        assert_eq!(ipv4_packet.get_destination(), tunnel_ip);
+        assert_ipv4_checksum(&packet);
+        let udp_packet = UdpPacket::new(ipv4_packet.payload()).unwrap();
+        assert_eq!(
+            udp_packet.get_checksum(),
+            udp::ipv4_checksum(&udp_packet, &source, &tunnel_ip)
+        );
+    }
+
+    #[test]
+    fn test_rewrite_ipv4_destination_preserves_zero_udp_checksum() {
+        let source = "10.1.1.1".parse().unwrap();
+        let assigned_ip = "10.144.144.10".parse().unwrap();
+        let tunnel_ip = "10.14.14.10".parse().unwrap();
+        let mut packet = build_udp_packet(source, assigned_ip, false);
+
+        rewrite_ipv4_destination(&mut packet, assigned_ip, tunnel_ip).unwrap();
+
+        let ipv4_packet = Ipv4Packet::new(&packet).unwrap();
+        let udp_packet = UdpPacket::new(ipv4_packet.payload()).unwrap();
+        assert_eq!(udp_packet.get_checksum(), 0);
+    }
+
+    #[test]
+    fn test_rewrite_ipv4_source_accepts_icmp_echo() {
+        let tunnel_ip = "10.14.14.10".parse().unwrap();
+        let assigned_ip = "10.144.144.10".parse().unwrap();
+        let destination = "10.1.1.1".parse().unwrap();
+        let mut packet = build_icmp_packet(tunnel_ip, destination, IcmpTypes::EchoRequest);
+        let original_icmp_checksum = IcmpPacket::new(Ipv4Packet::new(&packet).unwrap().payload())
+            .unwrap()
+            .get_checksum();
+
+        rewrite_ipv4_source(&mut packet, tunnel_ip, assigned_ip).unwrap();
+
+        let ipv4_packet = Ipv4Packet::new(&packet).unwrap();
+        let icmp_packet = IcmpPacket::new(ipv4_packet.payload()).unwrap();
+        assert_eq!(ipv4_packet.get_source(), assigned_ip);
+        assert_ipv4_checksum(&packet);
+        assert_eq!(icmp_packet.get_checksum(), original_icmp_checksum);
+    }
+
+    #[test]
+    fn test_rewrite_ipv4_rejects_non_first_fragment() {
+        let tunnel_ip = "10.14.14.10".parse().unwrap();
+        let assigned_ip = "10.144.144.10".parse().unwrap();
+        let destination = "10.1.1.1".parse().unwrap();
+        let mut packet = build_tcp_packet(tunnel_ip, destination);
+        let mut ipv4_packet = MutableIpv4Packet::new(&mut packet).unwrap();
+        ipv4_packet.set_fragment_offset(1);
+
+        assert_eq!(
+            rewrite_ipv4_source(&mut packet, tunnel_ip, assigned_ip),
+            Err(Ipv4NatError::UnsupportedFragment)
+        );
     }
 
     #[test]
@@ -733,6 +1333,9 @@ mod tests {
         let vpn_cfg = loader.get_vpn_portal_config().unwrap();
         assert_eq!(vpn_cfg.clients.len(), 2);
         assert_eq!(vpn_cfg.clients[0].name, "client1");
-        assert_eq!(vpn_cfg.clients[1].assigned_ip, Some("10.14.14.10".parse().unwrap()));
+        assert_eq!(
+            vpn_cfg.clients[1].assigned_ip,
+            Some("10.14.14.10".parse().unwrap())
+        );
     }
 }

--- a/easytier/src/vpn_portal/wireguard.rs
+++ b/easytier/src/vpn_portal/wireguard.rs
@@ -18,9 +18,9 @@ use pnet::packet::{MutablePacket, Packet};
 use pnet::packet::{
     icmp::{IcmpPacket, IcmpTypes},
     ip::{IpNextHeaderProtocol, IpNextHeaderProtocols},
-    ipv4::{self, Ipv4Flags, Ipv4Packet, MutableIpv4Packet},
-    tcp::{self, MutableTcpPacket},
-    udp::{self, MutableUdpPacket},
+    ipv4::{Ipv4Flags, Ipv4Packet, MutableIpv4Packet},
+    tcp::MutableTcpPacket,
+    udp::MutableUdpPacket,
 };
 use tokio::task::JoinSet;
 use tracing::Level;
@@ -29,9 +29,15 @@ use crate::{
     common::{
         config::{NetworkIdentity, VpnPortalClientConfig},
         global_ctx::{ArcGlobalCtx, GlobalCtxEvent},
-        join_joinset_background, shrink_dashmap,
+        join_joinset_background,
+        packet_checksum::{
+            update_ip_packet_checksum, update_tcp_packet_checksum,
+            update_udp_packet_checksum_if_present,
+        },
+        shrink_dashmap,
     },
     peers::{PeerPacketFilter, peer_manager::PeerManager},
+    proto::common::{is_virtual_peer_id, to_virtual_peer_id},
     tunnel::{
         Tunnel, TunnelListener,
         mpsc::{MpscTunnel, MpscTunnelSender},
@@ -145,7 +151,7 @@ fn virtual_peer_id_from_pubkey(pubkey: &[u8]) -> u32 {
     let mut hasher = DefaultHasher::new();
     pubkey.hash(&mut hasher);
     let hash = hasher.finish();
-    (hash as u32) | 0x80000000
+    to_virtual_peer_id(hash as u32)
 }
 
 fn is_assignable_client_ip(cidr: cidr::Ipv4Cidr, ip: Ipv4Addr) -> bool {
@@ -170,10 +176,6 @@ fn ipv4_packet_total_len(packet: &[u8]) -> Result<usize, Ipv4NatError> {
     Ok(total_len)
 }
 
-fn update_ipv4_checksum(ipv4_packet: &mut MutableIpv4Packet) {
-    ipv4_packet.set_checksum(ipv4::checksum(&ipv4_packet.to_immutable()));
-}
-
 fn update_transport_checksum(ipv4_packet: &mut MutableIpv4Packet) -> Result<(), Ipv4NatError> {
     let source = ipv4_packet.get_source();
     let destination = ipv4_packet.get_destination();
@@ -183,22 +185,12 @@ fn update_transport_checksum(ipv4_packet: &mut MutableIpv4Packet) -> Result<(), 
         IpNextHeaderProtocols::Tcp => {
             let mut tcp_packet = MutableTcpPacket::new(ipv4_packet.payload_mut())
                 .ok_or(Ipv4NatError::InvalidTransportPacket)?;
-            tcp_packet.set_checksum(tcp::ipv4_checksum(
-                &tcp_packet.to_immutable(),
-                &source,
-                &destination,
-            ));
+            update_tcp_packet_checksum(&mut tcp_packet, &source, &destination);
         }
         IpNextHeaderProtocols::Udp => {
             let mut udp_packet = MutableUdpPacket::new(ipv4_packet.payload_mut())
                 .ok_or(Ipv4NatError::InvalidTransportPacket)?;
-            if udp_packet.get_checksum() != 0 {
-                udp_packet.set_checksum(udp::ipv4_checksum(
-                    &udp_packet.to_immutable(),
-                    &source,
-                    &destination,
-                ));
-            }
+            update_udp_packet_checksum_if_present(&mut udp_packet, &source, &destination);
         }
         IpNextHeaderProtocols::Icmp => {
             let icmp_packet = IcmpPacket::new(ipv4_packet.payload())
@@ -246,7 +238,7 @@ fn rewrite_ipv4_source(
     reject_fragmented_packet(&ipv4_packet)?;
     ipv4_packet.set_source(new_source);
     update_transport_checksum(&mut ipv4_packet)?;
-    update_ipv4_checksum(&mut ipv4_packet);
+    update_ip_packet_checksum(&mut ipv4_packet);
 
     Ok(())
 }
@@ -273,7 +265,7 @@ fn rewrite_ipv4_destination(
     reject_fragmented_packet(&ipv4_packet)?;
     ipv4_packet.set_destination(new_destination);
     update_transport_checksum(&mut ipv4_packet)?;
-    update_ipv4_checksum(&mut ipv4_packet);
+    update_ip_packet_checksum(&mut ipv4_packet);
 
     Ok(())
 }
@@ -771,7 +763,7 @@ impl WireGuardImpl {
                 .iter()
                 .filter_map(|entry| {
                     let virtual_peer_id = entry.value().virtual_peer_id;
-                    (virtual_peer_id != 0).then_some(virtual_peer_id)
+                    is_virtual_peer_id(virtual_peer_id).then_some(virtual_peer_id)
                 })
                 .collect();
             peer_mgr.refresh_virtual_peers(virtual_peer_ids);
@@ -967,9 +959,12 @@ PersistentKeepalive = 25
 mod tests {
     use super::*;
     use crate::common::config::ConfigLoader;
-    use pnet::packet::icmp::{self, MutableIcmpPacket};
     use pnet::packet::tcp::TcpPacket;
     use pnet::packet::udp::UdpPacket;
+    use pnet::packet::{
+        icmp::{self, MutableIcmpPacket},
+        ipv4, tcp, udp,
+    };
 
     fn build_tcp_packet(src: Ipv4Addr, dst: Ipv4Addr) -> BytesMut {
         let mut packet = BytesMut::new();
@@ -991,7 +986,7 @@ mod tests {
         tcp_packet.set_checksum(tcp::ipv4_checksum(&tcp_packet.to_immutable(), &src, &dst));
         drop(tcp_packet);
 
-        update_ipv4_checksum(&mut ipv4_packet);
+        update_ip_packet_checksum(&mut ipv4_packet);
         packet
     }
 
@@ -1017,7 +1012,7 @@ mod tests {
         }
         drop(udp_packet);
 
-        update_ipv4_checksum(&mut ipv4_packet);
+        update_ip_packet_checksum(&mut ipv4_packet);
         packet
     }
 
@@ -1041,7 +1036,7 @@ mod tests {
         icmp_packet.set_checksum(icmp::checksum(&icmp_packet.to_immutable()));
         drop(icmp_packet);
 
-        update_ipv4_checksum(&mut ipv4_packet);
+        update_ip_packet_checksum(&mut ipv4_packet);
         packet
     }
 


### PR DESCRIPTION
## Summary

Adds multi-client WireGuard portal support with per-client 1:1 static NAT, allowing WG clients to use arbitrary tunnel IP addresses (including duplicates across clients) while maintaining unique EasyTier virtual IPs.

## Changes

### Multi-client WG Portal
- Per-client WireGuard key pairs and virtual peer OSPF routing
- Each client gets its own EasyTier virtual IP and dedicated OSPF peer

### 1:1 Static NAT
- `tunnel_ip` config field: specifies WG client tunnel address, defaults to `assigned_ip` for full backward compatibility
- Inbound SNAT: rewrite source from `tunnel_ip` to `assigned_ip` with IPv4/TCP/UDP checksum recalculation
- Outbound DNAT: lookup by `assigned_ip`, rewrite destination to `tunnel_ip` with checksum recalculation
- Multiple WG clients can share the same `tunnel_ip` — isolated by pubkey

### OSPF Route Convergence
- Trigger immediate `update_route_table` + `sync_now` on virtual peer add/remove/refresh
- Fix `build_route_info` / `build_conn_peer_list` iteration (`break` → `continue`)
- Refined virtual peer detection to check both peer ID and info fields

### Virtual Peer Refresh Optimization
- Batch refresh via `refresh_virtual_peers()` — single version bump per tick instead of per-peer
- No version bump when route is unchanged (keeps OSPF stable during idle periods)

## Test Plan

- 4 integration tests (netns + Docker) covering: basic multi-client NAT, same tunnel IP across clients, disconnect/reconnect, TCP echo with source IP verification
- Unit tests for TCP/UDP/ICMP checksum rewrite and IPv4 fragment rejection
- All tests pass in Docker (`--privileged`, netns, WG kernel module)