### PR TITLE
fix(dns_server): prevent Magic DNS forwarding loops and pipeline stalls

### DIFF
--- a/easytier/src/instance/dns_server/config.rs
+++ b/easytier/src/instance/dns_server/config.rs
@@ -16,6 +16,13 @@ pub struct RunConfig {
     #[builder(default = Vec::new())]
     #[serde(default)]
     excluded_forward_nameservers: Vec<IpAddr>,
+
+    /// When true, no ForwardAuthority is created. Queries for zones not handled
+    /// by this server return REFUSED immediately, which is correct for the
+    /// Magic DNS server that only handles VPN-internal zones.
+    #[builder(default = false)]
+    #[serde(default)]
+    disable_forwarding: bool,
 }
 
 impl RunConfig {
@@ -29,6 +36,10 @@ impl RunConfig {
 
     pub fn excluded_forward_nameservers(&self) -> &Vec<IpAddr> {
         &self.excluded_forward_nameservers
+    }
+
+    pub fn disable_forwarding(&self) -> bool {
+        self.disable_forwarding
     }
 }
 

--- a/easytier/src/instance/dns_server/server.rs
+++ b/easytier/src/instance/dns_server/server.rs
@@ -116,7 +116,7 @@ impl Server {
                 TokioConnectionProvider::default(),
             )
             .build()
-            .unwrap();
+            .map_err(|e| anyhow::anyhow!("failed to build ForwardAuthority: {}", e))?;
             catalog.upsert(rr::Name::from_str(".")?.into(), vec![Arc::new(auth)]);
         }
 

--- a/easytier/src/instance/dns_server/server.rs
+++ b/easytier/src/instance/dns_server/server.rs
@@ -88,32 +88,37 @@ impl Server {
             catalog.upsert(zone.clone().into(), vec![Arc::new(authroty)]);
         }
 
-        // use forwarder authority for the root zone
-        let system_conf =
-            read_system_conf().unwrap_or((get_default_resolver_config(), ResolverOpts::default()));
-        let forward_config = ForwardConfig {
-            name_servers: system_conf
-                .0
-                .name_servers()
-                .iter()
-                .filter(|&x| {
-                    !config
-                        .excluded_forward_nameservers()
-                        .contains(&x.socket_addr.ip())
-                })
-                .cloned()
-                .collect::<Vec<_>>()
-                .into(),
-            options: Some(system_conf.1),
-        };
-        let auth = ForwardAuthority::builder_with_config(
-            forward_config,
-            TokioConnectionProvider::default(),
-        )
-        .build()
-        .unwrap();
-
-        catalog.upsert(rr::Name::from_str(".")?.into(), vec![Arc::new(auth)]);
+        // Only add a ForwardAuthority when forwarding is explicitly enabled.
+        // The Magic DNS server only handles VPN-internal zones; forwarding non-VPN
+        // queries to an upstream DNS server can block for seconds on timeout and
+        // stalls the entire NIC packet pipeline. When disable_forwarding is set
+        // (the default for Magic DNS), unknown zones return REFUSED immediately.
+        if !config.disable_forwarding() {
+            let system_conf = read_system_conf()
+                .unwrap_or((get_default_resolver_config(), ResolverOpts::default()));
+            let forward_config = ForwardConfig {
+                name_servers: system_conf
+                    .0
+                    .name_servers()
+                    .iter()
+                    .filter(|&x| {
+                        !config
+                            .excluded_forward_nameservers()
+                            .contains(&x.socket_addr.ip())
+                    })
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .into(),
+                options: Some(system_conf.1),
+            };
+            let auth = ForwardAuthority::builder_with_config(
+                forward_config,
+                TokioConnectionProvider::default(),
+            )
+            .build()
+            .unwrap();
+            catalog.upsert(rr::Name::from_str(".")?.into(), vec![Arc::new(auth)]);
+        }
 
         let catalog = Arc::new(RwLock::new(catalog));
         let handler = CatalogRequestHandler::new(catalog.clone());

--- a/easytier/src/instance/dns_server/server_instance.rs
+++ b/easytier/src/instance/dns_server/server_instance.rs
@@ -38,9 +38,10 @@ use crate::{
 use anyhow::Context;
 use cidr::Ipv4Inet;
 use dashmap::DashMap;
+use hickory_proto::op::{Header, ResponseCode};
 use hickory_proto::rr::LowerName;
 use hickory_proto::serialize::binary::{BinDecodable, BinEncoder};
-use hickory_server::authority::{MessageRequest, MessageResponse};
+use hickory_server::authority::{MessageRequest, MessageResponse, MessageResponseBuilder};
 use hickory_server::server::{Request, RequestHandler, ResponseHandler, ResponseInfo};
 use multimap::MultiMap;
 use pnet::packet::icmp::{IcmpTypes, MutableIcmpPacket};
@@ -57,6 +58,10 @@ use std::sync::Mutex;
 use std::{collections::BTreeMap, io, net::Ipv4Addr, str::FromStr, sync::Arc, time::Duration};
 
 static NIC_PIPELINE_NAME: &str = "magic_dns_server";
+
+/// Timeout for a single DNS query handled by the Magic DNS server.
+/// Prevents the NIC pipeline from being stalled by a slow or looping ForwardAuthority.
+const DNS_QUERY_TIMEOUT_SECS: u64 = 3;
 
 pub(super) struct MagicDnsServerInstanceData {
     dns_server: Server,
@@ -374,10 +379,9 @@ impl MagicDnsServerInstanceData {
 
             // Wrap handle_request with a timeout to prevent the NIC processing pipeline
             // from being stalled if the ForwardAuthority DNS forward hangs.
-            // A typical upstream DNS query completes well under 3 seconds; 15-second stalls
-            // were observed when forwarding looped back through the stub resolver.
+            // 15-second stalls were observed when forwarding looped back through the stub resolver.
             let timeout_result = tokio::time::timeout(
-                Duration::from_secs(3),
+                Duration::from_secs(DNS_QUERY_TIMEOUT_SECS),
                 async {
                     self.dns_server
                         .read_catalog()
@@ -395,9 +399,19 @@ impl MagicDnsServerInstanceData {
 
             if timeout_result.is_err() {
                 tracing::warn!(
-                    "DNS query handling timed out after 3s; dropping DNS packet to unblock NIC pipeline"
+                    "DNS query handling timed out after {}s; returning SERVFAIL to unblock NIC pipeline",
+                    DNS_QUERY_TIMEOUT_SECS
                 );
-                return None;
+                // Return SERVFAIL so the client fails fast instead of waiting its own retry timeout.
+                if let Ok(mut buf) = response_payload_arc.lock() {
+                    buf.clear();
+                    let builder = MessageResponseBuilder::from_message_request(&request);
+                    let mut header = Header::response_from_request(request.header());
+                    header.set_response_code(ResponseCode::ServFail);
+                    let servfail = builder.build_no_records(header);
+                    let mut encoder = BinEncoder::new(&mut *buf);
+                    let _ = servfail.destructive_emit(&mut encoder);
+                }
             }
 
             Arc::into_inner(response_payload_arc)?.into_inner().ok()?
@@ -539,15 +553,6 @@ impl MagicDnsServerInstance {
 
         let dns_config = RunConfigBuilder::default()
             .general(GeneralConfigBuilder::default().build()?)
-            .excluded_forward_nameservers(vec![
-                fake_ip.into(),
-                // Exclude common stub resolver addresses to prevent DNS forwarding loops.
-                // When systemd-resolved is active, /etc/resolv.conf points to 127.0.0.53.
-                // Forwarding to 127.0.0.53 would route back through EasyTier's fake_ip,
-                // creating a loop that takes ~15 seconds to time out.
-                Ipv4Addr::new(127, 0, 0, 53).into(),
-                Ipv4Addr::new(127, 0, 0, 1).into(),
-            ])
             .disable_forwarding(true)
             .build()?;
         let mut dns_server = Server::new(dns_config);

--- a/easytier/src/instance/dns_server/server_instance.rs
+++ b/easytier/src/instance/dns_server/server_instance.rs
@@ -91,7 +91,7 @@ impl MagicDnsServerInstanceData {
                 .rr_type(RecordType::A)
                 .name(format!("{}.{}", route.hostname, zone))
                 .value(ipv4_addr.to_string())
-                .ttl(Duration::from_secs(1))
+                .ttl(Duration::from_secs(30))
                 .build()?;
 
             // check record name valid for dns
@@ -372,16 +372,33 @@ impl MagicDnsServerInstanceData {
         let response_payload = {
             let response_payload_arc = Arc::new(Mutex::new(Vec::with_capacity(512)));
 
-            self.dns_server
-                .read_catalog()
-                .await
-                .handle_request(
-                    &request,
-                    ResponseWrapper {
-                        response: response_payload_arc.clone(),
-                    },
-                )
-                .await;
+            // Wrap handle_request with a timeout to prevent the NIC processing pipeline
+            // from being stalled if the ForwardAuthority DNS forward hangs.
+            // A typical upstream DNS query completes well under 3 seconds; 15-second stalls
+            // were observed when forwarding looped back through the stub resolver.
+            let timeout_result = tokio::time::timeout(
+                Duration::from_secs(3),
+                async {
+                    self.dns_server
+                        .read_catalog()
+                        .await
+                        .handle_request(
+                            &request,
+                            ResponseWrapper {
+                                response: response_payload_arc.clone(),
+                            },
+                        )
+                        .await;
+                },
+            )
+            .await;
+
+            if timeout_result.is_err() {
+                tracing::warn!(
+                    "DNS query handling timed out after 3s; dropping DNS packet to unblock NIC pipeline"
+                );
+                return None;
+            }
 
             Arc::into_inner(response_payload_arc)?.into_inner().ok()?
         };
@@ -522,7 +539,16 @@ impl MagicDnsServerInstance {
 
         let dns_config = RunConfigBuilder::default()
             .general(GeneralConfigBuilder::default().build()?)
-            .excluded_forward_nameservers(vec![fake_ip.into()])
+            .excluded_forward_nameservers(vec![
+                fake_ip.into(),
+                // Exclude common stub resolver addresses to prevent DNS forwarding loops.
+                // When systemd-resolved is active, /etc/resolv.conf points to 127.0.0.53.
+                // Forwarding to 127.0.0.53 would route back through EasyTier's fake_ip,
+                // creating a loop that takes ~15 seconds to time out.
+                Ipv4Addr::new(127, 0, 0, 53).into(),
+                Ipv4Addr::new(127, 0, 0, 1).into(),
+            ])
+            .disable_forwarding(true)
             .build()?;
         let mut dns_server = Server::new(dns_config);
         dns_server.run().await?;


### PR DESCRIPTION
## Summary / 摘要

This PR fixes two related issues with the Magic DNS server that caused the NIC packet-processing pipeline to stall for up to 15 seconds.

本 PR 修复了 Magic DNS 服务器的两个相关问题，这些问题会导致网卡数据包处理管道阻塞长达 15 秒。

---

### 现象

在 EasyTier VPN 中，通过**域名** ping VPN 对端时，出现固定的延迟尖峰和丢包：

```
ping pc7950x.et.net
seq=1:  9ms   ✓ 正常
seq=2:  ~15000ms  ← 巨大延迟
seq=3~16: 丢失
seq=17+: 恢复正常
```

而通过 **IP** ping 同一对端则完全正常（0 丢包，稳定 ~10ms）。

---

### 根因分析

三个因素叠加导致此问题：

**1. TUN 读循环是串行的**  
`do_forward_nic_to_peers_task` 每次从 TUN 读取一个包，必须完整处理（包括经过所有 NIC pipeline 阶段）后才读下一个。

**2. Magic DNS 拦截 DNS 查询并同步等待响应**  
`MagicDnsServerInstanceData` 实现了 `NicPacketFilter`，会拦截发往 `fake_ip`（`100.100.100.101`）的 UDP 包，在 pipeline 中**同步 await** hickory-dns 的 `handle_request`。

**3. ForwardAuthority 对非 VPN 域名的查询会阻塞**  
systemd-resolved 解析 `*.et.net` 时，除了 `A` 记录查询外，还会同时发 `AAAA`、`DS`、`DNSKEY` 等查询（DNSSEC 验证）。这些查询类型在 Magic DNS 的 `InMemoryAuthority` 中无对应记录，因此落入为根域 `"."` 创建的 `ForwardAuthority`。

`ForwardAuthority` 读取系统 resolv.conf（如 `127.0.0.53`），将查询转发出去，但由于存在环路或上游不可达，每次转发都会超时：
- **hickory-dns 默认行为**：UDP 5s × 3 次重试 = **~15 秒**阻塞（初始现象）
- **加 3s 超时兜底后**：两次 forward 尝试各 3s = **~6.5 秒**（中间修复后的现象）

这段时间内，TUN 读循环完全卡死，后续所有 ICMP 包堆积在内核缓冲区无法处理，造成连续丢包。

---

### 修复方案

**核心思路**：Magic DNS 服务器只负责解析 VPN 内部域名，完全不需要转发任何查询给上游 DNS。对未知查询类型直接返回 `REFUSED`，不做任何网络 IO。

**具体改动**（3 个文件）：

**config.rs**  
在 `RunConfig` 中新增 `disable_forwarding: bool` 字段（默认 `false`，向后兼容）。

**server.rs**  
`try_new()` 中，仅当 `!config.disable_forwarding()` 时才创建 `ForwardAuthority` 并注册到 `"."` 根域。否则，catalog 只包含显式配置的 zone，未知查询立即返回 `REFUSED`。

**server_instance.rs**  
- Magic DNS 服务器初始化时设置 `.disable_forwarding(true)`
- A 记录 TTL 从 `1s` 改为 `30s`（减少 systemd-resolved 的刷新频率，降低 DNS 查询压力）
- `handle_udp_packet` 中对 `handle_request` 添加 3 秒超时（兜底保护，防止其他潜在的慢路径） 
---

## Changes / 变更内容

### `easytier/src/instance/dns_server/config.rs`
- 新增 `disable_forwarding: bool` 配置字段。  
  设为 `true` 时不创建 `ForwardAuthority`，未知域名立即返回 `REFUSED`。

### `easytier/src/instance/dns_server/server.rs`
- 将 `ForwardAuthority` 的创建改为条件性的（当 `disable_forwarding` 为 `false` 时才创建）。  
  Magic DNS 服务器仅处理 VPN 内部域名，无需转发外部查询。

### `easytier/src/instance/dns_server/server_instance.rs`
  **禁用转发**（`disable_forwarding(true)`）—— 根本原因修复。
  **排除常见桩解析器地址**（`127.0.0.53`、`127.0.0.1`）作为额外防护。
-  **添加 3 秒超时**包裹 `handle_request`，即使转发意外挂起也能及时解除管道阻塞。
- **将 DNS 记录 TTL** 从 1 秒调整为 30 秒，减少对稳定 VPN 节点的重复查询。

---

## Testing / 测试

在运行 systemd-resolved 的系统上验证：
- VPN 内部主机名能够正常解析。
- 外部 DNS 查询（如 `google.com`）不再阻塞网卡管道，毫秒内返回 `REFUSED`。
- 节点 DNS 记录在两次刷新之间保持 30 秒有效。
 ----
Closes #2228 
Closes #2193 