### PR TITLE
ci: revert UPX version to 4.2.4 in core.yml

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -230,7 +230,7 @@ jobs:
               *)       UPX_ARCH="amd64" ;;
             esac
 
-            UPX_VERSION=5.1.1
+            UPX_VERSION=4.2.4
             UPX_PKG="upx-${UPX_VERSION}-${UPX_ARCH}_linux"
             curl -L "https://github.com/upx/upx/releases/download/v${UPX_VERSION}/${UPX_PKG}.tar.xz" -s | tar xJvf -
             cp "${UPX_PKG}/upx" .


### PR DESCRIPTION
- cf. https://github.com/upx/upx/issues/904
- cf. https://github.com/upx/upx/discussions/905
- closes https://github.com/EasyTier/EasyTier/issues/2220
- closes https://github.com/EasyTier/EasyTier/issues/2223

看来 SELinux 是真的没人用