### PR TITLE
feat: 支持配置 PeerConn 心跳参数并在 GUI 中暴露

### DIFF
--- a/easytier-contrib/easytier-android-jni/example_config.toml
+++ b/easytier-contrib/easytier-android-jni/example_config.toml
@@ -54,3 +54,11 @@ network = "my_easytier_network"
 
 # 延迟优先 (可选)
 # latency_first = false
+
+[flags]
+# PeerConn 最大心跳间隔，单位秒。默认 32；0 表示使用默认值
+peer_conn_max_heartbeat_interval_secs = 32
+# 连续丢失多少次 Pong 后关闭 PeerConn。默认 5；0 表示使用默认值
+peer_conn_max_missed_heartbeats = 5
+# 单次等待 Pong 的超时时间，单位秒。默认 2；0 表示使用默认值
+peer_conn_pong_timeout_secs = 2

--- a/easytier-contrib/easytier-android-jni/kotlin/com/easytier/jni/EasyTierDataPlaneJNI.kt
+++ b/easytier-contrib/easytier-android-jni/kotlin/com/easytier/jni/EasyTierDataPlaneJNI.kt
@@ -34,6 +34,9 @@ import kotlinx.coroutines.withContext
  *     [flags]
  *     no_tun = true
  *     bind_device = false
+ *     peer_conn_max_heartbeat_interval_secs = 32
+ *     peer_conn_max_missed_heartbeats = 5
+ *     peer_conn_pong_timeout_secs = 2
  * """.trimIndent()
  *
  * EasyTierJNI.runNetworkInstance(config)

--- a/easytier-contrib/easytier-ffi/examples/go/README.md
+++ b/easytier-contrib/easytier-ffi/examples/go/README.md
@@ -37,6 +37,9 @@ network_secret = "mysecret"
 [flags]
 no_tun = true # disable tun device to avoid permission issues.
 bind_device = false # allow loopback peers in local examples.
+peer_conn_max_heartbeat_interval_secs = 32
+peer_conn_max_missed_heartbeats = 5
+peer_conn_pong_timeout_secs = 2
 
 [[peer]]
 uri = "tcp://123.123.123.123:11010"
@@ -66,6 +69,9 @@ network_secret = "mysecret"
 [flags]
 no_tun = true
 bind_device = false
+peer_conn_max_heartbeat_interval_secs = 32
+peer_conn_max_missed_heartbeats = 5
+peer_conn_pong_timeout_secs = 2
 
 [[peer]]
 uri = "tcp://123.123.123.123:11010"

--- a/easytier-contrib/easytier-ffi/examples/go/easytier_async_test.go
+++ b/easytier-contrib/easytier-ffi/examples/go/easytier_async_test.go
@@ -126,6 +126,9 @@ network_secret = %s
 [flags]
 no_tun = true
 bind_device = false
+peer_conn_max_heartbeat_interval_secs = 32
+peer_conn_max_missed_heartbeats = 5
+peer_conn_pong_timeout_secs = 2
 `,
 		strconv.Quote(instance),
 		strconv.Quote(ipv4),

--- a/easytier-contrib/easytier-magisk/config/config.toml
+++ b/easytier-contrib/easytier-magisk/config/config.toml
@@ -34,5 +34,7 @@ disable_p2p = false
 relay_all_peer_rpc = false
 disable_udp_hole_punching = false
 disable_tcp_hole_punching = false
-
+peer_conn_max_heartbeat_interval_secs = 32
+peer_conn_max_missed_heartbeats = 5
+peer_conn_pong_timeout_secs = 2
 

--- a/easytier-web/frontend-lib/src/components/Config.vue
+++ b/easytier-web/frontend-lib/src/components/Config.vue
@@ -242,6 +242,49 @@ watch(() => curNetwork.value, syncNormalizedNetwork, { immediate: true, deep: fa
               </div>
 
               <div class="flex flex-row gap-x-9 flex-wrap">
+                <div class="flex flex-col gap-2 basis-3/12 grow">
+                  <div class="flex">
+                    <label for="peer_conn_max_heartbeat_interval_secs">
+                      {{ t('peer_conn_max_heartbeat_interval_secs') }}
+                    </label>
+                    <span class="pi pi-question-circle ml-2 self-center"
+                      v-tooltip="t('peer_conn_max_heartbeat_interval_secs_help')"></span>
+                  </div>
+                  <InputNumber id="peer_conn_max_heartbeat_interval_secs"
+                    v-model="curNetwork.peer_conn_max_heartbeat_interval_secs"
+                    aria-describedby="peer_conn_max_heartbeat_interval_secs-help" :format="false" :allow-empty="false"
+                    :min="0" fluid />
+                </div>
+
+                <div class="flex flex-col gap-2 basis-3/12 grow">
+                  <div class="flex">
+                    <label for="peer_conn_max_missed_heartbeats">
+                      {{ t('peer_conn_max_missed_heartbeats') }}
+                    </label>
+                    <span class="pi pi-question-circle ml-2 self-center"
+                      v-tooltip="t('peer_conn_max_missed_heartbeats_help')"></span>
+                  </div>
+                  <InputNumber id="peer_conn_max_missed_heartbeats"
+                    v-model="curNetwork.peer_conn_max_missed_heartbeats"
+                    aria-describedby="peer_conn_max_missed_heartbeats-help" :format="false" :allow-empty="false"
+                    :min="0" fluid />
+                </div>
+
+                <div class="flex flex-col gap-2 basis-3/12 grow">
+                  <div class="flex">
+                    <label for="peer_conn_pong_timeout_secs">
+                      {{ t('peer_conn_pong_timeout_secs') }}
+                    </label>
+                    <span class="pi pi-question-circle ml-2 self-center"
+                      v-tooltip="t('peer_conn_pong_timeout_secs_help')"></span>
+                  </div>
+                  <InputNumber id="peer_conn_pong_timeout_secs" v-model="curNetwork.peer_conn_pong_timeout_secs"
+                    aria-describedby="peer_conn_pong_timeout_secs-help" :format="false" :allow-empty="false" :min="0"
+                    fluid />
+                </div>
+              </div>
+
+              <div class="flex flex-row gap-x-9 flex-wrap">
                 <div class="flex flex-col gap-2 basis-5/12 grow">
                   <label for="hostname">{{ t('hostname') }}</label>
                   <InputText id="hostname" v-model="curNetwork.hostname" aria-describedby="hostname-help" :format="true"

--- a/easytier-web/frontend-lib/src/locales/cn.yaml
+++ b/easytier-web/frontend-lib/src/locales/cn.yaml
@@ -145,6 +145,15 @@ relay_all_peer_rpc_help: |
 need_p2p: 需要 P2P
 need_p2p_help: 即使其他节点启用了 lazy p2p，也要求它们主动与当前节点建立 P2P 连接。
 
+peer_conn_max_heartbeat_interval_secs: PeerConn 最大心跳间隔
+peer_conn_max_heartbeat_interval_secs_help: PeerConn 心跳退避后的最大间隔，单位秒。默认 32，填 0 表示使用默认值。
+
+peer_conn_max_missed_heartbeats: PeerConn 最大失败次数
+peer_conn_max_missed_heartbeats_help: 连续多少次未收到 Pong 后关闭 PeerConn。默认 5，填 0 表示使用默认值。
+
+peer_conn_pong_timeout_secs: PeerConn Pong 超时
+peer_conn_pong_timeout_secs_help: 单次等待 Pong 响应的超时时间，单位秒。默认 2，填 0 表示使用默认值。
+
 multi_thread: 启用多线程
 multi_thread_help: 使用多线程运行时
 

--- a/easytier-web/frontend-lib/src/locales/en.yaml
+++ b/easytier-web/frontend-lib/src/locales/en.yaml
@@ -144,6 +144,15 @@ relay_all_peer_rpc_help: |
 need_p2p: Need P2P
 need_p2p_help: Ask other peers to proactively establish P2P connections to this node even when they enable lazy P2P.
 
+peer_conn_max_heartbeat_interval_secs: PeerConn Max Heartbeat Interval
+peer_conn_max_heartbeat_interval_secs_help: Maximum PeerConn heartbeat interval after backoff, in seconds. Default is 32; 0 means default.
+
+peer_conn_max_missed_heartbeats: PeerConn Max Missed Heartbeats
+peer_conn_max_missed_heartbeats_help: Close a PeerConn after this many consecutive missing Pong responses. Default is 5; 0 means default.
+
+peer_conn_pong_timeout_secs: PeerConn Pong Timeout
+peer_conn_pong_timeout_secs_help: Single Pong response wait timeout, in seconds. Default is 2; 0 means default.
+
 multi_thread: Multi Thread
 multi_thread_help: Use multi-thread runtime
 

--- a/easytier-web/frontend-lib/src/types/network.ts
+++ b/easytier-web/frontend-lib/src/types/network.ts
@@ -128,6 +128,9 @@ export interface NetworkConfig {
   enable_exit_node?: boolean
   relay_all_peer_rpc?: boolean
   need_p2p?: boolean
+  peer_conn_max_heartbeat_interval_secs?: number
+  peer_conn_max_missed_heartbeats?: number
+  peer_conn_pong_timeout_secs?: number
   multi_thread?: boolean
   proxy_forward_by_system?: boolean
   disable_encryption?: boolean
@@ -206,6 +209,9 @@ export function DEFAULT_NETWORK_CONFIG(): NetworkConfig {
     enable_exit_node: false,
     relay_all_peer_rpc: false,
     need_p2p: false,
+    peer_conn_max_heartbeat_interval_secs: 32,
+    peer_conn_max_missed_heartbeats: 5,
+    peer_conn_pong_timeout_secs: 2,
     multi_thread: true,
     proxy_forward_by_system: false,
     disable_encryption: false,
@@ -247,6 +253,9 @@ export function normalizeNetworkConfig(config: NetworkConfig): NetworkConfig {
   const normalized: NetworkConfig = {
     ...config,
     peer_urls: cleanPeerUrls(config.peer_urls),
+    peer_conn_max_heartbeat_interval_secs: config.peer_conn_max_heartbeat_interval_secs ?? 32,
+    peer_conn_max_missed_heartbeats: config.peer_conn_max_missed_heartbeats ?? 5,
+    peer_conn_pong_timeout_secs: config.peer_conn_pong_timeout_secs ?? 2,
   }
 
   const publicServerUrl = normalized.public_server_url?.trim() ?? ''

--- a/easytier/locales/app.yml
+++ b/easytier/locales/app.yml
@@ -172,6 +172,15 @@ core_clap:
   need_p2p:
     en: "announce that other peers should proactively establish p2p connections to this node even when they enable lazy-p2p"
     zh-CN: "声明即使其他节点启用了 lazy-p2p，也应主动与当前节点建立P2P连接"
+  peer_conn_max_heartbeat_interval_secs:
+    en: "maximum PeerConn heartbeat interval in seconds. default is 32; 0 means default"
+    zh-CN: "PeerConn 最大心跳间隔，单位秒。默认 32；0 表示使用默认值"
+  peer_conn_max_missed_heartbeats:
+    en: "close a PeerConn after this many consecutive missed Pong responses. default is 5; 0 means default"
+    zh-CN: "连续丢失多少次 Pong 后关闭 PeerConn。默认 5；0 表示使用默认值"
+  peer_conn_pong_timeout_secs:
+    en: "single Pong wait timeout in seconds. default is 2; 0 means default"
+    zh-CN: "单次等待 Pong 的超时时间，单位秒。默认 2；0 表示使用默认值"
   disable_tcp_hole_punching:
     en: "disable tcp hole punching"
     zh-CN: "禁用TCP打洞功能"

--- a/easytier/src/common/config.rs
+++ b/easytier/src/common/config.rs
@@ -74,6 +74,9 @@ pub fn gen_default_flags() -> Flags {
         disable_relay_data: false,
         enable_udp_broadcast_relay: false,
         socket_mark: None,
+        peer_conn_max_heartbeat_interval_secs: 32,
+        peer_conn_max_missed_heartbeats: 5,
+        peer_conn_pong_timeout_secs: 2,
     }
 }
 

--- a/easytier/src/core.rs
+++ b/easytier/src/core.rs
@@ -511,6 +511,27 @@ struct NetworkOptions {
     )]
     need_p2p: Option<bool>,
 
+    #[arg(
+        long,
+        env = "ET_PEER_CONN_MAX_HEARTBEAT_INTERVAL_SECS",
+        help = t!("core_clap.peer_conn_max_heartbeat_interval_secs").to_string(),
+    )]
+    peer_conn_max_heartbeat_interval_secs: Option<u32>,
+
+    #[arg(
+        long,
+        env = "ET_PEER_CONN_MAX_MISSED_HEARTBEATS",
+        help = t!("core_clap.peer_conn_max_missed_heartbeats").to_string(),
+    )]
+    peer_conn_max_missed_heartbeats: Option<u32>,
+
+    #[arg(
+        long,
+        env = "ET_PEER_CONN_PONG_TIMEOUT_SECS",
+        help = t!("core_clap.peer_conn_pong_timeout_secs").to_string(),
+    )]
+    peer_conn_pong_timeout_secs: Option<u32>,
+
     #[cfg(feature = "socks5")]
     #[arg(
         long,
@@ -1127,6 +1148,15 @@ impl NetworkOptions {
             .unwrap_or(f.disable_udp_hole_punching);
         f.relay_all_peer_rpc = self.relay_all_peer_rpc.unwrap_or(f.relay_all_peer_rpc);
         f.need_p2p = self.need_p2p.unwrap_or(f.need_p2p);
+        f.peer_conn_max_heartbeat_interval_secs = self
+            .peer_conn_max_heartbeat_interval_secs
+            .unwrap_or(f.peer_conn_max_heartbeat_interval_secs);
+        f.peer_conn_max_missed_heartbeats = self
+            .peer_conn_max_missed_heartbeats
+            .unwrap_or(f.peer_conn_max_missed_heartbeats);
+        f.peer_conn_pong_timeout_secs = self
+            .peer_conn_pong_timeout_secs
+            .unwrap_or(f.peer_conn_pong_timeout_secs);
         f.multi_thread = self.multi_thread.unwrap_or(f.multi_thread);
         if let Some(compression) = &self.compression {
             f.data_compress_algo = match compression.as_str() {

--- a/easytier/src/launcher.rs
+++ b/easytier/src/launcher.rs
@@ -924,6 +924,20 @@ impl NetworkConfig {
             flags.need_p2p = need_p2p;
         }
 
+        if let Some(peer_conn_max_heartbeat_interval_secs) =
+            self.peer_conn_max_heartbeat_interval_secs
+        {
+            flags.peer_conn_max_heartbeat_interval_secs = peer_conn_max_heartbeat_interval_secs;
+        }
+
+        if let Some(peer_conn_max_missed_heartbeats) = self.peer_conn_max_missed_heartbeats {
+            flags.peer_conn_max_missed_heartbeats = peer_conn_max_missed_heartbeats;
+        }
+
+        if let Some(peer_conn_pong_timeout_secs) = self.peer_conn_pong_timeout_secs {
+            flags.peer_conn_pong_timeout_secs = peer_conn_pong_timeout_secs;
+        }
+
         if let Some(multi_thread) = self.multi_thread {
             flags.multi_thread = multi_thread;
         }
@@ -1133,6 +1147,10 @@ impl NetworkConfig {
         result.enable_exit_node = Some(flags.enable_exit_node);
         result.relay_all_peer_rpc = Some(flags.relay_all_peer_rpc);
         result.need_p2p = Some(flags.need_p2p);
+        result.peer_conn_max_heartbeat_interval_secs =
+            Some(flags.peer_conn_max_heartbeat_interval_secs);
+        result.peer_conn_max_missed_heartbeats = Some(flags.peer_conn_max_missed_heartbeats);
+        result.peer_conn_pong_timeout_secs = Some(flags.peer_conn_pong_timeout_secs);
         result.multi_thread = Some(flags.multi_thread);
         result.proxy_forward_by_system = Some(flags.proxy_forward_by_system);
         result.disable_encryption = Some(!flags.enable_encryption);
@@ -1403,6 +1421,9 @@ mod tests {
                 flags.enable_exit_node = rng.gen_bool(0.4);
                 flags.relay_all_peer_rpc = rng.gen_bool(0.5);
                 flags.need_p2p = rng.gen_bool(0.3);
+                flags.peer_conn_max_heartbeat_interval_secs = rng.gen_range(1..120);
+                flags.peer_conn_max_missed_heartbeats = rng.gen_range(1..10);
+                flags.peer_conn_pong_timeout_secs = rng.gen_range(1..10);
                 flags.multi_thread = rng.gen_bool(0.7);
                 flags.proxy_forward_by_system = rng.gen_bool(0.3);
                 flags.enable_encryption = rng.gen_bool(0.8);
@@ -1450,6 +1471,36 @@ mod tests {
                 serde_json::to_string(&network_config).unwrap()
             );
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_network_config_peer_conn_ping_flags() -> Result<(), anyhow::Error> {
+        let network_config = super::NetworkConfig {
+            networking_method: Some(super::NetworkingMethod::Standalone as i32),
+            peer_conn_max_heartbeat_interval_secs: Some(12),
+            peer_conn_max_missed_heartbeats: Some(3),
+            peer_conn_pong_timeout_secs: Some(1),
+            ..Default::default()
+        };
+
+        let generated_config = network_config.gen_config()?;
+        let flags = generated_config.get_flags();
+        assert_eq!(flags.peer_conn_max_heartbeat_interval_secs, 12);
+        assert_eq!(flags.peer_conn_max_missed_heartbeats, 3);
+        assert_eq!(flags.peer_conn_pong_timeout_secs, 1);
+
+        let parsed_network_config = super::NetworkConfig::new_from_config(&generated_config)?;
+        assert_eq!(
+            parsed_network_config.peer_conn_max_heartbeat_interval_secs,
+            Some(12)
+        );
+        assert_eq!(
+            parsed_network_config.peer_conn_max_missed_heartbeats,
+            Some(3)
+        );
+        assert_eq!(parsed_network_config.peer_conn_pong_timeout_secs, Some(1));
 
         Ok(())
     }

--- a/easytier/src/peers/peer_conn.rs
+++ b/easytier/src/peers/peer_conn.rs
@@ -29,7 +29,7 @@ use snow::{HandshakeState, params::NoiseParams};
 
 use super::{
     PacketRecvChan,
-    peer_conn_ping::PeerConnPinger,
+    peer_conn_ping::{PeerConnPingConfig, PeerConnPinger},
     peer_session::{PeerSession, PeerSessionAction},
     traffic_metrics::AggregateTrafficMetrics,
 };
@@ -1437,6 +1437,12 @@ impl PeerConn {
     }
 
     pub fn start_pingpong(&mut self) {
+        let flags = self.global_ctx.get_flags();
+        let ping_config = PeerConnPingConfig::new(
+            flags.peer_conn_max_heartbeat_interval_secs,
+            flags.peer_conn_max_missed_heartbeats,
+            flags.peer_conn_pong_timeout_secs,
+        );
         let mut pingpong = PeerConnPinger::new(
             self.my_peer_id,
             self.get_peer_id(),
@@ -1446,6 +1452,7 @@ impl PeerConn {
             self.loss_rate_stats.clone(),
             self.throughput.clone(),
             self.control_metrics(&self.get_conn_info().network_name),
+            ping_config,
         );
 
         let close_event_notifier = self.close_event_notifier.clone();

--- a/easytier/src/peers/peer_conn_ping.rs
+++ b/easytier/src/peers/peer_conn_ping.rs
@@ -25,6 +25,47 @@ use crate::{
     },
 };
 
+const DEFAULT_MAX_HEARTBEAT_INTERVAL_SECS: u64 = 32;
+const DEFAULT_MAX_MISSED_HEARTBEATS: u32 = 5;
+const DEFAULT_PONG_TIMEOUT_SECS: u64 = 2;
+
+#[derive(Clone, Copy, Debug)]
+pub struct PeerConnPingConfig {
+    pub max_heartbeat_interval: Duration,
+    pub max_missed_heartbeats: u32,
+    pub pong_timeout: Duration,
+}
+
+impl PeerConnPingConfig {
+    pub fn new(
+        max_heartbeat_interval_secs: u32,
+        max_missed_heartbeats: u32,
+        pong_timeout_secs: u32,
+    ) -> Self {
+        let max_heartbeat_interval_secs = if max_heartbeat_interval_secs == 0 {
+            DEFAULT_MAX_HEARTBEAT_INTERVAL_SECS
+        } else {
+            u64::from(max_heartbeat_interval_secs)
+        };
+        let max_missed_heartbeats = if max_missed_heartbeats == 0 {
+            DEFAULT_MAX_MISSED_HEARTBEATS
+        } else {
+            max_missed_heartbeats
+        };
+        let pong_timeout_secs = if pong_timeout_secs == 0 {
+            DEFAULT_PONG_TIMEOUT_SECS
+        } else {
+            u64::from(pong_timeout_secs)
+        };
+
+        Self {
+            max_heartbeat_interval: Duration::from_secs(max_heartbeat_interval_secs.max(1)),
+            max_missed_heartbeats: max_missed_heartbeats.max(1),
+            pong_timeout: Duration::from_secs(pong_timeout_secs.max(1)),
+        }
+    }
+}
+
 struct PingIntervalController {
     throughput: Arc<Throughput>,
     loss_counter: Arc<AtomicU32>,
@@ -35,7 +76,7 @@ struct PingIntervalController {
     last_send_logic_time: u64,
 
     backoff_idx: i32,
-    max_backoff_idx: i32,
+    max_heartbeat_interval_secs: u64,
 
     last_throughput: Throughput,
 }
@@ -48,14 +89,21 @@ impl std::fmt::Debug for PingIntervalController {
             .field("logic_time", &self.logic_time)
             .field("last_send_logic_time", &self.last_send_logic_time)
             .field("backoff_idx", &self.backoff_idx)
-            .field("max_backoff_idx", &self.max_backoff_idx)
+            .field(
+                "max_heartbeat_interval_secs",
+                &self.max_heartbeat_interval_secs,
+            )
             .field("last_throughput", &self.last_throughput)
             .finish()
     }
 }
 
 impl PingIntervalController {
-    fn new(throughput: Arc<Throughput>, loss_counter: Arc<AtomicU32>) -> Self {
+    fn new(
+        throughput: Arc<Throughput>,
+        loss_counter: Arc<AtomicU32>,
+        config: PeerConnPingConfig,
+    ) -> Self {
         let last_throughput = (*throughput).clone();
 
         Self {
@@ -66,7 +114,7 @@ impl PingIntervalController {
             last_send_logic_time: 0,
 
             backoff_idx: 0,
-            max_backoff_idx: 5,
+            max_heartbeat_interval_secs: config.max_heartbeat_interval.as_secs().max(1),
 
             last_throughput,
         }
@@ -95,14 +143,23 @@ impl PingIntervalController {
 
         self.last_throughput = (*self.throughput).clone();
 
-        if (self.logic_time - self.last_send_logic_time) < (1 << self.backoff_idx) {
+        let cur_interval_secs = 1u64
+            .checked_shl(self.backoff_idx.max(0) as u32)
+            .unwrap_or(u64::MAX)
+            .min(self.max_heartbeat_interval_secs);
+        if (self.logic_time - self.last_send_logic_time) < cur_interval_secs {
             return false;
         }
 
-        self.backoff_idx = std::cmp::min(self.backoff_idx + 1, self.max_backoff_idx);
+        if cur_interval_secs < self.max_heartbeat_interval_secs {
+            self.backoff_idx += 1;
+        }
 
         // use this makes two peers not pingpong at the same time
-        if self.backoff_idx > self.max_backoff_idx - 2 && thread_rng().gen_bool(0.2) {
+        if cur_interval_secs >= self.max_heartbeat_interval_secs / 4
+            && self.backoff_idx > 0
+            && thread_rng().gen_bool(0.2)
+        {
             self.backoff_idx -= 1;
         }
 
@@ -120,6 +177,7 @@ pub struct PeerConnPinger {
     loss_rate_stats: Arc<AtomicU32>,
     throughput_stats: Arc<Throughput>,
     control_metrics: AggregateTrafficMetrics,
+    config: PeerConnPingConfig,
     tasks: JoinSet<Result<(), TunnelError>>,
 }
 
@@ -143,6 +201,7 @@ impl PeerConnPinger {
         loss_rate_stats: Arc<AtomicU32>,
         throughput_stats: Arc<Throughput>,
         control_metrics: AggregateTrafficMetrics,
+        config: PeerConnPingConfig,
     ) -> Self {
         Self {
             my_peer_id,
@@ -154,6 +213,7 @@ impl PeerConnPinger {
             loss_rate_stats,
             throughput_stats,
             control_metrics,
+            config,
         }
     }
 
@@ -170,6 +230,7 @@ impl PeerConnPinger {
         control_metrics: &AggregateTrafficMetrics,
         receiver: &mut broadcast::Receiver<ZCPacket>,
         seq: u32,
+        pong_timeout: Duration,
     ) -> Result<u128, Error> {
         // should add seq here. so latency can be calculated more accurately
         let req = Self::new_ping_packet(my_node_id, peer_id, seq);
@@ -179,7 +240,7 @@ impl PeerConnPinger {
 
         let now = std::time::Instant::now();
         // wait until we get a pong packet in ctrl_resp_receiver
-        let resp = timeout(Duration::from_secs(2), async {
+        let resp = timeout(pong_timeout, async {
             loop {
                 match receiver.recv().await {
                     Ok(p) => {
@@ -231,17 +292,21 @@ impl PeerConnPinger {
 
         // one with 1% precision
         let loss_rate_stats_1 = WindowLatency::new(100);
-        // disconnect the connection if lost 5 pingpong consecutively
+        // disconnect the connection if configured pingpong attempts are lost consecutively
         let loss_counter = Arc::new(AtomicU32::new(0));
 
         let stopped = Arc::new(AtomicU32::new(0));
 
-        // generate a pingpong task every 200ms
+        // the controller checks whether to generate a pingpong task once per second
         let mut pingpong_tasks = JoinSet::new();
         let ctrl_resp_sender = self.ctrl_sender.clone();
         let stopped_clone = stopped.clone();
-        let mut controller =
-            PingIntervalController::new(self.throughput_stats.clone(), loss_counter.clone());
+        let config = self.config;
+        let mut controller = PingIntervalController::new(
+            self.throughput_stats.clone(),
+            loss_counter.clone(),
+            config,
+        );
         self.tasks.spawn(
             async move {
                 let mut req_seq = 0;
@@ -280,6 +345,7 @@ impl PeerConnPinger {
                             &control_metrics,
                             &mut receiver,
                             req_seq,
+                            config.pong_timeout,
                         )
                         .await;
 
@@ -323,7 +389,8 @@ impl PeerConnPinger {
             let current_rx_packets = throughput.rx_packets();
             if last_rx_packets != current_rx_packets {
                 // if we receive some packet from peers, reset the counter to avoid conn close.
-                // conn will close only if we have 5 continous round pingpong loss after no packet received.
+                // conn will close only if configured pingpong attempts are lost consecutively
+                // after no packet received.
                 loss_counter.store(0, Ordering::Relaxed);
             }
 
@@ -336,7 +403,7 @@ impl PeerConnPinger {
                 my_node_id
             );
 
-            if loss_counter.load(Ordering::Relaxed) >= 5 {
+            if loss_counter.load(Ordering::Relaxed) >= self.config.max_missed_heartbeats {
                 tracing::warn!(
                     ?ret,
                     ?self,

--- a/easytier/src/proto/api_manage.proto
+++ b/easytier/src/proto/api_manage.proto
@@ -102,6 +102,9 @@ message NetworkConfig {
   optional bool disable_relay_data = 65;
   optional bool enable_udp_broadcast_relay = 66;
   optional uint32 socket_mark = 67;
+  optional uint32 peer_conn_max_heartbeat_interval_secs = 68;
+  optional uint32 peer_conn_max_missed_heartbeats = 69;
+  optional uint32 peer_conn_pong_timeout_secs = 70;
 }
 
 message PortForwardConfig {

--- a/easytier/src/proto/common.proto
+++ b/easytier/src/proto/common.proto
@@ -84,6 +84,13 @@ message FlagsInConfig {
   // applied via setsockopt. Requires CAP_NET_ADMIN; silently ignored on
   // non-Linux platforms.
   optional uint32 socket_mark = 43;
+
+  // PeerConn heartbeat maximum interval in seconds. 0 means default.
+  uint32 peer_conn_max_heartbeat_interval_secs = 44;
+  // Close a PeerConn after this many consecutive missed Pong responses. 0 means default.
+  uint32 peer_conn_max_missed_heartbeats = 45;
+  // Single Pong wait timeout in seconds. 0 means default.
+  uint32 peer_conn_pong_timeout_secs = 46;
 }
 
 message RpcDescriptor {

--- a/script/install.sh
+++ b/script/install.sh
@@ -273,6 +273,9 @@ p2p_only = false
 relay_all_peer_rpc = false
 disable_tcp_hole_punching = false
 disable_udp_hole_punching = false
+peer_conn_max_heartbeat_interval_secs = 32
+peer_conn_max_missed_heartbeats = 5
+peer_conn_pong_timeout_secs = 2
 
 EOF
 


### PR DESCRIPTION
在网络环境变化后，由于 PeerConn 间隔过长，之前的连接一直没有失效，导致设备短时间内无法通过 EasyTier 正常连接，且用户无法通过配置调节相关参数。

原先 PeerConn 心跳的最大心跳间隔、连续 Pong 失败关闭阈值、单次 Pong 等待超时是写死的。本 PR 将 PeerConn 心跳相关参数改为可配置项。

新增配置项：

```toml
[flags]
peer_conn_max_heartbeat_interval_secs = 32
peer_conn_max_missed_heartbeats = 5
peer_conn_pong_timeout_secs = 2
```

调小后会更激进地探测并删除无效的连接