### PR TITLE
SOCKS5 + no tun 模式下使用端口转发

### DIFF
--- a/easytier/src/gateway/socks5.rs
+++ b/easytier/src/gateway/socks5.rs
@@ -640,6 +640,7 @@ impl Socks5Server {
                     } else {
                         let _ = net.lock().await.take();
                     }
+                    port_forward_list_change_notifier.notify_waiters();
                 }
 
                 select! {
@@ -818,8 +819,29 @@ impl Socks5Server {
         let cancel_token = CancellationToken::new();
         self.cancel_tokens
             .insert(cfg.clone(), cancel_token.clone().drop_guard());
+        let port_forward_list_change_notifier = self.port_forward_list_change_notifier.clone();
 
         self.tasks.lock().unwrap().spawn(async move {
+            // Wait for SOCKS5 network stack to be ready before accepting connections
+            loop {
+                if net.lock().await.is_some() {
+                    break;
+                }
+                tracing::info!(
+                    "port forward for {:?} waiting for SOCKS5 network stack",
+                    bind_addr
+                );
+                tokio::select! {
+                    biased;
+                    _ = cancel_token.cancelled() => {
+                        tracing::info!("port forward for {:?} cancelled while waiting for network stack", bind_addr);
+                        return;
+                    }
+                    _ = port_forward_list_change_notifier.notified() => {}
+                    _ = tokio::time::sleep(Duration::from_secs(1)) => {}
+                }
+            }
+ 
             loop {
                 let (incoming_socket, addr) = select! {
                     biased;
@@ -888,8 +910,29 @@ impl Socks5Server {
         let cancel_token = CancellationToken::new();
         self.cancel_tokens
             .insert(cfg.clone(), cancel_token.clone().drop_guard());
+        let port_forward_list_change_notifier = self.port_forward_list_change_notifier.clone();
 
         self.tasks.lock().unwrap().spawn(async move {
+            // Wait for SOCKS5 network stack to be ready before accepting packets
+            loop {
+                if net.lock().await.is_some() {
+                    break;
+                }
+                tracing::info!(
+                    "udp port forward for {:?} waiting for SOCKS5 network stack",
+                    bind_addr
+                );
+                tokio::select! {
+                    biased;
+                    _ = cancel_token.cancelled() => {
+                        tracing::info!("udp port forward for {:?} cancelled while waiting for network stack", bind_addr);
+                        return;
+                    }
+                    _ = port_forward_list_change_notifier.notified() => {}
+                    _ = tokio::time::sleep(Duration::from_secs(1)) => {}
+                }
+            }
+ 
             loop {
                 // we set the max buffer size of smoltcp to 8192, so we need to use a buffer size that is less than 8192 here.
                 let mut buf = vec![0u8; 8192];


### PR DESCRIPTION
SOCKS5 + no tun 模式下端口转发报错，由于不会rust，代码由cc+mimo完成，可编译运行。
大致原理:
- 添加 port-forward 监听器，由于启用 --no-tun，网络栈不会初始化，超时后，尝试直连目标ip，直连失败报错；
- 启用 SOCKS5 后，会初始化 self.net 网络栈，尝试让  port-forward 走 self.net 网络栈，可工作。

报错
```
Caused by:
    0: Rust error: Failed to reload port forwards

       Caused by:
           0: tunnel error io error: 在其上下文中，该请求的地址无效。 (os error 10049)
           1: io error: 在其上下文中，该请求的地址无效。 (os error 10049)
           2: 在其上下文中，该请求的地址无效。 (os error 10049)
    1: Failed to reload port forwards

       Caused by:
           0: tunnel error io error: 在其上下文中，该请求的地址无效。 (os error 10049)
           1: io error: 在其上下文中，该请求的地址无效。 (os error 10049)
           2: 在其上下文中，该请求的地址无效。 (os error 10049)
```


AI修改摘要:
- 在 add_tcp_port_forward 和 add_udp_port_forward 的任务启动时添加了等待循环，阻塞直到网络栈（self.net）就绪。循环监听 port_forward_list_change_notifier 通知，并以 1 秒为间隔轮询，同时支持通过 CancellationToken 取消。
- 在 run_net_update_task 中，当网络栈状态变化（None ↔ Some）时触发 notify_waiters()，确保 port-forward 任务在网络栈就绪时能及时被唤醒。

修改文件： easytier/src/gateway/socks5.rs
