### PR TITLE
build: update pnpm config for v11 compatibility

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,11 @@ packages:
   - 'easytier-web/frontend-lib'
   - 'easytier-gui'
   - 'tauri-plugin-vpnservice'
+
+overrides:
+  minimatch: 10.2.4
+
+allowBuilds:
+  esbuild: true
+  unrs-resolver: true
+  vue-demi: true


### PR DESCRIPTION
pnpm v11 introduces breaking changes that cause frozen installations to fail:

1. The "pnpm" field in package.json is no longer read. Moved `overrides` to `pnpm-workspace.yaml` to fix `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`.
2. `strictDepBuilds` is now enabled by default. Added required dependencies (esbuild, unrs-resolver, vue-demi) to `allowBuilds` in the workspace config to fix `ERR_PNPM_IGNORED_BUILDS`.