### PR TITLE
fix: handle credential and console-managed route updates

### DIFF
--- a/easytier-web/src/client_manager/mod.rs
+++ b/easytier-web/src/client_manager/mod.rs
@@ -8,10 +8,15 @@ use std::sync::{
 
 use dashmap::DashMap;
 use easytier::{
+    common::config::ConfigSource,
     proto::{
-        api::manage::WebClientService, rpc_types::controller::BaseController, web::HeartbeatRequest,
+        api::manage::{DeleteNetworkInstanceRequest, WebClientService},
+        rpc_types::controller::BaseController,
+        web::HeartbeatRequest,
     },
-    rpc_service::remote_client::{self, RemoteClientManager},
+    rpc_service::remote_client::{
+        self, ListNetworkProps, PersistentConfig as _, RemoteClientManager, Storage as _,
+    },
     tunnel::TunnelListener,
     web_client::security,
 };
@@ -20,7 +25,7 @@ use session::{Location, Session};
 use storage::{Storage, StorageToken};
 
 use crate::FeatureFlags;
-use crate::webhook::SharedWebhookConfig;
+use crate::webhook::{ManagedNetworkConfig, SharedWebhookConfig};
 use tokio::task::JoinSet;
 
 use crate::db::{Db, UserIdInDb, entity::user_running_network_configs};
@@ -195,6 +200,129 @@ impl ClientManager {
 
     pub async fn list_machine_by_user_id(&self, user_id: UserIdInDb) -> Vec<url::Url> {
         self.storage.list_user_clients(user_id)
+    }
+
+    pub async fn reconcile_managed_network_configs(
+        &self,
+        user_id: UserIdInDb,
+        machine_id: uuid::Uuid,
+        desired_configs: Vec<ManagedNetworkConfig>,
+    ) -> anyhow::Result<()> {
+        let previous_configs = self
+            .storage
+            .db()
+            .list_network_configs((user_id, machine_id), ListNetworkProps::All)
+            .await?;
+        let previous_webhook_ids = previous_configs
+            .iter()
+            .filter_map(|cfg| {
+                (cfg.get_runtime_network_config_source() == ConfigSource::Webhook)
+                    .then(|| uuid::Uuid::parse_str(cfg.get_network_inst_id()).ok())
+                    .flatten()
+            })
+            .collect::<std::collections::HashSet<_>>();
+
+        session::SessionRpcService::reconcile_webhook_source_configs(
+            &self.storage,
+            user_id,
+            machine_id,
+            desired_configs,
+        )
+        .await?;
+
+        let running_ids = match self.get_session_by_machine_id(user_id, &machine_id) {
+            Some(session) => session
+                .data()
+                .read()
+                .await
+                .req()
+                .map(|req| {
+                    req.running_network_instances
+                        .into_iter()
+                        .map(Into::<uuid::Uuid>::into)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default(),
+            None => Vec::new(),
+        };
+        if running_ids.is_empty() {
+            return Ok(());
+        }
+
+        let configs = self
+            .storage
+            .db()
+            .list_network_configs((user_id, machine_id), ListNetworkProps::All)
+            .await?;
+        let desired_webhook_ids = configs
+            .iter()
+            .filter_map(|cfg| {
+                (cfg.get_runtime_network_config_source() == ConfigSource::Webhook)
+                    .then(|| uuid::Uuid::parse_str(cfg.get_network_inst_id()).ok())
+                    .flatten()
+            })
+            .collect::<std::collections::HashSet<_>>();
+
+        let running_webhook_ids = if let Some(client) = self.get_rpc_client((user_id, machine_id)) {
+            match client
+                .list_network_instance_meta(
+                    BaseController::default(),
+                    easytier::proto::api::manage::ListNetworkInstanceMetaRequest {
+                        inst_ids: running_ids.iter().copied().map(Into::into).collect(),
+                    },
+                )
+                .await
+            {
+                Ok(resp) => resp
+                    .metas
+                    .into_iter()
+                    .filter_map(|meta| {
+                        let inst_id = meta.inst_id.map(Into::<uuid::Uuid>::into)?;
+                        let source = ConfigSource::from_rpc(meta.source)?;
+                        (source == ConfigSource::Webhook).then_some(inst_id)
+                    })
+                    .collect::<std::collections::HashSet<_>>(),
+                Err(err) => {
+                    tracing::warn!(
+                        ?user_id,
+                        ?machine_id,
+                        %err,
+                        "failed to list running network metadata for managed cleanup"
+                    );
+                    running_ids
+                        .iter()
+                        .copied()
+                        .filter(|inst_id| previous_webhook_ids.contains(inst_id))
+                        .collect::<std::collections::HashSet<_>>()
+                }
+            }
+        } else {
+            running_ids
+                .iter()
+                .copied()
+                .filter(|inst_id| previous_webhook_ids.contains(inst_id))
+                .collect::<std::collections::HashSet<_>>()
+        };
+
+        let stale_running_ids = running_webhook_ids
+            .difference(&desired_webhook_ids)
+            .copied()
+            .collect::<Vec<_>>();
+        if stale_running_ids.is_empty() {
+            return Ok(());
+        }
+        let Some(client) = self.get_rpc_client((user_id, machine_id)) else {
+            return Ok(());
+        };
+        client
+            .delete_network_instance(
+                BaseController::default(),
+                DeleteNetworkInstanceRequest {
+                    inst_ids: stale_running_ids.into_iter().map(Into::into).collect(),
+                },
+            )
+            .await?;
+        Ok(())
     }
 
     pub async fn get_heartbeat_requests(&self, client_url: &url::Url) -> Option<HeartbeatRequest> {

--- a/easytier-web/src/client_manager/mod.rs
+++ b/easytier-web/src/client_manager/mod.rs
@@ -30,6 +30,18 @@ use tokio::task::JoinSet;
 
 use crate::db::{Db, UserIdInDb, entity::user_running_network_configs};
 
+fn managed_running_instance_id(
+    meta: easytier::proto::api::manage::NetworkMeta,
+    previous_webhook_ids: &std::collections::HashSet<uuid::Uuid>,
+) -> Option<uuid::Uuid> {
+    let inst_id = meta.inst_id.map(Into::<uuid::Uuid>::into)?;
+    if previous_webhook_ids.contains(&inst_id) {
+        return Some(inst_id);
+    }
+    let source = ConfigSource::from_rpc(meta.source)?;
+    (source == ConfigSource::Webhook).then_some(inst_id)
+}
+
 #[derive(rust_embed::Embed)]
 #[folder = "resources/"]
 #[include = "geoip2-cn.mmdb"]
@@ -276,11 +288,7 @@ impl ClientManager {
                 Ok(resp) => resp
                     .metas
                     .into_iter()
-                    .filter_map(|meta| {
-                        let inst_id = meta.inst_id.map(Into::<uuid::Uuid>::into)?;
-                        let source = ConfigSource::from_rpc(meta.source)?;
-                        (source == ConfigSource::Webhook).then_some(inst_id)
-                    })
+                    .filter_map(|meta| managed_running_instance_id(meta, &previous_webhook_ids))
                     .collect::<std::collections::HashSet<_>>(),
                 Err(err) => {
                     tracing::warn!(
@@ -456,10 +464,12 @@ impl
 
 #[cfg(test)]
 mod tests {
-    use std::{sync::Arc, time::Duration};
+    use std::{collections::HashSet, sync::Arc, time::Duration};
 
     use easytier::{
+        common::config::ConfigSource,
         instance_manager::NetworkInstanceManager,
+        proto::api::manage::{ConfigSource as RpcConfigSource, NetworkMeta},
         tunnel::{
             common::tests::wait_for_condition,
             udp::{UdpTunnelConnector, UdpTunnelListener},
@@ -469,6 +479,54 @@ mod tests {
     use sqlx::Executor;
 
     use crate::{FeatureFlags, client_manager::ClientManager, db::Db};
+
+    #[test]
+    fn managed_running_instance_id_keeps_previous_webhook_instance_with_user_runtime_source() {
+        let inst_id = uuid::Uuid::new_v4();
+        let previous_webhook_ids = HashSet::from([inst_id]);
+
+        assert_eq!(
+            super::managed_running_instance_id(
+                NetworkMeta {
+                    inst_id: Some(inst_id.into()),
+                    source: RpcConfigSource::User as i32,
+                    ..Default::default()
+                },
+                &previous_webhook_ids,
+            ),
+            Some(inst_id)
+        );
+    }
+
+    #[test]
+    fn managed_running_instance_id_uses_runtime_source_without_previous_db_signal() {
+        let webhook_inst_id = uuid::Uuid::new_v4();
+        let user_inst_id = uuid::Uuid::new_v4();
+        let previous_webhook_ids = HashSet::new();
+
+        assert_eq!(
+            super::managed_running_instance_id(
+                NetworkMeta {
+                    inst_id: Some(webhook_inst_id.into()),
+                    source: ConfigSource::Webhook.to_rpc(),
+                    ..Default::default()
+                },
+                &previous_webhook_ids,
+            ),
+            Some(webhook_inst_id)
+        );
+        assert_eq!(
+            super::managed_running_instance_id(
+                NetworkMeta {
+                    inst_id: Some(user_inst_id.into()),
+                    source: ConfigSource::User.to_rpc(),
+                    ..Default::default()
+                },
+                &previous_webhook_ids,
+            ),
+            None
+        );
+    }
 
     #[tokio::test]
     async fn test_client() {

--- a/easytier-web/src/client_manager/session.rs
+++ b/easytier-web/src/client_manager/session.rs
@@ -164,7 +164,7 @@ impl Drop for SessionData {
 pub type SharedSessionData = Arc<RwLock<SessionData>>;
 
 #[derive(Clone)]
-struct SessionRpcService {
+pub(super) struct SessionRpcService {
     data: SharedSessionData,
 }
 
@@ -193,7 +193,7 @@ impl SessionRpcService {
         Ok(serde_json::from_value::<NetworkConfig>(network_config)?)
     }
 
-    async fn reconcile_webhook_source_configs(
+    pub(super) async fn reconcile_webhook_source_configs(
         storage: &Storage,
         user_id: i32,
         machine_id: uuid::Uuid,

--- a/easytier-web/src/restful/network.rs
+++ b/easytier-web/src/restful/network.rs
@@ -3,6 +3,7 @@ use axum::http::StatusCode;
 use axum::routing::{delete, post};
 use axum::{Json, Router, extract::State, routing::get};
 use axum_login::AuthUser;
+use easytier::common::config::ConfigSource as RuntimeConfigSource;
 use easytier::launcher::NetworkConfig;
 use easytier::proto::common::Void;
 use easytier::proto::{api::manage::*, web::*};
@@ -60,6 +61,7 @@ struct SaveNetworkJsonReq {
 struct RunNetworkJsonReq {
     config: NetworkConfig,
     save: bool,
+    source: Option<i32>,
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
@@ -80,6 +82,17 @@ struct GetNetworkMetasJsonReq {
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 struct RemoveNetworkJsonReq {
     inst_ids: Vec<uuid::Uuid>,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+struct ManagedNetworkConfigJson {
+    instance_id: uuid::Uuid,
+    network_config: serde_json::Value,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+struct ReconcileManagedNetworkConfigsJsonReq {
+    managed_network_configs: Vec<ManagedNetworkConfigJson>,
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
@@ -302,8 +315,17 @@ impl NetworkApi {
         Path((user_id, machine_id)): Path<(UserIdInDb, uuid::Uuid)>,
         Json(payload): Json<RunNetworkJsonReq>,
     ) -> Result<Json<Void>, HttpHandleError> {
+        let source = payload
+            .source
+            .and_then(RuntimeConfigSource::from_rpc)
+            .unwrap_or(RuntimeConfigSource::Webhook);
         client_mgr
-            .handle_run_network_instance((user_id, machine_id), payload.config, payload.save)
+            .handle_run_network_instance_with_source(
+                (user_id, machine_id),
+                payload.config,
+                payload.save,
+                source,
+            )
             .await
             .map_err(convert_error)?;
         Ok(Void::default().into())
@@ -317,6 +339,31 @@ impl NetworkApi {
             .handle_remove_network_instances((user_id, machine_id), vec![inst_id])
             .await
             .map_err(convert_error)
+    }
+
+    async fn handle_reconcile_managed_network_configs_internal(
+        State(client_mgr): AppState,
+        Path((user_id, machine_id)): Path<(UserIdInDb, uuid::Uuid)>,
+        Json(payload): Json<ReconcileManagedNetworkConfigsJsonReq>,
+    ) -> Result<Json<Void>, HttpHandleError> {
+        let desired = payload
+            .managed_network_configs
+            .into_iter()
+            .map(|item| crate::webhook::ManagedNetworkConfig {
+                instance_id: item.instance_id.to_string(),
+                network_config: item.network_config,
+            })
+            .collect();
+        client_mgr
+            .reconcile_managed_network_configs(user_id, machine_id, desired)
+            .await
+            .map_err(|err| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    other_error(err.to_string()).into(),
+                )
+            })?;
+        Ok(Void::default().into())
     }
 
     async fn handle_list_network_instance_ids_internal(
@@ -347,6 +394,7 @@ impl NetworkApi {
             .route(
                 "/api/internal/users/:user-id/machines/:machine-id/networks",
                 post(Self::handle_run_network_instance_internal)
+                    .put(Self::handle_reconcile_managed_network_configs_internal)
                     .get(Self::handle_list_network_instance_ids_internal),
             )
             .route(

--- a/easytier/src/peers/credential_manager.rs
+++ b/easytier/src/peers/credential_manager.rs
@@ -127,6 +127,8 @@ impl CredentialManager {
         credential_id: Option<String>,
         reusable: bool,
     ) -> (String, String) {
+        self.remove_expired_credentials();
+
         let mut credentials = self.credentials.lock().unwrap();
         let id = if let Some(id) = credential_id
             .map(|x| x.trim().to_string())
@@ -191,6 +193,25 @@ impl CredentialManager {
         if removed {
             self.save_to_disk();
         }
+        removed
+    }
+
+    pub fn remove_expired_credentials(&self) -> bool {
+        self.remove_expired_credentials_at(current_unix_timestamp())
+    }
+
+    fn remove_expired_credentials_at(&self, now: i64) -> bool {
+        let removed = {
+            let mut credentials = self.credentials.lock().unwrap();
+            let before = credentials.len();
+            credentials.retain(|_, entry| entry.is_active_at(now));
+            before != credentials.len()
+        };
+
+        if removed {
+            self.save_to_disk();
+        }
+
         removed
     }
 
@@ -497,6 +518,35 @@ mod tests {
     }
 
     #[test]
+    fn test_remove_expired_credentials_removes_and_persists() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("creds.json");
+        let mgr = CredentialManager::new(Some(path.clone()));
+        mgr.generate_credential_with_id(
+            vec!["active".to_string()],
+            false,
+            vec![],
+            Duration::from_secs(3600),
+            Some("active-id".to_string()),
+        );
+        mgr.generate_credential_with_id(
+            vec!["expired".to_string()],
+            false,
+            vec![],
+            Duration::from_secs(0),
+            Some("expired-id".to_string()),
+        );
+
+        assert!(mgr.remove_expired_credentials());
+        assert_eq!(mgr.list_credentials().len(), 1);
+
+        let reloaded = CredentialManager::new(Some(path));
+        let list = reloaded.list_credentials();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].credential_id, "active-id");
+    }
+
+    #[test]
     fn test_generate_with_specified_id_reuses_existing_result() {
         let mgr = CredentialManager::new(None);
         let fixed_id = "fixed-credential-id".to_string();
@@ -526,6 +576,37 @@ mod tests {
         assert!(!list[0].allow_relay);
         assert_eq!(list[0].allowed_proxy_cidrs, vec!["10.0.0.0/24".to_string()]);
         assert_eq!(list[0].reusable, Some(true));
+    }
+
+    #[test]
+    fn test_generate_with_specified_id_replaces_expired_existing_result() {
+        let mgr = CredentialManager::new(None);
+        let fixed_id = "fixed-credential-id".to_string();
+        let (id1, secret1) = mgr.generate_credential_with_id(
+            vec!["expired".to_string()],
+            false,
+            vec![],
+            Duration::from_secs(0),
+            Some(fixed_id.clone()),
+        );
+        let (id2, secret2) = mgr.generate_credential_with_id(
+            vec!["fresh".to_string()],
+            true,
+            vec!["10.0.0.0/24".to_string()],
+            Duration::from_secs(3600),
+            Some(fixed_id.clone()),
+        );
+
+        assert_eq!(id1, fixed_id);
+        assert_eq!(id2, fixed_id);
+        assert_ne!(secret1, secret2);
+
+        let list = mgr.list_credentials();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].credential_id, fixed_id);
+        assert_eq!(list[0].groups, vec!["fresh".to_string()]);
+        assert!(list[0].allow_relay);
+        assert_eq!(list[0].allowed_proxy_cidrs, vec!["10.0.0.0/24".to_string()]);
     }
 
     #[test]

--- a/easytier/src/peers/peer_manager.rs
+++ b/easytier/src/peers/peer_manager.rs
@@ -503,6 +503,33 @@ impl PeerManager {
         });
     }
 
+    async fn close_untrusted_credential_peers(peer_map: &Arc<PeerMap>, global_ctx: &ArcGlobalCtx) {
+        let network_name = global_ctx.get_network_name();
+        for peer_id in peer_map.list_peers() {
+            if !matches!(
+                peer_map.get_peer_identity_type(peer_id),
+                Some(PeerIdentityType::Credential)
+            ) {
+                continue;
+            }
+            let Some(peer) = peer_map.get_peer_by_id(peer_id) else {
+                continue;
+            };
+            let Some(pubkey) = peer.get_peer_public_key() else {
+                continue;
+            };
+
+            if global_ctx.is_pubkey_trusted(&pubkey, &network_name) {
+                continue;
+            }
+
+            tracing::warn!(?peer_id, "closing untrusted credential peer");
+            if let Err(e) = peer_map.close_peer(peer_id).await {
+                tracing::warn!(?e, ?peer_id, "failed to close untrusted credential peer");
+            }
+        }
+    }
+
     fn build_foreign_network_manager_accessor(
         peer_map: &Arc<PeerMap>,
     ) -> Box<dyn GlobalForeignNetworkAccessor> {
@@ -1849,6 +1876,26 @@ impl PeerManager {
         });
     }
 
+    async fn run_credential_gc_routine(&self) {
+        let global_ctx = self.global_ctx.clone();
+        let peer_map = self.peers.clone();
+        self.tasks.lock().await.spawn(async move {
+            loop {
+                if global_ctx.get_network_identity().network_secret.is_some() {
+                    if global_ctx
+                        .get_credential_manager()
+                        .remove_expired_credentials()
+                    {
+                        global_ctx.issue_event(GlobalCtxEvent::CredentialChanged);
+                    }
+
+                    Self::close_untrusted_credential_peers(&peer_map, &global_ctx).await;
+                }
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            }
+        });
+    }
+
     async fn run_traffic_metrics_gc_routine(&self) {
         let mut event_receiver = self.global_ctx.subscribe();
         let traffic_metrics = self.traffic_metrics.clone();
@@ -1897,6 +1944,7 @@ impl PeerManager {
         self.run_relay_session_gc_routine().await;
         self.run_recent_traffic_gc_routine().await;
         self.run_peer_session_gc_routine().await;
+        self.run_credential_gc_routine().await;
         self.run_traffic_metrics_gc_routine().await;
 
         self.run_foriegn_network().await;
@@ -2135,6 +2183,7 @@ impl PeerManager {
 
 #[cfg(test)]
 mod tests {
+    use base64::Engine;
     use std::{
         fmt::Debug,
         sync::Arc,
@@ -2164,7 +2213,7 @@ mod tests {
             },
         },
         proto::{
-            common::{CompressionAlgoPb, NatType},
+            common::{CompressionAlgoPb, NatType, SecureModeConfig},
             peer_rpc::SecureAuthLevel,
         },
         tunnel::{
@@ -3404,6 +3453,92 @@ mod tests {
         )
         .await;
         // a is client, b is server
+    }
+
+    #[tokio::test]
+    async fn expired_credential_peer_conn_is_closed_without_ospf() {
+        let (admin_ch, _admin_rx) = create_packet_recv_chan();
+        let admin_ctx = get_mock_global_ctx();
+        admin_ctx.config.set_network_identity(NetworkIdentity::new(
+            "net1".to_string(),
+            "secret".to_string(),
+        ));
+        set_secure_mode_cfg(&admin_ctx, true);
+        let admin = Arc::new(PeerManager::new(
+            RouteAlgoType::None,
+            admin_ctx.clone(),
+            admin_ch,
+        ));
+        admin.run().await.unwrap();
+
+        let (_cred_id, cred_secret) = admin_ctx.get_credential_manager().generate_credential(
+            vec![],
+            false,
+            vec![],
+            Duration::from_secs(1),
+        );
+        let privkey_bytes: [u8; 32] = base64::engine::general_purpose::STANDARD
+            .decode(&cred_secret)
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let private = x25519_dalek::StaticSecret::from(privkey_bytes);
+        let public = x25519_dalek::PublicKey::from(&private);
+        let (credential_ch, _credential_rx) = create_packet_recv_chan();
+        let credential_ctx = get_mock_global_ctx();
+        credential_ctx
+            .config
+            .set_network_identity(NetworkIdentity::new_credential("net1".to_string()));
+        credential_ctx
+            .config
+            .set_secure_mode(Some(SecureModeConfig {
+                enabled: true,
+                local_private_key: Some(
+                    base64::engine::general_purpose::STANDARD.encode(private.as_bytes()),
+                ),
+                local_public_key: Some(
+                    base64::engine::general_purpose::STANDARD.encode(public.as_bytes()),
+                ),
+            }));
+        let credential = Arc::new(PeerManager::new(
+            RouteAlgoType::None,
+            credential_ctx,
+            credential_ch,
+        ));
+        credential.run().await.unwrap();
+        let credential_peer_id = credential.my_peer_id();
+
+        connect_peer_manager(credential.clone(), admin.clone()).await;
+
+        wait_for_condition(
+            || {
+                let admin = admin.clone();
+                async move {
+                    admin
+                        .get_peer_map()
+                        .list_peer_conns(credential_peer_id)
+                        .await
+                        .is_some_and(|conns| !conns.is_empty())
+                }
+            },
+            Duration::from_secs(5),
+        )
+        .await;
+
+        wait_for_condition(
+            || {
+                let admin = admin.clone();
+                async move {
+                    admin
+                        .get_peer_map()
+                        .list_peer_conns(credential_peer_id)
+                        .await
+                        .is_none_or(|conns| conns.is_empty())
+                }
+            },
+            Duration::from_secs(5),
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/easytier/src/peers/peer_ospf_route.rs
+++ b/easytier/src/peers/peer_ospf_route.rs
@@ -439,6 +439,9 @@ struct SyncedRouteInfo {
     // Tracks the currently accepted peer for non-reusable credentials.
     // Maps credential pubkey bytes -> peer_id.
     non_reusable_credential_owners: DashMap<Vec<u8>, PeerId>,
+    // Duplicate non-reusable credential peers are kept for OSPF sync and topology
+    // reachability, but excluded from forwarding until owner election selects them.
+    suppressed_non_reusable_credential_peers: DashMap<PeerId, ()>,
 
     version: AtomicVersion,
 }
@@ -656,6 +659,36 @@ impl SyncedRouteInfo {
         for (pubkey, peer_id) in active_owners {
             self.non_reusable_credential_owners.insert(pubkey, peer_id);
         }
+    }
+
+    fn replace_suppressed_non_reusable_credential_peers(
+        &self,
+        suppressed_peers: BTreeSet<PeerId>,
+    ) -> bool {
+        let current: BTreeSet<_> = self
+            .suppressed_non_reusable_credential_peers
+            .iter()
+            .map(|entry| *entry.key())
+            .collect();
+        if current == suppressed_peers {
+            return false;
+        }
+
+        self.suppressed_non_reusable_credential_peers
+            .retain(|peer_id, _| suppressed_peers.contains(peer_id));
+
+        for peer_id in suppressed_peers {
+            self.suppressed_non_reusable_credential_peers
+                .insert(peer_id, ());
+        }
+
+        self.version.inc();
+        true
+    }
+
+    fn is_route_suppressed(&self, peer_id: PeerId) -> bool {
+        self.suppressed_non_reusable_credential_peers
+            .contains_key(&peer_id)
     }
 
     fn update_credential_groups(
@@ -1231,11 +1264,13 @@ impl SyncedRouteInfo {
     where
         F: FnMut(PeerId) -> bool,
     {
-        self.verify_and_update_credential_trusts_with_active_peers_protecting(
-            network_secret,
-            is_peer_active,
-            None,
-        )
+        let (untrusted_peers, global_trusted_keys, _) = self
+            .verify_and_update_credential_trusts_with_active_peers_protecting(
+                network_secret,
+                is_peer_active,
+                None,
+            );
+        (untrusted_peers, global_trusted_keys)
     }
 
     fn verify_and_update_credential_trusts_with_active_peers_protecting<F>(
@@ -1246,6 +1281,7 @@ impl SyncedRouteInfo {
     ) -> (
         Vec<PeerId>,
         HashMap<Vec<u8>, crate::common::global_ctx::TrustedKeyMetadata>,
+        bool,
     )
     where
         F: FnMut(PeerId) -> bool,
@@ -1259,14 +1295,18 @@ impl SyncedRouteInfo {
         let (all_trusted, global_trusted_keys) =
             self.collect_trusted_credentials(&peer_infos, network_secret, now);
         let prev_trusted = self.replace_trusted_credential_pubkeys(&all_trusted);
-        let (active_non_reusable_owners, duplicate_untrusted_peers) =
+        let (active_non_reusable_owners, mut duplicate_untrusted_peers) =
             self.collect_non_reusable_credential_owners(&peer_infos, &all_trusted, is_peer_active);
+        if let Some(protected_peer_id) = protected_peer_id {
+            duplicate_untrusted_peers.remove(&protected_peer_id);
+        }
         self.replace_non_reusable_credential_owners(active_non_reusable_owners);
+        let suppressed_changed =
+            self.replace_suppressed_non_reusable_credential_peers(duplicate_untrusted_peers);
         self.update_credential_groups(&peer_infos, &all_trusted);
 
         let mut untrusted_peers =
             Self::collect_revoked_credential_peers(&peer_infos, &prev_trusted, &all_trusted);
-        untrusted_peers.extend(duplicate_untrusted_peers);
         if let Some(protected_peer_id) = protected_peer_id {
             untrusted_peers.remove(&protected_peer_id);
         }
@@ -1280,7 +1320,11 @@ impl SyncedRouteInfo {
             self.remove_peers(untrusted_peers.iter().copied());
         }
 
-        (untrusted_peers.into_iter().collect(), global_trusted_keys)
+        (
+            untrusted_peers.into_iter().collect(),
+            global_trusted_keys,
+            suppressed_changed,
+        )
     }
 
     fn is_admin_peer(&self, info: &RoutePeerInfo) -> bool {
@@ -1325,6 +1369,7 @@ type NextHopMap = DashMap<PeerId, NextHopInfo>;
 struct RouteTable {
     peer_infos: DashMap<PeerId, RoutePeerInfo>,
     next_hop_map: NextHopMap,
+    suppressed_peer_ids: DashMap<PeerId, ()>,
     ipv4_peer_id_map: DashMap<Ipv4Addr, PeerIdVersion>,
     ipv6_peer_id_map: DashMap<Ipv6Addr, PeerIdVersion>,
     cidr_peer_id_map: ArcSwap<PrefixMap<Ipv4Cidr, PeerIdVersion>>,
@@ -1337,6 +1382,7 @@ impl RouteTable {
         RouteTable {
             peer_infos: DashMap::new(),
             next_hop_map: DashMap::new(),
+            suppressed_peer_ids: DashMap::new(),
             ipv4_peer_id_map: DashMap::new(),
             ipv6_peer_id_map: DashMap::new(),
             cidr_peer_id_map: ArcSwap::new(Arc::new(PrefixMap::new())),
@@ -1346,6 +1392,13 @@ impl RouteTable {
     }
 
     fn get_next_hop(&self, dst_peer_id: PeerId) -> Option<NextHopInfo> {
+        if self.suppressed_peer_ids.contains_key(&dst_peer_id) {
+            return None;
+        }
+        self.get_topology_next_hop(dst_peer_id)
+    }
+
+    fn get_topology_next_hop(&self, dst_peer_id: PeerId) -> Option<NextHopInfo> {
         let cur_version = self.next_hop_map_version.get();
         self.next_hop_map.get(&dst_peer_id).and_then(|x| {
             if x.version >= cur_version {
@@ -1358,6 +1411,18 @@ impl RouteTable {
 
     fn peer_reachable(&self, peer_id: PeerId) -> bool {
         self.get_next_hop(peer_id).is_some()
+    }
+
+    fn topology_peer_reachable(&self, peer_id: PeerId) -> bool {
+        self.get_topology_next_hop(peer_id).is_some()
+    }
+
+    fn sync_suppressed_peer_ids(&self, synced_info: &SyncedRouteInfo) {
+        self.suppressed_peer_ids
+            .retain(|peer_id, _| synced_info.is_route_suppressed(*peer_id));
+        for entry in synced_info.suppressed_non_reusable_credential_peers.iter() {
+            self.suppressed_peer_ids.insert(*entry.key(), ());
+        }
     }
 
     fn get_udp_nat_type(&self, peer_id: PeerId) -> Option<NatType> {
@@ -1429,20 +1494,21 @@ impl RouteTable {
             v.version >= cur_version
         });
         self.peer_infos.retain(|k, _| {
-            // remove peer info for peers we cannot reach.
-            self.next_hop_map.contains_key(k)
+            // remove peer info for peers we cannot forward to.
+            self.peer_reachable(*k)
         });
         self.ipv4_peer_id_map.retain(|_, v| {
-            // remove ipv4 map for peers we cannot reach.
-            self.next_hop_map.contains_key(&v.peer_id)
+            // remove ipv4 map for peers we cannot forward to.
+            self.peer_reachable(v.peer_id)
         });
         self.ipv6_peer_id_map.retain(|_, v| {
-            // remove ipv6 map for peers we cannot reach.
-            self.next_hop_map.contains_key(&v.peer_id)
+            // remove ipv6 map for peers we cannot forward to.
+            self.peer_reachable(v.peer_id)
         });
 
         shrink_dashmap(&self.peer_infos, None);
         shrink_dashmap(&self.next_hop_map, None);
+        shrink_dashmap(&self.suppressed_peer_ids, None);
         shrink_dashmap(&self.ipv4_peer_id_map, None);
         shrink_dashmap(&self.ipv6_peer_id_map, None);
     }
@@ -1543,6 +1609,7 @@ impl RouteTable {
         cost_calc: &T,
     ) {
         let version = synced_info.version.get();
+        self.sync_suppressed_peer_ids(synced_info);
 
         let local_proxy_cidrs = synced_info
             .peer_infos
@@ -1592,6 +1659,10 @@ impl RouteTable {
             }
 
             let peer_id = item.key();
+            if !self.peer_reachable(*peer_id) {
+                continue;
+            }
+
             let Some(info) = synced_info.peer_infos.read().get(peer_id).cloned() else {
                 continue;
             };
@@ -1715,6 +1786,7 @@ impl RouteTable {
             cidrs_v6 = ?self.cidr_v6_peer_id_map.load(),
             "update peer cidr map"
         );
+        self.clean_expired_route_info();
     }
 
     fn get_peer_id_for_proxy(&self, ip: &IpAddr) -> Option<PeerId> {
@@ -2145,6 +2217,7 @@ impl PeerRouteServiceImpl {
                 group_trust_map_cache: DashMap::new(),
                 trusted_credential_pubkeys: DashMap::new(),
                 non_reusable_credential_owners: DashMap::new(),
+                suppressed_non_reusable_credential_peers: DashMap::new(),
                 version: AtomicVersion::new(),
             },
             public_ipv6_service: std::sync::Mutex::new(Weak::new()),
@@ -2168,6 +2241,7 @@ impl PeerRouteServiceImpl {
         ni.network_secret_digest.map(|d| d.to_vec())
     }
 
+    #[cfg(test)]
     fn is_active_non_reusable_credential_peer(&self, peer_id: PeerId) -> bool {
         peer_id == self.my_peer_id
             || self.sessions.contains_key(&peer_id)
@@ -2486,7 +2560,7 @@ impl PeerRouteServiceImpl {
         };
         for item in self.synced_route_info.conn_map.read().iter() {
             let src_peer_id = *item.0;
-            if !self.route_table.peer_reachable(src_peer_id) {
+            if !self.route_table.topology_peer_reachable(src_peer_id) {
                 continue;
             }
             add_to_all_peer_ids(src_peer_id, item.1.version.get());
@@ -2553,7 +2627,7 @@ impl PeerRouteServiceImpl {
             }
 
             // do not send unreachable peer info to dst peer.
-            if !self.route_table.peer_reachable(*peer_id) {
+            if !self.route_table.topology_peer_reachable(*peer_id) {
                 unreachable_peers_for_peer_info.insert(*peer_id, peer_info.version);
                 continue;
             }
@@ -2571,7 +2645,7 @@ impl PeerRouteServiceImpl {
                 return false;
             };
 
-            if self.route_table.peer_reachable(*peer_id) {
+            if self.route_table.topology_peer_reachable(*peer_id) {
                 route_infos.push(peer_info.clone());
             }
 
@@ -2621,7 +2695,7 @@ impl PeerRouteServiceImpl {
                 continue;
             }
 
-            if !self.route_table.peer_reachable(*peer_id) {
+            if !self.route_table.topology_peer_reachable(*peer_id) {
                 unreachable_peers_for_conn_info.insert(*peer_id, conn_info.version.get());
                 continue;
             }
@@ -2639,7 +2713,7 @@ impl PeerRouteServiceImpl {
                 return false;
             };
 
-            if self.route_table.peer_reachable(*peer_id) {
+            if self.route_table.topology_peer_reachable(*peer_id) {
                 add_to_conn_peer_list(*peer_id, conn_info);
             }
 
@@ -2755,7 +2829,7 @@ impl PeerRouteServiceImpl {
 
     fn refresh_credential_trusts(&self) -> Vec<PeerId> {
         let network_identity = self.global_ctx.get_network_identity();
-        let (untrusted, global_trusted_keys) = self
+        let (untrusted, global_trusted_keys, _) = self
             .synced_route_info
             .verify_and_update_credential_trusts_with_active_peers_protecting(
                 network_identity.network_secret.as_deref(),
@@ -2775,17 +2849,21 @@ impl PeerRouteServiceImpl {
         // route table from the latest synced peer/conn state before checking active peers.
         self.update_route_table_and_cached_local_conn_bitmap();
 
-        let (untrusted, global_trusted_keys) = self
+        let (untrusted, global_trusted_keys, suppressed_changed) = self
             .synced_route_info
             .verify_and_update_credential_trusts_with_active_peers_protecting(
                 network_identity.network_secret.as_deref(),
-                |peer_id| self.is_active_non_reusable_credential_peer(peer_id),
+                |peer_id| {
+                    peer_id == self.my_peer_id
+                        || self.sessions.contains_key(&peer_id)
+                        || self.route_table.topology_peer_reachable(peer_id)
+                },
                 Some(self.my_peer_id),
             );
         self.global_ctx
             .update_trusted_keys(global_trusted_keys, &network_identity.network_name);
 
-        if !untrusted.is_empty() {
+        if !untrusted.is_empty() || suppressed_changed {
             self.update_route_table_and_cached_local_conn_bitmap();
         }
         untrusted
@@ -2864,7 +2942,7 @@ impl PeerRouteServiceImpl {
             if let Ok(d) = now.duration_since(peer_info.last_update.unwrap().try_into().unwrap())
                 && (d > REMOVE_DEAD_PEER_INFO_AFTER
                     || (d > REMOVE_UNREACHABLE_PEER_INFO_AFTER
-                        && !self.route_table.peer_reachable(*peer_id)))
+                        && !self.route_table.topology_peer_reachable(*peer_id)))
             {
                 to_remove.push(*peer_id);
             }
@@ -4169,7 +4247,9 @@ mod tests {
         time::{Duration, SystemTime},
     };
 
-    use super::{NextHopInfo, PeerRoute, REMOVE_DEAD_PEER_INFO_AFTER, RouteConnInfo};
+    use super::{
+        NextHopInfo, PeerRoute, REMOVE_DEAD_PEER_INFO_AFTER, RouteConnInfo, SyncRouteSession,
+    };
     use crate::{
         common::{
             PeerId,
@@ -4431,6 +4511,31 @@ mod tests {
             ..Default::default()
         });
         peer_info
+    }
+
+    fn make_admin_route_peer_info(
+        peer_id: PeerId,
+        credential_key: &[u8],
+        network_secret: &str,
+        now: i64,
+    ) -> RoutePeerInfo {
+        let mut admin_info = RoutePeerInfo::new();
+        admin_info.peer_id = peer_id;
+        admin_info.version = 1;
+        admin_info.feature_flag = Some(PeerFeatureFlag {
+            is_credential_peer: false,
+            ..Default::default()
+        });
+        admin_info.trusted_credential_pubkeys = vec![TrustedCredentialPubkeyProof::new_signed(
+            TrustedCredentialPubkey {
+                pubkey: credential_key.to_vec(),
+                expiry_unix: now + 600,
+                reusable: Some(false),
+                ..Default::default()
+            },
+            network_secret,
+        )];
+        admin_info
     }
 
     fn make_route_conn_info<I>(connected_peers: I, last_update: SystemTime) -> RouteConnInfo
@@ -4882,22 +4987,7 @@ mod tests {
 
         let credential_key = vec![7; 32];
 
-        let mut admin_info = RoutePeerInfo::new();
-        admin_info.peer_id = 30;
-        admin_info.version = 1;
-        admin_info.feature_flag = Some(PeerFeatureFlag {
-            is_credential_peer: false,
-            ..Default::default()
-        });
-        admin_info.trusted_credential_pubkeys = vec![TrustedCredentialPubkeyProof::new_signed(
-            TrustedCredentialPubkey {
-                pubkey: credential_key.clone(),
-                expiry_unix: now + 600,
-                reusable: Some(false),
-                ..Default::default()
-            },
-            network_secret,
-        )];
+        let admin_info = make_admin_route_peer_info(30, &credential_key, network_secret, now);
 
         let mut original_peer = RoutePeerInfo::new();
         original_peer.peer_id = 41;
@@ -4948,9 +5038,9 @@ mod tests {
         let (second_untrusted, _) = service_impl
             .synced_route_info
             .verify_and_update_credential_trusts(Some(network_secret));
-        assert_eq!(second_untrusted, vec![41]);
+        assert!(second_untrusted.is_empty());
         assert!(
-            !service_impl
+            service_impl
                 .synced_route_info
                 .peer_infos
                 .read()
@@ -4971,6 +5061,8 @@ mod tests {
                 .map(|entry| *entry.value()),
             Some(39)
         );
+        assert!(service_impl.synced_route_info.is_route_suppressed(41));
+        assert!(!service_impl.synced_route_info.is_route_suppressed(39));
     }
 
     #[tokio::test]
@@ -4986,22 +5078,7 @@ mod tests {
         let stale_peer_id = 41;
         let replacement_peer_id = 39;
 
-        let mut admin_info = RoutePeerInfo::new();
-        admin_info.peer_id = 30;
-        admin_info.version = 1;
-        admin_info.feature_flag = Some(PeerFeatureFlag {
-            is_credential_peer: false,
-            ..Default::default()
-        });
-        admin_info.trusted_credential_pubkeys = vec![TrustedCredentialPubkeyProof::new_signed(
-            TrustedCredentialPubkey {
-                pubkey: credential_key.clone(),
-                expiry_unix: now + 600,
-                reusable: Some(false),
-                ..Default::default()
-            },
-            network_secret,
-        )];
+        let admin_info = make_admin_route_peer_info(30, &credential_key, network_secret, now);
 
         let mut stale_peer = RoutePeerInfo::new();
         stale_peer.peer_id = stale_peer_id;
@@ -5072,6 +5149,194 @@ mod tests {
                 .map(|entry| *entry.value()),
             Some(replacement_peer_id)
         );
+        assert!(
+            !service_impl
+                .synced_route_info
+                .is_route_suppressed(stale_peer_id)
+        );
+        assert!(
+            !service_impl
+                .synced_route_info
+                .is_route_suppressed(replacement_peer_id)
+        );
+    }
+
+    #[tokio::test]
+    async fn suppressed_non_reusable_credential_peer_stays_synced_and_can_be_reactivated() {
+        const NETWORK_SECRET: &str = "sec1";
+        const SELF_PEER_ID: PeerId = 1;
+        const ADMIN_PEER_ID: PeerId = 30;
+        const FIRST_PEER_ID: PeerId = 39;
+        const SECOND_PEER_ID: PeerId = 41;
+
+        let service_impl = PeerRouteServiceImpl::new(
+            SELF_PEER_ID,
+            get_mock_global_ctx_with_network(Some(NetworkIdentity::new(
+                "test-net".to_string(),
+                NETWORK_SECRET.to_string(),
+            ))),
+        );
+        let now_unix = SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let now = SystemTime::now();
+        let credential_key = vec![10; 32];
+
+        let mut self_info = RoutePeerInfo::new();
+        self_info.peer_id = SELF_PEER_ID;
+        self_info.version = 1;
+
+        let admin_info =
+            make_admin_route_peer_info(ADMIN_PEER_ID, &credential_key, NETWORK_SECRET, now_unix);
+        let mut first_peer = make_credential_route_peer_info(FIRST_PEER_ID, &credential_key);
+        first_peer.ipv4_addr = Some(std::net::Ipv4Addr::new(10, 144, 0, 39).into());
+        let mut second_peer = make_credential_route_peer_info(SECOND_PEER_ID, &credential_key);
+        second_peer.ipv4_addr = Some(std::net::Ipv4Addr::new(10, 144, 0, 41).into());
+        second_peer.proxy_cidrs.push("10.244.41.0/24".into());
+
+        {
+            let mut peer_infos = service_impl.synced_route_info.peer_infos.write();
+            peer_infos.insert(self_info.peer_id, self_info);
+            peer_infos.insert(admin_info.peer_id, admin_info);
+            peer_infos.insert(first_peer.peer_id, first_peer);
+            peer_infos.insert(second_peer.peer_id, second_peer);
+        }
+        {
+            let mut conn_map = service_impl.synced_route_info.conn_map.write();
+            conn_map.insert(SELF_PEER_ID, make_route_conn_info([ADMIN_PEER_ID], now));
+            conn_map.insert(
+                ADMIN_PEER_ID,
+                make_route_conn_info([SELF_PEER_ID, FIRST_PEER_ID, SECOND_PEER_ID], now),
+            );
+            conn_map.insert(FIRST_PEER_ID, make_route_conn_info([ADMIN_PEER_ID], now));
+            conn_map.insert(SECOND_PEER_ID, make_route_conn_info([ADMIN_PEER_ID], now));
+        }
+        service_impl.synced_route_info.version.set(1);
+
+        let first_untrusted = service_impl.refresh_credential_trusts_with_current_topology();
+        assert!(first_untrusted.is_empty());
+        assert_eq!(
+            service_impl
+                .synced_route_info
+                .non_reusable_credential_owners
+                .get(&credential_key)
+                .map(|entry| *entry.value()),
+            Some(FIRST_PEER_ID)
+        );
+        assert!(
+            service_impl
+                .synced_route_info
+                .peer_infos
+                .read()
+                .contains_key(&SECOND_PEER_ID)
+        );
+        assert!(
+            service_impl
+                .synced_route_info
+                .is_route_suppressed(SECOND_PEER_ID)
+        );
+        assert!(
+            service_impl
+                .route_table
+                .topology_peer_reachable(SECOND_PEER_ID)
+        );
+        assert!(service_impl.route_table.peer_reachable(FIRST_PEER_ID));
+        assert!(!service_impl.route_table.peer_reachable(SECOND_PEER_ID));
+        assert!(
+            service_impl
+                .route_table
+                .peer_infos
+                .contains_key(&FIRST_PEER_ID)
+        );
+        assert!(
+            !service_impl
+                .route_table
+                .peer_infos
+                .contains_key(&SECOND_PEER_ID)
+        );
+        assert_eq!(
+            service_impl
+                .route_table
+                .ipv4_peer_id_map
+                .get(&"10.144.0.41".parse().unwrap())
+                .map(|entry| entry.peer_id),
+            None
+        );
+        assert_eq!(
+            service_impl
+                .route_table
+                .get_peer_id_for_proxy(&"10.244.41.1".parse().unwrap()),
+            None
+        );
+        let sync_session = SyncRouteSession::new(SELF_PEER_ID, ADMIN_PEER_ID);
+        let sync_peer_ids: BTreeSet<_> = service_impl
+            .build_route_info(&sync_session)
+            .unwrap()
+            .into_iter()
+            .map(|info| info.peer_id)
+            .collect();
+        assert!(sync_peer_ids.contains(&SECOND_PEER_ID));
+
+        {
+            let mut conn_map = service_impl.synced_route_info.conn_map.write();
+            conn_map.insert(
+                ADMIN_PEER_ID,
+                make_route_conn_info([SELF_PEER_ID, SECOND_PEER_ID], now),
+            );
+            conn_map.insert(FIRST_PEER_ID, make_route_conn_info([], now));
+            conn_map.insert(SECOND_PEER_ID, make_route_conn_info([ADMIN_PEER_ID], now));
+        }
+        service_impl.synced_route_info.version.inc();
+
+        let second_untrusted = service_impl.refresh_credential_trusts_with_current_topology();
+        assert!(second_untrusted.is_empty());
+        assert_eq!(
+            service_impl
+                .synced_route_info
+                .non_reusable_credential_owners
+                .get(&credential_key)
+                .map(|entry| *entry.value()),
+            Some(SECOND_PEER_ID)
+        );
+        assert!(
+            !service_impl
+                .synced_route_info
+                .is_route_suppressed(SECOND_PEER_ID)
+        );
+        assert!(
+            service_impl
+                .route_table
+                .topology_peer_reachable(SECOND_PEER_ID)
+        );
+        assert!(!service_impl.route_table.peer_reachable(FIRST_PEER_ID));
+        assert!(service_impl.route_table.peer_reachable(SECOND_PEER_ID));
+        assert!(
+            !service_impl
+                .route_table
+                .peer_infos
+                .contains_key(&FIRST_PEER_ID)
+        );
+        assert!(
+            service_impl
+                .route_table
+                .peer_infos
+                .contains_key(&SECOND_PEER_ID)
+        );
+        assert_eq!(
+            service_impl
+                .route_table
+                .ipv4_peer_id_map
+                .get(&"10.144.0.41".parse().unwrap())
+                .map(|entry| entry.peer_id),
+            Some(SECOND_PEER_ID)
+        );
+        assert_eq!(
+            service_impl
+                .route_table
+                .get_peer_id_for_proxy(&"10.244.41.1".parse().unwrap()),
+            Some(SECOND_PEER_ID)
+        );
     }
 
     #[tokio::test]
@@ -5101,7 +5366,7 @@ mod tests {
                 },
             );
 
-        let (untrusted_peers, _) = service_impl
+        let (untrusted_peers, _, _) = service_impl
             .synced_route_info
             .verify_and_update_credential_trusts_with_active_peers_protecting(
                 None,
@@ -5152,22 +5417,8 @@ mod tests {
         self_info.peer_id = SELF_PEER_ID;
         self_info.version = 1;
 
-        let mut admin_info = RoutePeerInfo::new();
-        admin_info.peer_id = admin_peer_id;
-        admin_info.version = 1;
-        admin_info.feature_flag = Some(PeerFeatureFlag {
-            is_credential_peer: false,
-            ..Default::default()
-        });
-        admin_info.trusted_credential_pubkeys = vec![TrustedCredentialPubkeyProof::new_signed(
-            TrustedCredentialPubkey {
-                pubkey: credential_key.clone(),
-                expiry_unix: now + 600,
-                reusable: Some(false),
-                ..Default::default()
-            },
-            NETWORK_SECRET,
-        )];
+        let admin_info =
+            make_admin_route_peer_info(admin_peer_id, &credential_key, NETWORK_SECRET, now);
 
         let stale_peer = make_credential_route_peer_info(stale_peer_id, &credential_key);
         let replacement_peer =

--- a/easytier/src/peers/tests.rs
+++ b/easytier/src/peers/tests.rs
@@ -1220,9 +1220,6 @@ async fn credential_expiry_disconnects_from_all_admins() {
     .await;
 
     tokio::time::sleep(Duration::from_secs(3)).await;
-    admin_a
-        .get_global_ctx()
-        .issue_event(crate::common::global_ctx::GlobalCtxEvent::CredentialChanged);
 
     wait_for_condition(
         || {

--- a/easytier/src/rpc_service/remote_client.rs
+++ b/easytier/src/rpc_service/remote_client.rs
@@ -53,6 +53,17 @@ where
         config: NetworkConfig,
         save: bool,
     ) -> Result<(), RemoteClientError<E>> {
+        self.handle_run_network_instance_with_source(identify, config, save, ConfigSource::User)
+            .await
+    }
+
+    async fn handle_run_network_instance_with_source(
+        &self,
+        identify: T,
+        config: NetworkConfig,
+        save: bool,
+        source: ConfigSource,
+    ) -> Result<(), RemoteClientError<E>> {
         let client = self
             .get_rpc_client(identify.clone())
             .ok_or(RemoteClientError::ClientNotFound)?;
@@ -63,7 +74,7 @@ where
                     inst_id: None,
                     config: Some(config.clone()),
                     overwrite: true,
-                    source: ConfigSource::User.to_rpc(),
+                    source: source.to_rpc(),
                 },
             )
             .await?;
@@ -74,7 +85,7 @@ where
                     identify,
                     resp.inst_id.unwrap_or_default().into(),
                     config,
-                    ConfigSource::User,
+                    source,
                 )
                 .await
                 .map_err(RemoteClientError::PersistentError)?;


### PR DESCRIPTION
## Summary
- keep duplicate non-reusable credential peers in OSPF sync while suppressing them from forwarding
- use topology reachability for OSPF sync and credential owner election, with forwarding reachability filtered at route lookup
- reconcile console-managed network config and cleanup legacy webhook instances

## Tests
- cargo test -p easytier peer_ospf_route --lib
- cargo fmt --check