### PR TITLE
feat: add Docker healthcheck

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -42,4 +42,7 @@ EXPOSE 11011/tcp
 # wss
 EXPOSE 11012/tcp
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD easytier-cli node info >/dev/null || exit 1
+
 ENTRYPOINT ["/sbin/tini", "--", "easytier-core"]

--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -42,7 +42,7 @@ EXPOSE 11011/tcp
 # wss
 EXPOSE 11012/tcp
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
-    CMD easytier-cli node info >/dev/null || exit 1
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=5 \
+    CMD ["/usr/local/bin/easytier-cli", "--rpc-portal", "127.0.0.1:15888", "--output", "json", "node", "info"]
 
 ENTRYPOINT ["/sbin/tini", "--", "easytier-core"]


### PR DESCRIPTION
## Summary
- add a Docker HEALTHCHECK for EasyTier images using `easytier-cli node info`
- mark containers unhealthy when the local EasyTier RPC status check fails

## Tests
- `docker build --build-arg TARGETPLATFORM=linux/amd64 -f .github/workflows/Dockerfile -t easytier-healthcheck-test:local <temporary-context>`
- `docker image inspect easytier-healthcheck-test:local --format {{json .Config.Healthcheck}}`
- `git diff --check`

Fixes #1595