### PR TITLE
fix: recover macOS TUN after sleep wake

### DIFF
--- a/easytier/src/instance/instance.rs
+++ b/easytier/src/instance/instance.rs
@@ -831,6 +831,7 @@ impl Instance {
         tokio::spawn(async move {
             let default_ipv4_addr = Ipv4Inet::new(Ipv4Addr::new(10, 126, 126, 0), 24).unwrap();
             let mut current_dhcp_ip: Option<Ipv4Inet> = None;
+            let mut nic_needs_recreate = false;
             let mut next_sleep_time = 0;
             let nic_closed_notifier = Arc::new(Notify::new());
             loop {
@@ -842,8 +843,11 @@ impl Instance {
                 };
 
                 if nic_closed_notifier.notified().now_or_never().is_some() {
-                    tracing::debug!("nic ctx is closed, try recreate it");
-                    current_dhcp_ip = None;
+                    tracing::info!(
+                        ?current_dhcp_ip,
+                        "nic ctx is closed, recreate it while preserving dhcp ip if possible"
+                    );
+                    nic_needs_recreate = true;
                 }
 
                 // do not allocate ip if no peer connected
@@ -856,7 +860,12 @@ impl Instance {
                 }
 
                 let mut used_ipv4 = HashSet::new();
+                let my_peer_id = peer_manager_c.my_peer_id();
                 for route in routes {
+                    if route.peer_id == my_peer_id {
+                        continue;
+                    }
+
                     let Some(peer_ipv4_addr) = route.ipv4_addr else {
                         continue;
                     };
@@ -864,12 +873,36 @@ impl Instance {
                     used_ipv4.insert(peer_ipv4_addr.into());
                 }
 
-                let dhcp_inet = used_ipv4.iter().next().unwrap_or(&default_ipv4_addr);
+                let dhcp_inet = used_ipv4
+                    .iter()
+                    .next()
+                    .or(current_dhcp_ip.as_ref())
+                    .unwrap_or(&default_ipv4_addr);
                 // if old ip is already in this subnet and not conflicted, use it
                 if let Some(ip) = current_dhcp_ip
                     && ip.network() == dhcp_inet.network()
                     && !used_ipv4.contains(&ip)
                 {
+                    if !nic_needs_recreate {
+                        continue;
+                    }
+                    tracing::info!(?ip, "recreating nic with existing dhcp ip");
+                    let candidate_ipv4_addr = Some(ip);
+
+                    Self::recreate_nic_for_dhcp(
+                        &global_ctx_c,
+                        &peer_manager_c,
+                        #[cfg(feature = "tun")]
+                        nic_ctx.clone(),
+                        #[cfg(feature = "tun")]
+                        _peer_packet_receiver.clone(),
+                        #[cfg(feature = "tun")]
+                        nic_closed_notifier.clone(),
+                        &mut current_dhcp_ip,
+                        &mut nic_needs_recreate,
+                        candidate_ipv4_addr,
+                    )
+                    .await;
                     continue;
                 }
 
@@ -884,65 +917,127 @@ impl Instance {
                     continue;
                 }
 
-                let last_ip = current_dhcp_ip;
-                tracing::debug!(
-                    ?current_dhcp_ip,
-                    ?candidate_ipv4_addr,
-                    "dhcp start changing ip"
-                );
-
-                #[cfg(feature = "tun")]
-                Self::clear_nic_ctx(nic_ctx.clone(), _peer_packet_receiver.clone()).await;
-
-                if let Some(ip) = candidate_ipv4_addr {
-                    if global_ctx_c.no_tun() {
-                        current_dhcp_ip = Some(ip);
-                        global_ctx_c.set_ipv4(Some(ip));
-                        global_ctx_c
-                            .issue_event(GlobalCtxEvent::DhcpIpv4Changed(last_ip, Some(ip)));
-                        continue;
-                    }
-
-                    #[cfg(all(not(mobile), feature = "tun"))]
-                    {
-                        let mut new_nic_ctx = NicCtx::new(
-                            global_ctx_c.clone(),
-                            &peer_manager_c,
-                            _peer_packet_receiver.clone(),
-                            nic_closed_notifier.clone(),
-                        );
-                        if let Err(e) = new_nic_ctx.run(Some(ip), global_ctx_c.get_ipv6()).await {
-                            tracing::error!(
-                                ?current_dhcp_ip,
-                                ?candidate_ipv4_addr,
-                                ?e,
-                                "add ip failed"
-                            );
-                            global_ctx_c.set_ipv4(None);
-                            continue;
-                        }
-                        #[cfg(feature = "magic-dns")]
-                        let ifname = new_nic_ctx.ifname().await;
-                        Self::use_new_nic_ctx(
-                            nic_ctx.clone(),
-                            new_nic_ctx,
-                            #[cfg(feature = "magic-dns")]
-                            Self::create_magic_dns_runner(peer_manager_c.clone(), ifname, ip),
-                        )
-                        .await;
-                    }
-
-                    current_dhcp_ip = Some(ip);
-                    global_ctx_c.set_ipv4(Some(ip));
-                    global_ctx_c.issue_event(GlobalCtxEvent::DhcpIpv4Changed(last_ip, Some(ip)));
-                } else {
-                    current_dhcp_ip = None;
-                    global_ctx_c.set_ipv4(None);
-                    global_ctx_c.issue_event(GlobalCtxEvent::DhcpIpv4Conflicted(last_ip));
-                }
+                Self::recreate_nic_for_dhcp(
+                    &global_ctx_c,
+                    &peer_manager_c,
+                    #[cfg(feature = "tun")]
+                    nic_ctx.clone(),
+                    #[cfg(feature = "tun")]
+                    _peer_packet_receiver.clone(),
+                    #[cfg(feature = "tun")]
+                    nic_closed_notifier.clone(),
+                    &mut current_dhcp_ip,
+                    &mut nic_needs_recreate,
+                    candidate_ipv4_addr,
+                )
+                .await;
             }
         });
     }
+
+    #[cfg(all(target_os = "macos", feature = "tun"))]
+    async fn reset_peer_connections_after_macos_tun_recreate(peer_manager: &Arc<PeerManager>) {
+        let peer_map = peer_manager.get_peer_map();
+        let peer_ids = peer_map.list_peers_with_conn().await;
+        if peer_ids.is_empty() {
+            return;
+        }
+
+        tracing::warn!(
+            ?peer_ids,
+            "macOS tun device was recreated, closing peer connections to force reconnect"
+        );
+
+        for peer_id in peer_ids {
+            if let Err(err) = peer_map.close_peer(peer_id).await {
+                tracing::warn!(
+                    ?peer_id,
+                    ?err,
+                    "failed to close peer after macOS tun recreate"
+                );
+            }
+        }
+    }
+
+    async fn recreate_nic_for_dhcp(
+        global_ctx_c: &ArcGlobalCtx,
+        peer_manager_c: &Arc<PeerManager>,
+        #[cfg(feature = "tun")] nic_ctx: ArcNicCtx,
+        #[cfg(feature = "tun")] peer_packet_receiver: Arc<Mutex<PacketRecvChanReceiver>>,
+        #[cfg(feature = "tun")] nic_closed_notifier: Arc<Notify>,
+        current_dhcp_ip: &mut Option<Ipv4Inet>,
+        nic_needs_recreate: &mut bool,
+        candidate_ipv4_addr: Option<Ipv4Inet>,
+    ) {
+        let last_ip = *current_dhcp_ip;
+        #[allow(unused_variables)]
+        let should_reset_peer_connections = *nic_needs_recreate;
+        tracing::debug!(
+            ?current_dhcp_ip,
+            ?candidate_ipv4_addr,
+            "dhcp start changing ip"
+        );
+
+        #[cfg(feature = "tun")]
+        Self::clear_nic_ctx(nic_ctx.clone(), peer_packet_receiver.clone()).await;
+
+        if let Some(ip) = candidate_ipv4_addr {
+            if global_ctx_c.no_tun() {
+                *current_dhcp_ip = Some(ip);
+                global_ctx_c.set_ipv4(Some(ip));
+                global_ctx_c.issue_event(GlobalCtxEvent::DhcpIpv4Changed(last_ip, Some(ip)));
+                *nic_needs_recreate = false;
+                return;
+            }
+
+            #[cfg(all(not(mobile), feature = "tun"))]
+            {
+                let mut new_nic_ctx = NicCtx::new(
+                    global_ctx_c.clone(),
+                    peer_manager_c,
+                    peer_packet_receiver.clone(),
+                    nic_closed_notifier.clone(),
+                );
+                if let Err(e) = new_nic_ctx.run(Some(ip), global_ctx_c.get_ipv6()).await {
+                    tracing::error!(?current_dhcp_ip, ?candidate_ipv4_addr, ?e, "add ip failed");
+                    global_ctx_c.set_ipv4(None);
+                    return;
+                }
+                #[cfg(feature = "magic-dns")]
+                let ifname = new_nic_ctx.ifname().await;
+                Self::use_new_nic_ctx(
+                    nic_ctx.clone(),
+                    new_nic_ctx,
+                    #[cfg(feature = "magic-dns")]
+                    Self::create_magic_dns_runner(Arc::clone(peer_manager_c), ifname, ip),
+                )
+                .await;
+            }
+
+            *current_dhcp_ip = Some(ip);
+            global_ctx_c.set_ipv4(Some(ip));
+            global_ctx_c.issue_event(GlobalCtxEvent::DhcpIpv4Changed(last_ip, Some(ip)));
+            *nic_needs_recreate = false;
+        } else {
+            *current_dhcp_ip = None;
+            global_ctx_c.set_ipv4(None);
+            global_ctx_c.issue_event(GlobalCtxEvent::DhcpIpv4Conflicted(last_ip));
+            *nic_needs_recreate = false;
+        }
+
+        #[cfg(all(target_os = "macos", feature = "tun"))]
+        if should_reset_peer_connections {
+            Self::reset_peer_connections_after_macos_tun_recreate(peer_manager_c).await;
+        }
+    }
+
+    #[cfg(all(target_os = "macos", feature = "tun"))]
+    fn finish_static_ip_first_round(first_round: &mut bool) {
+        *first_round = false;
+    }
+
+    #[cfg(not(all(target_os = "macos", feature = "tun")))]
+    fn finish_static_ip_first_round(_first_round: &mut bool) {}
 
     #[cfg(all(not(mobile), feature = "tun"))]
     fn check_for_static_ip(&self, first_round_output: oneshot::Sender<Result<(), Error>>) {
@@ -961,6 +1056,8 @@ impl Instance {
 
         tokio::spawn(async move {
             let mut output_tx = Some(first_round_output);
+            #[allow(unused_variables)]
+            let mut first_round = true;
             loop {
                 let close_notifier = Arc::new(Notify::new());
                 {
@@ -972,6 +1069,8 @@ impl Instance {
                         }
                         return;
                     };
+
+                    Self::clear_nic_ctx(nic_ctx.clone(), peer_packet_receiver.clone()).await;
 
                     let mut new_nic_ctx = NicCtx::new(
                         peer_mgr.get_global_ctx(),
@@ -995,7 +1094,7 @@ impl Instance {
                     {
                         let ifname = new_nic_ctx.ifname().await;
                         let dns_runner = if let Some(ipv4) = ipv4_addr {
-                            Self::create_magic_dns_runner(peer_mgr, ifname, ipv4)
+                            Self::create_magic_dns_runner(Arc::clone(&peer_mgr), ifname, ipv4)
                         } else {
                             None
                         };
@@ -1003,11 +1102,17 @@ impl Instance {
                     }
                     #[cfg(not(feature = "magic-dns"))]
                     Self::use_new_nic_ctx(nic_ctx.clone(), new_nic_ctx).await;
+
+                    #[cfg(all(target_os = "macos", feature = "tun"))]
+                    if !first_round {
+                        Self::reset_peer_connections_after_macos_tun_recreate(&peer_mgr).await;
+                    }
                 }
 
                 if let Some(output_tx) = output_tx.take() {
                     let _ = output_tx.send(Ok(()));
                 }
+                Self::finish_static_ip_first_round(&mut first_round);
 
                 // NOTICE: make sure we do not hold the peer manager here,
                 while close_notifier.notified().now_or_never().is_none() {

--- a/easytier/src/instance/virtual_nic.rs
+++ b/easytier/src/instance/virtual_nic.rs
@@ -1006,6 +1006,7 @@ impl NicCtx {
                 let ret = sink.send(packet).await;
                 if ret.is_err() {
                     tracing::error!(?ret, "do_forward_tunnel_to_nic sink error");
+                    break;
                 }
             }
             close_notifier.notify_one();
@@ -1036,6 +1037,41 @@ impl NicCtx {
                 );
             }
         }
+    }
+
+    #[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
+    fn run_macos_sleep_wake_recreate_watcher(&mut self) {
+        const CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+        const WAKE_GAP_THRESHOLD: std::time::Duration = std::time::Duration::from_secs(20);
+        const NETWORK_SETTLE_DELAY: std::time::Duration = std::time::Duration::from_secs(3);
+
+        let close_notifier = self.close_notifier.clone();
+        self.tasks.spawn(async move {
+            let mut last_wall = std::time::SystemTime::now();
+            loop {
+                tokio::time::sleep(CHECK_INTERVAL).await;
+
+                let now = std::time::SystemTime::now();
+                match now.duration_since(last_wall) {
+                    Ok(elapsed) if elapsed > WAKE_GAP_THRESHOLD => {
+                        tracing::warn!(
+                            ?elapsed,
+                            "detected macOS sleep/wake gap, recreating tun device"
+                        );
+                        tokio::time::sleep(NETWORK_SETTLE_DELAY).await;
+                        close_notifier.notify_one();
+                        return;
+                    }
+                    Ok(_) => {
+                        last_wall = now;
+                    }
+                    Err(err) => {
+                        tracing::warn!(?err, "system time moved backwards in macOS wake watcher");
+                        last_wall = now;
+                    }
+                }
+            }
+        });
     }
 
     async fn apply_route_changes(
@@ -1376,6 +1412,8 @@ impl NicCtx {
 
         self.do_forward_nic_to_peers_task(stream)?;
         self.do_forward_peers_to_nic(sink);
+        #[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
+        self.run_macos_sleep_wake_recreate_watcher();
 
         // Assign IPv4 address if provided
         if let Some(ipv4_addr) = ipv4_addr {


### PR DESCRIPTION
# 修复 macOS 休眠唤醒后 TUN 数据面可能无法恢复

Fixes #2049

## 背景

在 macOS 上以普通 TUN 模式运行 `easytier-core` 时，机器经历休眠/唤醒后可能出现一种半失效状态：

- `easytier-core` 进程仍在运行，launchd 没有重启服务。
- 管理接口里仍能看到 peer、route、connector 等控制面状态。
- 但虚拟网段内的 peer 无法互相 ping 通，用户数据面不恢复。
- 手动 `launchctl kickstart` 或重启 `easytier-core` 后通信恢复。

这个问题在 macOS 的普通 TUN backend 上更容易复现。真实环境中还观察到：休眠唤醒后旧 `utun` 可能处于不可用或半不可用状态，EasyTier 控制面连接有时仍被认为存活，但用户数据包已经无法正常穿过旧的数据路径。

## 与上游最新代码的关系

提交 PR 前已同步到上游最新 `origin/main`：

```text
origin/main: 8428a89 refactor: introduce HedgeExt for task hedging; rewrite NatDstQuicConnector (#2229)
tag: v2.6.4
```

同步后重点检查了近期网络相关改动：

- `55f15bb fix(connector): classify manual reconnect timeouts by stage (#2062)`
  - 改善 manual connector 的 reconnect 超时分类。
  - 不处理 macOS TUN 设备在休眠唤醒后的生命周期。
- `bfbfa2e fix: reuse conn by dst_peer_id, every peer use only 1 quic conn, to fix nat lost problem (#2216)`
  - 处理 NAT/QUIC 连接复用问题。
  - 不处理本地 TUN 写入失败或 TUN 重建后的 peer connection 刷新。
- `8e1d079 feat: add Windows UDP broadcast relay (#2222)`
  - 修改了 `virtual_nic.rs`，但仅针对 Windows UDP broadcast relay。
  - 本 PR 合并时保留了这部分上游改动。
- 之前的 `#1593 fix(core): Fix sleep-wake reconnect by resetting alive_conn_urls`
  - 已经修复了一类 sleep/wake 后 connector alive URL 状态错误的问题。
  - 本 PR 处理的是另一个层面的问题：macOS TUN 设备和数据面连接在唤醒后可能需要主动重建。

因此，本 PR 不是重复已有修复，而是补齐 macOS TUN 生命周期和 peer data path 恢复逻辑。

## 原因分析

### 1. TUN sink 写入失败后没有退出 forwarding task

`NicCtx::do_forward_peers_to_nic` 负责把来自 peer 的用户数据包写回 TUN。

原逻辑中，当 `sink.send(packet).await` 返回错误时，只记录日志：

```rust
tracing::error!(?ret, "do_forward_tunnel_to_nic sink error");
```

但 forwarding loop 会继续运行。这样会导致一个问题：TUN 已经不可写时，任务仍可能卡在旧 sink 上，`close_notifier` 不会及时触发，外层也就没有机会清理并重建 NIC context。

在 macOS 休眠/唤醒后，`utun` 设备可能进入这种半失效状态。此时继续保留旧 forwarding task 会让 EasyTier 看起来还活着，但数据面已经不可靠。

### 2. macOS sleep/wake 不一定会以明确的网络错误形式暴露

macOS 唤醒后，系统网络栈、物理网卡、路由、TUN 设备恢复时序并不总是同步。

仅依赖后续 I/O 错误来发现问题并不稳妥，因为：

- 旧 TUN 可能没有立即返回错误。
- control plane 连接可能仍被 EasyTier 视为 alive。
- peer ping/pong 或 connector 状态不能等价证明用户数据面正常。

因此需要一个 macOS 专用的轻量 watcher：通过 wall clock gap 判断进程经历了 sleep/wake，然后主动触发 TUN 重建。

### 3. TUN 重建后，仅保留旧 peer connections 仍可能数据面黑洞

实际复现中曾观察到：

- 唤醒后 TUN 已经从一个 `utun` 重建到另一个 `utun`。
- DHCP 地址也保持不变。
- 但 peer ping 仍不通。
- 重启整个 `easytier-core` 后立即恢复。

这说明“只重建 TUN”仍不够。旧 peer connections 可能还被控制面认为可用，但其对应的数据路径已经过期或黑洞。

因此，在 macOS TUN 被主动重建后，需要关闭现有 peer connections，让 connector/peer manager 建立新的连接路径。

## 修复方案

本 PR 包含三个层面的修复。

### 1. TUN sink 写入失败后退出 loop

在 `do_forward_peers_to_nic` 中，如果写入 TUN sink 失败，立即 `break`：

```rust
let ret = sink.send(packet).await;
if ret.is_err() {
    tracing::error!(?ret, "do_forward_tunnel_to_nic sink error");
    break;
}
```

这样 forwarding task 结束后会继续执行：

```rust
close_notifier.notify_one();
```

外层 NIC lifecycle 逻辑就能感知 TUN 已失效并重建。

### 2. macOS 普通 TUN backend 增加 sleep/wake watcher

新增 `run_macos_sleep_wake_recreate_watcher`，仅在：

```rust
#[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
```

下启用。

逻辑：

- 每 5 秒记录一次 wall clock。
- 如果两次检查之间的 elapsed 超过 20 秒，认为进程经历了 sleep/wake 或长时间挂起。
- 等待 3 秒让网络栈 settle。
- 调用 `close_notifier.notify_one()`，触发 NIC context 重建。

相关日志：

```text
detected macOS sleep/wake gap, recreating tun device
```

该逻辑不影响：

- Windows。
- Linux。
- FreeBSD。
- macOS Network Extension backend，即 `feature = "macos-ne"`。
- mobile `run_for_mobile` 路径。

### 3. DHCP/static IP TUN 重建后重置 peer connections

#### DHCP 模式

原 DHCP loop 在 `nic_closed_notifier` 被触发后，会清空 `current_dhcp_ip`。这会导致 TUN 重建时重新选择地址。

本 PR 改为：

- `nic_closed_notifier` 触发时设置 `nic_needs_recreate = true`。
- 尽量保留当前 DHCP IP。
- 计算已占用地址时跳过本机 route，避免把自己的 IP 当成冲突。
- 选择 DHCP 网段时优先使用 peer route 暴露出来的网段；只有没有 peer route 时才回退到当前 IP 或默认网段，避免在拓扑网段已经变化时错误保留旧网段。
- 如果原 IP 仍在同一网段且未冲突，则使用原 IP 重建 TUN。

相关日志：

```text
nic ctx is closed, recreate it while preserving dhcp ip if possible
recreating nic with existing dhcp ip
```

#### peer connection reset

新增 macOS 专用 helper：

```rust
reset_peer_connections_after_macos_tun_recreate
```

它会：

1. 从 peer map 中列出当前有连接的 peer。
2. 对这些 peer 调用 `close_peer(peer_id)`。
3. 让既有连接全部关闭，connector 后续重新建连。

相关日志：

```text
macOS tun device was recreated, closing peer connections to force reconnect
```

这一步只在 macOS + TUN 下执行，并且只在 NIC 重建场景执行，避免影响正常启动。

#### static IP 模式

静态 IP 路径也补了同样的处理：

- 第一次启动不关闭 peer connections。
- 每次创建新 TUN 前先 `clear_nic_ctx`，确保旧 TUN context 被释放，避免旧设备仍持有相同地址/路由。
- 后续 TUN close/recreate 后，关闭 peer connections 以强制重连。

## 为什么不只修 connector

上游已有 reconnect 相关修复，但这个问题的触发点不完全在 connector：

- TUN 可能已经不可用，但 connector 仍能认为某些连接 alive。
- 数据面黑洞时，control plane 状态不一定立即反映故障。
- 真实测试中，TUN 已重建但不重置 peer connections 仍会 ping 不通。

因此本 PR 在 NIC lifecycle 层处理：

- 先确保 TUN 不可写时 NIC 能被重建。
- 再确保 macOS sleep/wake 后主动重建 TUN。
- 最后确保 TUN 重建后 peer data path 也被刷新。

## 实际验证

在 macOS + launchd + TUN 模式下用 patched `easytier-core` 运行数天。

验证环境特征：

- `easytier-core` 由 launchd 作为 daemon 运行。
- 本地启用 EasyTier DHCP。
- 本机经历多次 macOS sleep/darkwake/fullwake。
- 未使用外部 watchdog 自动重启 EasyTier。

观察到的行为：

- launchd 中 `easytier-core` 进程没有被重启。
- sleep/wake 后 EasyTier 自动重建 `utun`。
- DHCP 地址保持不变，例如 `192.168.88.7/24 -> 192.168.88.7/24`。
- TUN 重建后旧 peer connections 被成批关闭。
- 随后 connector 自动重连 peer。
- `easytier-cli peer` 显示 peer loss 为 `0.0%`。
- 虚拟网段内 peer ping 正常。

真实日志中可见的典型顺序：

```text
tun device ready dev="utun6"
dhcp ip changed old=Some(.../24) new=Some(.../24)
peer connection removed ...
connecting to peer ...
new peer connection added ...
```

当前检查命令：

```sh
cargo fmt --all
cargo check -p easytier --bin easytier-core
```

`cargo check` 已通过。当前上游代码在 macOS 下仍有既有 `macos_bpf.rs` 的 `unsafe_op_in_unsafe_fn` warning，本 PR 未涉及该文件。

额外在 OrbStack Docker 提供的 Linux 环境中做了验证：

```sh
cargo test -p easytier --lib tests::three_node::basic_three_node_test::proto_1___tcp__::encrypt_algorithm_pair_01____aes_gcm_____aes_gcm___ -- --exact --nocapture --test-threads=1
```

结果：通过。这个用例覆盖了 Linux 网络命名空间、bridge/veth、三节点连接、route 同步和用户数据面转发。

Docker 环境说明：

- 容器需要 `--privileged`。
- 需要额外安装 `bridge-utils`，否则测试里的 `brctl` 调用会在 `easytier/src/tests/mod.rs` 直接失败。
- 补齐 `bridge-utils` 后，代表性三节点端到端用例从失败恢复为通过。

也尝试过在同一 Docker 环境中执行全量：

```sh
cargo test -p easytier --lib
```

结果：`898 passed; 294 failed; 5 ignored`。失败集中在并发运行的大量复杂网络矩阵、public IPv6、UPnP、IPv6 domain、subnet proxy / portal 等依赖容器网络栈和测试隔离的场景。未观察到失败指向本 PR 修改的 macOS-only watcher 或 TUN recreate 逻辑；其中很多基础三节点、credential、ACL、port-forward、TUN 基础测试已经在补齐依赖后通过。该全量结果不作为本 PR 的阻塞项，但在 PR 中保留说明，方便 reviewer 复现和判断。

## Review 过程

本地用 `codex review --base origin/main` 对最终 diff 做了多轮 review。

review 中发现并修复过的问题：

- DHCP 网段选择最初错误地优先保留当前 IP，可能在 peer route 网段变化时继续停留在旧网段；已改为优先使用 peer route 网段。
- static IP 重建路径最初没有在创建新 TUN 前释放旧 NIC context，可能造成旧 TUN 仍占用相同地址/路由；已在 static IP loop 中补 `clear_nic_ctx`。
- Linux cfg 路径里曾出现 `first_round` 的 unused-assignment warning；已通过 cfg helper 消除，避免非 macOS 编译路径出现无意义 warning。

最终 review 结论：

```text
No discrete correctness issues were identified in the reviewed changes.
The new NIC recreation paths appear to preserve existing behavior while adding macOS wake handling and peer reset logic.
```

## 风险与兼容性

### 影响范围

主要影响：

- macOS。
- 普通 TUN backend。
- TUN close/recreate 场景。

非目标平台基本不受影响：

- Windows watcher 逻辑不会编译进去。
- Linux/FreeBSD watcher 逻辑不会编译进去。
- macOS Network Extension backend 不启用该 watcher。

### 行为变化

当 macOS 进程被挂起超过 20 秒后：

- EasyTier 会主动重建 TUN。
- 如果这是 TUN 重建而非首次启动，会关闭现有 peer connections。
- peer 连接会经历一次短暂重连。

这是有意为之。相比保留半失效数据面，主动短暂重连更可控。

### DHCP 地址冲突

本 PR 在保留当前 DHCP IP 时，会跳过本机 route，并检查该 IP 是否仍在目标网段且未被其他 peer 占用。

如果当前 IP 已冲突，则仍走原有逻辑重新选择可用地址。

## 后续可能改进

这次修复以最小改动解决 macOS TUN sleep/wake 恢复问题。更长期可以考虑：

- 在 EasyTier 内部定义更明确的 NIC lifecycle event。
- 让 connector/peer manager 对“本地数据面重建”有专门响应，而不是由 Instance 直接关闭 peer。
- 对 macOS 使用更直接的系统 sleep/wake notification，而不是 wall clock gap。

当前实现选择 wall clock gap，是因为：

- 不依赖额外 macOS framework 绑定。
- 对 daemon/headless 场景简单可靠。
- 已能覆盖真实 sleep/wake 复现场景。
