### PR TITLE
TCP打洞策略修改

### DIFF
--- a/easytier/src/common/global_ctx.rs
+++ b/easytier/src/common/global_ctx.rs
@@ -71,6 +71,9 @@ pub enum GlobalCtxEvent {
     PublicIpv6Changed(Option<cidr::Ipv6Inet>, Option<cidr::Ipv6Inet>), // (old, new)
     PublicIpv6RoutesUpdated(Vec<cidr::Ipv6Inet>, Vec<cidr::Ipv6Inet>), // (added, removed)
 
+    // TCP NAT type detection completed, can trigger TCP hole punch
+    TcpNatTypeDetected,
+
     PortForwardAdded(PortForwardConfigPb),
 
     ConfigPatched(InstanceConfigPatch),

--- a/easytier/src/common/global_ctx.rs
+++ b/easytier/src/common/global_ctx.rs
@@ -355,6 +355,18 @@ impl GlobalCtx {
         }
     }
 
+    /// Call this after wrapping GlobalCtx in Arc to enable UPnP during NAT detection
+    pub fn set_global_ctx_after_init(self: &Arc<Self>) {
+        let collector = self.stun_info_collection.lock().unwrap().clone();
+        // Downcast to StunInfoCollector to call set_global_ctx
+        if let Some(collector) = collector.as_any().downcast_ref::<StunInfoCollector>() {
+            collector.set_global_ctx(self.clone());
+            tracing::info!("set global context for stun info collector to enable UPnP during NAT detection");
+        } else {
+            tracing::warn!("cannot set global context: stun info collector is not StunInfoCollector");
+        }
+    }
+
     pub fn subscribe(&self) -> EventBusSubscriber {
         self.event_bus.subscribe()
     }

--- a/easytier/src/common/stun.rs
+++ b/easytier/src/common/stun.rs
@@ -23,7 +23,24 @@ use stun_codec::{Message, MessageClass, MessageDecoder, MessageEncoder};
 use crate::common::error::Error;
 
 use super::dns::resolve_txt_record;
+use super::global_ctx::ArcGlobalCtx;
 use super::stun_codec_ext::*;
+
+/// Find the bind address of the physical network interface.
+/// This helps avoid using virtual network interfaces (like those created by EasyTier).
+fn find_physical_bind_addr() -> Option<IpAddr> {
+    // Connect to a common external address to determine the physical interface
+    let sock = std::net::UdpSocket::bind("0.0.0.0:0").ok()?;
+    sock.connect("8.8.8.8:53").ok()?;
+    let local_addr = sock.local_addr().ok()?;
+
+    // Skip loopback addresses
+    if local_addr.ip().is_loopback() {
+        return None;
+    }
+
+    Some(local_addr.ip())
+}
 
 const DEFAULT_UDP_STUN_SERVERS: &[&str] = &[
     "txt:stun.easytier.cn",
@@ -766,14 +783,19 @@ impl TcpStunClient {
     }
 
     async fn connect(&self) -> Result<tokio::net::TcpStream, Error> {
+        // Try to bind to the physical interface address to avoid virtual network interfaces
+        let physical_ip = find_physical_bind_addr();
         let bind_addr = match self.stun_server {
             SocketAddr::V4(_) => {
-                SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), self.source_port)
+                let ip = physical_ip.unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+                SocketAddr::new(ip, self.source_port)
             }
             SocketAddr::V6(_) => {
                 SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), self.source_port)
             }
         };
+
+        tracing::debug!(?bind_addr, ?physical_ip, "tcp stun client binding to addr");
 
         let socket2_socket = socket2::Socket::new(
             socket2::Domain::for_address(self.stun_server),
@@ -862,6 +884,15 @@ impl TcpNatTypeDetector {
         &self,
         source_port: u16,
     ) -> Result<StunNatTypeDetectResult, Error> {
+        self.detect_nat_type_with_upnp(source_port, None).await
+    }
+
+    #[tracing::instrument(skip(self, global_ctx))]
+    pub async fn detect_nat_type_with_upnp(
+        &self,
+        source_port: u16,
+        global_ctx: Option<ArcGlobalCtx>,
+    ) -> Result<StunNatTypeDetectResult, Error> {
         let mut stun_servers = vec![];
         let mut host_resolver = HostResolverIter::new(
             self.stun_server_hosts.clone(),
@@ -879,6 +910,31 @@ impl TcpNatTypeDetector {
         } else {
             Some(source_port)
         };
+
+        // Create UPnP mapping for the port before NAT detection
+        // This prevents router firewall from blocking TCP connections
+        // If source_port is 0, we'll create the mapping after the first STUN request
+        let mut _port_mapping_lease = if let Some(ref ctx) = global_ctx {
+            let port = selected_source_port.unwrap_or(0);
+            if port != 0 {
+                let listener_url = format!("tcp://0.0.0.0:{}", port).parse().unwrap();
+                match crate::common::upnp::resolve_tcp_public_addr(ctx.clone(), &listener_url, port).await {
+                    Ok((_mapped_addr, lease)) => {
+                        tracing::info!(?port, "tcp nat detection: upnp mapping created");
+                        lease
+                    }
+                    Err(e) => {
+                        tracing::debug!(?e, ?port, "tcp nat detection: upnp mapping failed, continuing without");
+                        None
+                    }
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         for server in stun_servers.iter() {
             let resp = TcpStunClient::new(*server, selected_source_port.unwrap_or(0))
                 .bind_request()
@@ -886,6 +942,21 @@ impl TcpNatTypeDetector {
             if let Ok(resp) = resp {
                 if selected_source_port.is_none() {
                     selected_source_port = Some(resp.local_addr.port());
+
+                    // Create UPnP mapping now that we have a port
+                    if let Some(ref ctx) = global_ctx {
+                        let port = resp.local_addr.port();
+                        let listener_url = format!("tcp://0.0.0.0:{}", port).parse().unwrap();
+                        match crate::common::upnp::resolve_tcp_public_addr(ctx.clone(), &listener_url, port).await {
+                            Ok((_mapped_addr, lease)) => {
+                                tracing::info!(?port, "tcp nat detection: upnp mapping created after first STUN");
+                                _port_mapping_lease = lease;
+                            }
+                            Err(e) => {
+                                tracing::debug!(?e, ?port, "tcp nat detection: upnp mapping failed, continuing without");
+                            }
+                        }
+                    }
                 }
                 source_addr.get_or_insert(resp.local_addr);
                 bind_resps.push(resp);
@@ -916,6 +987,7 @@ pub trait StunInfoCollectorTrait: Send + Sync {
         udp: Arc<UdpSocket>,
     ) -> Result<SocketAddr, Error>;
     async fn get_tcp_port_mapping(&self, local_port: u16) -> Result<SocketAddr, Error>;
+    fn as_any(&self) -> &dyn std::any::Any;
 }
 
 pub struct StunInfoCollector {
@@ -929,6 +1001,8 @@ pub struct StunInfoCollector {
     redetect_notify: Arc<tokio::sync::Notify>,
     tasks: std::sync::Mutex<JoinSet<()>>,
     started: AtomicBool,
+    // Optional global context for UPnP support during NAT detection
+    global_ctx: Arc<std::sync::Mutex<Option<ArcGlobalCtx>>>,
 }
 
 #[async_trait::async_trait]
@@ -1071,6 +1145,10 @@ impl StunInfoCollectorTrait for StunInfoCollector {
 
         Err(Error::NotFound)
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 impl StunInfoCollector {
@@ -1090,6 +1168,7 @@ impl StunInfoCollector {
             redetect_notify: Arc::new(tokio::sync::Notify::new()),
             tasks: std::sync::Mutex::new(JoinSet::new()),
             started: AtomicBool::new(false),
+            global_ctx: Arc::new(std::sync::Mutex::new(None)),
         }
     }
 
@@ -1114,6 +1193,11 @@ impl StunInfoCollector {
     pub fn set_tcp_stun_servers(&self, stun_servers: Vec<String>) {
         let mut g = self.tcp_stun_servers.write().unwrap();
         *g = stun_servers;
+    }
+
+    pub fn set_global_ctx(&self, global_ctx: ArcGlobalCtx) {
+        let mut g = self.global_ctx.lock().unwrap();
+        *g = Some(global_ctx);
     }
 
     pub fn get_default_servers() -> Vec<String> {
@@ -1242,6 +1326,7 @@ impl StunInfoCollector {
         let tcp_nat_test_result = self.tcp_nat_test_result.clone();
         let nat_test_time = self.nat_test_result_time.clone();
         let redetect_notify = self.redetect_notify.clone();
+        let global_ctx = self.global_ctx.clone();
         self.tasks.lock().unwrap().spawn(async move {
             loop {
                 let tcp_servers = tcp_stun_servers.read().unwrap().clone();
@@ -1253,7 +1338,9 @@ impl StunInfoCollector {
                     .collect();
 
                 let tcp_detector = TcpNatTypeDetector::new(tcp_servers, 1);
-                let tcp_ret = tcp_detector.detect_nat_type(0).await;
+                // Use UPnP during NAT detection to bypass router firewall
+                let ctx = global_ctx.lock().unwrap().clone();
+                let tcp_ret = tcp_detector.detect_nat_type_with_upnp(0, ctx).await;
                 tracing::debug!(?tcp_ret, "finish tcp nat type detect");
 
                 let mut sleep_sec = 10;
@@ -1338,6 +1425,10 @@ impl StunInfoCollectorTrait for MockStunInfoCollector {
             port = 40144;
         }
         Ok(format!("127.0.0.1:{}", port).parse().unwrap())
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 

--- a/easytier/src/common/stun.rs
+++ b/easytier/src/common/stun.rs
@@ -23,23 +23,23 @@ use stun_codec::{Message, MessageClass, MessageDecoder, MessageEncoder};
 use crate::common::error::Error;
 
 use super::dns::resolve_txt_record;
-use super::global_ctx::ArcGlobalCtx;
+use super::global_ctx::{ArcGlobalCtx, GlobalCtxEvent};
 use super::stun_codec_ext::*;
 
-/// Find the bind address of the physical network interface.
-/// This helps avoid using virtual network interfaces (like those created by EasyTier).
-fn find_physical_bind_addr() -> Option<IpAddr> {
-    // Connect to a common external address to determine the physical interface
+/// Get the local IPv4 address of the physical network interface.
+/// Connects to 8.8.8.8 to determine the correct interface (same method as EasyTier's local_ipv4).
+fn get_physical_ipv4() -> Option<IpAddr> {
     let sock = std::net::UdpSocket::bind("0.0.0.0:0").ok()?;
-    sock.connect("8.8.8.8:53").ok()?;
+    sock.connect("8.8.8.8:80").ok()?;
     let local_addr = sock.local_addr().ok()?;
 
-    // Skip loopback addresses
-    if local_addr.ip().is_loopback() {
-        return None;
+    match local_addr.ip() {
+        std::net::IpAddr::V4(ip) if !ip.is_loopback() && !ip.is_unspecified() => {
+            tracing::info!(?ip, "stun: found physical interface ipv4 addr");
+            Some(IpAddr::V4(ip))
+        }
+        _ => None,
     }
-
-    Some(local_addr.ip())
 }
 
 const DEFAULT_UDP_STUN_SERVERS: &[&str] = &[
@@ -784,7 +784,7 @@ impl TcpStunClient {
 
     async fn connect(&self) -> Result<tokio::net::TcpStream, Error> {
         // Try to bind to the physical interface address to avoid virtual network interfaces
-        let physical_ip = find_physical_bind_addr();
+        let physical_ip = get_physical_ipv4();
         let bind_addr = match self.stun_server {
             SocketAddr::V4(_) => {
                 let ip = physical_ip.unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
@@ -795,7 +795,7 @@ impl TcpStunClient {
             }
         };
 
-        tracing::debug!(?bind_addr, ?physical_ip, "tcp stun client binding to addr");
+        tracing::info!(?bind_addr, ?physical_ip, "tcp stun client binding to addr");
 
         let socket2_socket = socket2::Socket::new(
             socket2::Domain::for_address(self.stun_server),
@@ -924,7 +924,7 @@ impl TcpNatTypeDetector {
                         lease
                     }
                     Err(e) => {
-                        tracing::debug!(?e, ?port, "tcp nat detection: upnp mapping failed, continuing without");
+                        tracing::info!(?e, ?port, "tcp nat detection: upnp mapping failed, continuing without");
                         None
                     }
                 }
@@ -953,7 +953,7 @@ impl TcpNatTypeDetector {
                                 _port_mapping_lease = lease;
                             }
                             Err(e) => {
-                                tracing::debug!(?e, ?port, "tcp nat detection: upnp mapping failed, continuing without");
+                                tracing::info!(?e, ?port, "tcp nat detection: upnp mapping failed, continuing without");
                             }
                         }
                     }
@@ -987,6 +987,8 @@ pub trait StunInfoCollectorTrait: Send + Sync {
         udp: Arc<UdpSocket>,
     ) -> Result<SocketAddr, Error>;
     async fn get_tcp_port_mapping(&self, local_port: u16) -> Result<SocketAddr, Error>;
+    /// Get the TCP port mapping from NAT detection phase (the first UPnP mapping created)
+    fn get_nat_detection_tcp_port(&self) -> Option<u16>;
     fn as_any(&self) -> &dyn std::any::Any;
 }
 
@@ -1144,6 +1146,12 @@ impl StunInfoCollectorTrait for StunInfoCollector {
         }
 
         Err(Error::NotFound)
+    }
+
+    /// Get the TCP port from NAT detection phase (the first UPnP mapping created)
+    fn get_nat_detection_tcp_port(&self) -> Option<u16> {
+        let tcp_result = self.tcp_nat_test_result.read().unwrap();
+        tcp_result.as_ref().map(|r| r.source_addr.port())
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -1341,13 +1349,30 @@ impl StunInfoCollector {
                 // Use UPnP during NAT detection to bypass router firewall
                 let ctx = global_ctx.lock().unwrap().clone();
                 let tcp_ret = tcp_detector.detect_nat_type_with_upnp(0, ctx).await;
-                tracing::debug!(?tcp_ret, "finish tcp nat type detect");
+                tracing::info!(?tcp_ret, "finish tcp nat type detect");
 
                 let mut sleep_sec = 10;
                 if let Ok(resp) = &tcp_ret {
+                    let old_result = tcp_nat_test_result.read().unwrap().clone();
+                    let old_nat_type = old_result.as_ref().map(|r| r.nat_type()).unwrap_or(NatType::Unknown);
+                    let new_nat_type = resp.nat_type();
+
                     nat_test_time.store(Local::now());
                     *tcp_nat_test_result.write().unwrap() = Some(resp.clone());
-                    if resp.nat_type() != NatType::Unknown {
+
+                    // If NAT type changed from Unknown to a known type, notify TCP hole punch
+                    if old_nat_type == NatType::Unknown && new_nat_type != NatType::Unknown {
+                        tracing::info!(
+                            ?old_nat_type,
+                            ?new_nat_type,
+                            "TCP NAT type changed from Unknown, notifying TCP hole punch"
+                        );
+                        if let Some(ctx) = global_ctx.lock().unwrap().as_ref() {
+                            ctx.issue_event(GlobalCtxEvent::TcpNatTypeDetected);
+                        }
+                    }
+
+                    if new_nat_type != NatType::Unknown {
                         sleep_sec = 600;
                     }
                 }
@@ -1425,6 +1450,10 @@ impl StunInfoCollectorTrait for MockStunInfoCollector {
             port = 40144;
         }
         Ok(format!("127.0.0.1:{}", port).parse().unwrap())
+    }
+
+    fn get_nat_detection_tcp_port(&self) -> Option<u16> {
+        None
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/easytier/src/common/stun.rs
+++ b/easytier/src/common/stun.rs
@@ -35,7 +35,7 @@ fn get_physical_ipv4() -> Option<IpAddr> {
 
     match local_addr.ip() {
         std::net::IpAddr::V4(ip) if !ip.is_loopback() && !ip.is_unspecified() => {
-            tracing::info!(?ip, "stun: found physical interface ipv4 addr");
+            tracing::debug!(?ip, "stun: found physical interface ipv4 addr");
             Some(IpAddr::V4(ip))
         }
         _ => None,
@@ -795,7 +795,7 @@ impl TcpStunClient {
             }
         };
 
-        tracing::info!(?bind_addr, ?physical_ip, "tcp stun client binding to addr");
+        tracing::debug!(?bind_addr, ?physical_ip, "tcp stun client binding to addr");
 
         let socket2_socket = socket2::Socket::new(
             socket2::Domain::for_address(self.stun_server),
@@ -920,11 +920,11 @@ impl TcpNatTypeDetector {
                 let listener_url = format!("tcp://0.0.0.0:{}", port).parse().unwrap();
                 match crate::common::upnp::resolve_tcp_public_addr(ctx.clone(), &listener_url, port).await {
                     Ok((_mapped_addr, lease)) => {
-                        tracing::info!(?port, "tcp nat detection: upnp mapping created");
+                        tracing::debug!(?port, "tcp nat detection: upnp mapping created");
                         lease
                     }
                     Err(e) => {
-                        tracing::info!(?e, ?port, "tcp nat detection: upnp mapping failed, continuing without");
+                        tracing::debug!(?e, ?port, "tcp nat detection: upnp mapping failed, continuing without");
                         None
                     }
                 }
@@ -949,11 +949,11 @@ impl TcpNatTypeDetector {
                         let listener_url = format!("tcp://0.0.0.0:{}", port).parse().unwrap();
                         match crate::common::upnp::resolve_tcp_public_addr(ctx.clone(), &listener_url, port).await {
                             Ok((_mapped_addr, lease)) => {
-                                tracing::info!(?port, "tcp nat detection: upnp mapping created after first STUN");
+                                tracing::debug!(?port, "tcp nat detection: upnp mapping created after first STUN");
                                 _port_mapping_lease = lease;
                             }
                             Err(e) => {
-                                tracing::info!(?e, ?port, "tcp nat detection: upnp mapping failed, continuing without");
+                                tracing::debug!(?e, ?port, "tcp nat detection: upnp mapping failed, continuing without");
                             }
                         }
                     }
@@ -1349,7 +1349,7 @@ impl StunInfoCollector {
                 // Use UPnP during NAT detection to bypass router firewall
                 let ctx = global_ctx.lock().unwrap().clone();
                 let tcp_ret = tcp_detector.detect_nat_type_with_upnp(0, ctx).await;
-                tracing::info!(?tcp_ret, "finish tcp nat type detect");
+                tracing::debug!(?tcp_ret, "finish tcp nat type detect");
 
                 let mut sleep_sec = 10;
                 if let Ok(resp) = &tcp_ret {

--- a/easytier/src/common/upnp.rs
+++ b/easytier/src/common/upnp.rs
@@ -1426,7 +1426,7 @@ pub fn get_physical_ipv4_addr() -> Option<Ipv4Addr> {
 
     match local_addr.ip() {
         std::net::IpAddr::V4(ip) if !ip.is_loopback() && !ip.is_unspecified() => {
-            tracing::info!(?ip, "found physical interface ipv4 addr");
+            tracing::debug!(?ip, "found physical interface ipv4 addr");
             Some(ip)
         }
         _ => None,

--- a/easytier/src/common/upnp.rs
+++ b/easytier/src/common/upnp.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt,
-    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4},
     sync::Arc,
     time::Duration,
 };
@@ -1414,6 +1414,23 @@ pub fn find_physical_interface_bind_addr() -> Option<SocketAddr> {
 
     tracing::debug!(?local_addr, "found physical interface bind addr");
     Some(local_addr)
+}
+
+/// Get the local IPv4 address of the physical network interface.
+/// Uses EasyTier's existing `local_ipv4` function which connects to 8.8.8.8 to determine the correct interface.
+pub fn get_physical_ipv4_addr() -> Option<Ipv4Addr> {
+    // Use a blocking call to get the local IPv4 address
+    let socket = std::net::UdpSocket::bind("0.0.0.0:0").ok()?;
+    socket.connect("8.8.8.8:80").ok()?;
+    let local_addr = socket.local_addr().ok()?;
+
+    match local_addr.ip() {
+        std::net::IpAddr::V4(ip) if !ip.is_loopback() && !ip.is_unspecified() => {
+            tracing::info!(?ip, "found physical interface ipv4 addr");
+            Some(ip)
+        }
+        _ => None,
+    }
 }
 
 #[cfg(test)]

--- a/easytier/src/common/upnp.rs
+++ b/easytier/src/common/upnp.rs
@@ -108,7 +108,17 @@ impl ActiveUdpPortMapping {
         local_listener: &url::Url,
     ) -> anyhow::Result<(TokioGateway, SocketAddr)> {
         let _g = global_ctx.net_ns.guard();
+
+        // Try to find the correct bind address for the physical interface
+        // This avoids using virtual network interfaces created by EasyTier
+        let bind_addr = find_physical_interface_bind_addr().unwrap_or(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0)
+        );
+
+        tracing::debug!(?bind_addr, "searching igd gateway for udp");
+
         let gateway = search_gateway(SearchOptions {
+            bind_addr,
             timeout: Some(UPNP_SEARCH_TIMEOUT),
             single_search_timeout: Some(UPNP_SEARCH_RESPONSE_TIMEOUT),
             ..Default::default()
@@ -188,6 +198,139 @@ impl ActiveUdpPortMapping {
     }
 }
 
+struct ActiveTcpPortMapping {
+    backend: PortMappingBackend,
+    local_listener: url::Url,
+    local_addr: SocketAddr,
+    gateway_external_port: u16,
+}
+
+impl ActiveTcpPortMapping {
+    async fn discover_nat_pmp_gateway(
+        local_listener: &url::Url,
+    ) -> anyhow::Result<(Ipv4Addr, SocketAddr)> {
+        let client = new_tokio_natpmp().await.context("create nat-pmp client")?;
+        let gateway = *client.gateway();
+        let gateway_addr = SocketAddr::V4(SocketAddrV4::new(gateway, natpmp::NATPMP_PORT));
+        let local_addr = resolve_internal_addr(gateway_addr, local_listener).await?;
+        Ok((gateway, local_addr))
+    }
+
+    async fn establish_via_nat_pmp(
+        local_listener: &url::Url,
+        gateway: Ipv4Addr,
+        local_addr: SocketAddr,
+    ) -> anyhow::Result<Self> {
+        let gateway_external_port =
+            add_tcp_mapping_port_nat_pmp(gateway, local_addr, local_listener)
+                .await
+                .with_context(|| {
+                    format!("map tcp socket for {local_listener} via nat-pmp gateway {gateway}")
+                })?;
+
+        Ok(Self {
+            backend: PortMappingBackend::NatPmp { gateway },
+            local_listener: local_listener.clone(),
+            local_addr,
+            gateway_external_port,
+        })
+    }
+
+    async fn discover_igd_gateway(
+        global_ctx: &ArcGlobalCtx,
+        local_listener: &url::Url,
+    ) -> anyhow::Result<(TokioGateway, SocketAddr)> {
+        let _g = global_ctx.net_ns.guard();
+
+        // Try to find the correct bind address for the physical interface
+        // This avoids using virtual network interfaces created by EasyTier
+        let bind_addr = find_physical_interface_bind_addr().unwrap_or(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0)
+        );
+
+        tracing::debug!(?bind_addr, "searching igd gateway for tcp");
+
+        let gateway = search_gateway(SearchOptions {
+            bind_addr,
+            timeout: Some(UPNP_SEARCH_TIMEOUT),
+            single_search_timeout: Some(UPNP_SEARCH_RESPONSE_TIMEOUT),
+            ..Default::default()
+        })
+        .await
+        .with_context(|| format!("search igd gateway for {local_listener}"))?;
+        let local_addr = resolve_internal_addr(gateway.addr, local_listener).await?;
+
+        Ok((gateway, local_addr))
+    }
+
+    async fn establish_via_igd(
+        local_listener: &url::Url,
+        gateway: TokioGateway,
+        local_addr: SocketAddr,
+    ) -> anyhow::Result<Self> {
+        let gateway_external_port = add_tcp_mapping_port_igd(&gateway, local_addr, local_listener)
+            .await
+            .with_context(|| {
+                format!(
+                    "map tcp socket for {local_listener} via gateway {}",
+                    gateway.addr
+                )
+            })?;
+
+        Ok(Self {
+            backend: PortMappingBackend::Igd { gateway },
+            local_listener: local_listener.clone(),
+            local_addr,
+            gateway_external_port,
+        })
+    }
+
+    fn backend_name(&self) -> &'static str {
+        self.backend.name()
+    }
+
+    async fn renew(&self) -> anyhow::Result<()> {
+        match &self.backend {
+            PortMappingBackend::NatPmp { gateway } => {
+                renew_tcp_mapping_nat_pmp(
+                    *gateway,
+                    self.local_addr,
+                    self.gateway_external_port,
+                    &self.local_listener,
+                )
+                .await
+            }
+            PortMappingBackend::Igd { gateway } => {
+                renew_tcp_mapping_igd(
+                    gateway,
+                    self.local_addr,
+                    self.gateway_external_port,
+                    &self.local_listener,
+                )
+                .await
+            }
+        }
+    }
+
+    async fn remove(&self) -> anyhow::Result<()> {
+        match &self.backend {
+            PortMappingBackend::NatPmp { gateway } => {
+                remove_tcp_mapping_nat_pmp(
+                    *gateway,
+                    self.local_addr,
+                    self.gateway_external_port,
+                    &self.local_listener,
+                )
+                .await
+            }
+            PortMappingBackend::Igd { gateway } => {
+                remove_tcp_mapping_igd(gateway, self.gateway_external_port, &self.local_listener)
+                    .await
+            }
+        }
+    }
+}
+
 pub struct UdpPortMappingLease {
     backend: &'static str,
     gateway_external_port: u16,
@@ -214,6 +357,39 @@ impl fmt::Debug for UdpPortMappingLease {
 }
 
 impl Drop for UdpPortMappingLease {
+    fn drop(&mut self) {
+        if let Some(stop_tx) = self.stop_tx.take() {
+            let _ = stop_tx.send(());
+        }
+    }
+}
+
+pub struct TcpPortMappingLease {
+    backend: &'static str,
+    gateway_external_port: u16,
+    stop_tx: Option<oneshot::Sender<()>>,
+}
+
+impl TcpPortMappingLease {
+    pub fn backend(&self) -> &'static str {
+        self.backend
+    }
+
+    pub fn gateway_external_port(&self) -> u16 {
+        self.gateway_external_port
+    }
+}
+
+impl fmt::Debug for TcpPortMappingLease {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TcpPortMappingLease")
+            .field("backend", &self.backend)
+            .field("gateway_external_port", &self.gateway_external_port)
+            .finish()
+    }
+}
+
+impl Drop for TcpPortMappingLease {
     fn drop(&mut self) {
         if let Some(stop_tx) = self.stop_tx.take() {
             let _ = stop_tx.send(());
@@ -268,6 +444,130 @@ pub async fn resolve_udp_public_addr(
     }
 
     Ok((mapped_addr, port_mapping))
+}
+
+pub async fn resolve_tcp_public_addr(
+    global_ctx: ArcGlobalCtx,
+    local_listener: &url::Url,
+    local_port: u16,
+) -> anyhow::Result<(SocketAddr, Option<TcpPortMappingLease>)> {
+    // Add timeout to prevent hanging when UPnP is not available
+    let upnp_timeout = Duration::from_secs(3);
+
+    let port_mapping = match tokio::time::timeout(
+        upnp_timeout,
+        try_start_tcp_port_mapping(&global_ctx, local_listener),
+    )
+    .await
+    {
+        Ok(Ok(mapping)) => mapping,
+        Ok(Err(err)) => {
+            tracing::warn!(
+                ?err,
+                %local_listener,
+                "failed to establish tcp port mapping, fallback to stun-only"
+            );
+            None
+        }
+        Err(_) => {
+            tracing::warn!(
+                %local_listener,
+                "tcp port mapping timed out, UPnP may not be available, fallback to stun-only"
+            );
+            None
+        }
+    };
+
+    let mapped_addr = global_ctx
+        .get_stun_info_collector()
+        .get_tcp_port_mapping(local_port)
+        .await
+        .map_err(anyhow::Error::from)
+        .with_context(|| format!("resolve tcp public addr for {local_listener}"))?;
+
+    if let Some(port_mapping) = port_mapping.as_ref() {
+        let mapped_listener = build_url_from_socket_addr(&mapped_addr.to_string(), "tcp");
+        global_ctx.issue_event(GlobalCtxEvent::ListenerPortMappingEstablished {
+            local_listener: local_listener.clone(),
+            mapped_listener,
+            backend: port_mapping.backend().to_string(),
+        });
+        tracing::info!(
+            %local_listener,
+            backend = port_mapping.backend(),
+            gateway_external_port = port_mapping.gateway_external_port(),
+            stun_mapped_addr = %mapped_addr,
+            "tcp public addr resolved after port mapping"
+        );
+    } else {
+        tracing::debug!(
+            %local_listener,
+            stun_mapped_addr = %mapped_addr,
+            "tcp public addr resolved without port mapping"
+        );
+    }
+
+    Ok((mapped_addr, port_mapping))
+}
+
+async fn try_start_tcp_port_mapping(
+    global_ctx: &ArcGlobalCtx,
+    local_listener: &url::Url,
+) -> anyhow::Result<Option<TcpPortMappingLease>> {
+    if global_ctx.get_flags().disable_upnp || !should_map_tcp_listener(local_listener) {
+        return Ok(None);
+    }
+
+    let mapping = discover_tcp_port_mapping(global_ctx.clone(), local_listener.clone()).await?;
+    tracing::info!(
+        %local_listener,
+        backend = mapping.backend_name(),
+        local_addr = %mapping.local_addr,
+        gateway_external_port = mapping.gateway_external_port,
+        "tcp port mapping established"
+    );
+
+    let backend = mapping.backend_name();
+    let gateway_external_port = mapping.gateway_external_port;
+    let runtime_global_ctx = global_ctx.clone();
+    let runtime_local_listener = local_listener.clone();
+    let (stop_tx, stop_rx) = oneshot::channel();
+    if should_run_port_mapping_in_dedicated_thread(&runtime_global_ctx) {
+        tokio::task::spawn_blocking(move || {
+            let _g = runtime_global_ctx.net_ns.guard();
+            match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(runtime) => {
+                    runtime.block_on(run_tcp_port_mapping_task(
+                        runtime_local_listener,
+                        mapping,
+                        stop_rx,
+                    ));
+                }
+                Err(err) => {
+                    tracing::error!(
+                        ?err,
+                        %runtime_local_listener,
+                        "failed to build runtime for tcp port mapping renew task"
+                    );
+                }
+            }
+        });
+    } else {
+        tokio::spawn(run_tcp_port_mapping_task(
+            runtime_local_listener,
+            mapping,
+            stop_rx,
+        ));
+    }
+
+    Ok(Some(TcpPortMappingLease {
+        backend,
+        gateway_external_port,
+        stop_tx: Some(stop_tx),
+    }))
 }
 
 async fn try_start_udp_port_mapping(
@@ -396,6 +696,75 @@ async fn discover_udp_port_mapping(
                 }),
                 Err(nat_pmp_err) => Err(anyhow!(
                     "udp port mapping failed for {local_listener}: igd discovery error: {igd_err}; nat-pmp discovery error: {nat_pmp_err}"
+                )),
+            }
+        }
+    }
+}
+
+async fn discover_tcp_port_mapping(
+    global_ctx: ArcGlobalCtx,
+    local_listener: url::Url,
+) -> anyhow::Result<ActiveTcpPortMapping> {
+    match discover_igd_gateway_for_tcp_in_netns(global_ctx.clone(), local_listener.clone()).await {
+        Ok((gateway, local_addr)) => match establish_igd_tcp_mapping_in_netns(
+            global_ctx.clone(),
+            local_listener.clone(),
+            gateway,
+            local_addr,
+        )
+        .await
+        {
+            Ok(mapping) => Ok(mapping),
+            Err(igd_err) => {
+                tracing::debug!(
+                    ?igd_err,
+                    %local_listener,
+                    "igd tcp port mapping failed, retry with nat-pmp"
+                );
+                match discover_nat_pmp_gateway_for_tcp_in_netns(global_ctx.clone(), local_listener.clone())
+                    .await
+                {
+                    Ok((gateway, local_addr)) => establish_nat_pmp_tcp_mapping_in_netns(
+                        global_ctx,
+                        local_listener.clone(),
+                        gateway,
+                        local_addr,
+                    )
+                    .await
+                    .map_err(|nat_pmp_err| {
+                        anyhow!(
+                            "tcp port mapping failed for {local_listener}: igd error: {igd_err}; nat-pmp error: {nat_pmp_err}"
+                        )
+                    }),
+                    Err(nat_pmp_err) => Err(anyhow!(
+                        "tcp port mapping failed for {local_listener}: igd error: {igd_err}; nat-pmp discovery error: {nat_pmp_err}"
+                    )),
+                }
+            }
+        },
+        Err(igd_err) => {
+            tracing::debug!(
+                ?igd_err,
+                %local_listener,
+                "igd gateway discovery failed for tcp, retry with nat-pmp"
+            );
+            match discover_nat_pmp_gateway_for_tcp_in_netns(global_ctx.clone(), local_listener.clone()).await
+            {
+                Ok((gateway, local_addr)) => establish_nat_pmp_tcp_mapping_in_netns(
+                    global_ctx,
+                    local_listener.clone(),
+                    gateway,
+                    local_addr,
+                )
+                .await
+                .map_err(|nat_pmp_err| {
+                    anyhow!(
+                        "tcp port mapping failed for {local_listener}: igd discovery error: {igd_err}; nat-pmp error: {nat_pmp_err}"
+                    )
+                }),
+                Err(nat_pmp_err) => Err(anyhow!(
+                    "tcp port mapping failed for {local_listener}: igd discovery error: {igd_err}; nat-pmp discovery error: {nat_pmp_err}"
                 )),
             }
         }
@@ -537,6 +906,137 @@ fn should_run_port_mapping_in_dedicated_thread(global_ctx: &ArcGlobalCtx) -> boo
     global_ctx.net_ns.name().is_some()
 }
 
+async fn discover_igd_gateway_for_tcp_in_netns(
+    global_ctx: ArcGlobalCtx,
+    local_listener: url::Url,
+) -> anyhow::Result<(TokioGateway, SocketAddr)> {
+    if !should_run_port_mapping_in_dedicated_thread(&global_ctx) {
+        return ActiveTcpPortMapping::discover_igd_gateway(&global_ctx, &local_listener).await;
+    }
+
+    tokio::task::spawn_blocking(move || {
+        let _g = global_ctx.net_ns.guard();
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("build runtime for igd gateway discovery")?
+            .block_on(ActiveTcpPortMapping::discover_igd_gateway(
+                &global_ctx,
+                &local_listener,
+            ))
+    })
+    .await
+    .context("join igd gateway discovery task")?
+}
+
+async fn establish_igd_tcp_mapping_in_netns(
+    global_ctx: ArcGlobalCtx,
+    local_listener: url::Url,
+    gateway: TokioGateway,
+    local_addr: SocketAddr,
+) -> anyhow::Result<ActiveTcpPortMapping> {
+    if !should_run_port_mapping_in_dedicated_thread(&global_ctx) {
+        return ActiveTcpPortMapping::establish_via_igd(&local_listener, gateway, local_addr).await;
+    }
+
+    tokio::task::spawn_blocking(move || {
+        let _g = global_ctx.net_ns.guard();
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("build runtime for igd mapping establishment")?
+            .block_on(ActiveTcpPortMapping::establish_via_igd(
+                &local_listener,
+                gateway,
+                local_addr,
+            ))
+    })
+    .await
+    .context("join igd mapping establishment task")?
+}
+
+async fn discover_nat_pmp_gateway_for_tcp_in_netns(
+    global_ctx: ArcGlobalCtx,
+    local_listener: url::Url,
+) -> anyhow::Result<(Ipv4Addr, SocketAddr)> {
+    if !should_run_port_mapping_in_dedicated_thread(&global_ctx) {
+        return ActiveTcpPortMapping::discover_nat_pmp_gateway(&local_listener).await;
+    }
+
+    tokio::task::spawn_blocking(move || {
+        let _g = global_ctx.net_ns.guard();
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("build runtime for nat-pmp gateway discovery")?
+            .block_on(ActiveTcpPortMapping::discover_nat_pmp_gateway(
+                &local_listener,
+            ))
+    })
+    .await
+    .context("join nat-pmp gateway discovery task")?
+}
+
+async fn establish_nat_pmp_tcp_mapping_in_netns(
+    global_ctx: ArcGlobalCtx,
+    local_listener: url::Url,
+    gateway: Ipv4Addr,
+    local_addr: SocketAddr,
+) -> anyhow::Result<ActiveTcpPortMapping> {
+    if !should_run_port_mapping_in_dedicated_thread(&global_ctx) {
+        return ActiveTcpPortMapping::establish_via_nat_pmp(&local_listener, gateway, local_addr)
+            .await;
+    }
+
+    tokio::task::spawn_blocking(move || {
+        let _g = global_ctx.net_ns.guard();
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("build runtime for nat-pmp mapping establishment")?
+            .block_on(ActiveTcpPortMapping::establish_via_nat_pmp(
+                &local_listener,
+                gateway,
+                local_addr,
+            ))
+    })
+    .await
+    .context("join nat-pmp mapping establishment task")?
+}
+
+async fn run_tcp_port_mapping_task(
+    local_listener: url::Url,
+    mapping: ActiveTcpPortMapping,
+    mut stop_rx: oneshot::Receiver<()>,
+) {
+    loop {
+        tokio::select! {
+            _ = tokio::time::sleep(UPNP_RENEW_INTERVAL) => {
+                if let Err(err) = mapping.renew().await {
+                    tracing::warn!(
+                        ?err,
+                        %local_listener,
+                        backend = mapping.backend_name(),
+                        gateway_external_port = mapping.gateway_external_port,
+                        "failed to renew tcp port mapping"
+                    );
+                }
+            }
+            _ = &mut stop_rx => break,
+        }
+    }
+
+    if let Err(err) = mapping.remove().await {
+        tracing::debug!(
+            ?err,
+            %local_listener,
+            backend = mapping.backend_name(),
+            gateway_external_port = mapping.gateway_external_port,
+            "failed to remove tcp port mapping"
+        );
+    }
+}
+
 async fn add_udp_mapping_port_igd(
     gateway: &TokioGateway,
     local_addr: SocketAddr,
@@ -613,18 +1113,76 @@ async fn add_udp_mapping_port_nat_pmp(
     }
 }
 
+async fn add_tcp_mapping_port_igd(
+    gateway: &TokioGateway,
+    local_addr: SocketAddr,
+    local_listener: &url::Url,
+) -> anyhow::Result<u16> {
+    // For TCP hole punching, external port MUST equal internal port.
+    // Routers with default NAT behavior do not change source ports,
+    // so we must use add_port (same-port) to ensure port consistency.
+    gateway
+        .add_port(
+            PortMappingProtocol::TCP,
+            local_addr.port(),
+            local_addr,
+            UPNP_LEASE_DURATION_SECS,
+            UPNP_DESCRIPTION,
+        )
+        .await
+        .map(|_| local_addr.port())
+        .map_err(|err| {
+            anyhow!(
+                "igd tcp mapping failed for {local_listener}: {err}"
+            )
+        })
+}
+
+async fn add_tcp_mapping_port_nat_pmp(
+    gateway: Ipv4Addr,
+    local_addr: SocketAddr,
+    local_listener: &url::Url,
+) -> anyhow::Result<u16> {
+    // For TCP hole punching, external port MUST equal internal port.
+    // Use same-port mapping to ensure port consistency.
+    request_nat_pmp_mapping_with_protocol(
+        gateway,
+        local_addr.port(),
+        local_addr.port(),
+        UPNP_LEASE_DURATION_SECS,
+        NatPmpProtocol::TCP,
+    )
+    .await
+    .map(|_| local_addr.port())
+    .map_err(|err| {
+        anyhow!(
+            "nat-pmp tcp mapping failed for {local_listener}: {err}"
+        )
+    })
+}
+
 async fn request_nat_pmp_mapping(
     gateway: Ipv4Addr,
     private_port: u16,
     public_port: u16,
     lifetime_secs: u32,
 ) -> anyhow::Result<u16> {
+    request_nat_pmp_mapping_with_protocol(gateway, private_port, public_port, lifetime_secs, NatPmpProtocol::UDP).await
+}
+
+async fn request_nat_pmp_mapping_with_protocol(
+    gateway: Ipv4Addr,
+    private_port: u16,
+    public_port: u16,
+    lifetime_secs: u32,
+    protocol: NatPmpProtocol,
+) -> anyhow::Result<u16> {
     let client = new_tokio_natpmp_with(gateway)
         .await
         .with_context(|| format!("create nat-pmp client for gateway {gateway}"))?;
     client
         .send_port_mapping_request(
-            NatPmpProtocol::UDP,
+            protocol,
             private_port,
             public_port,
             lifetime_secs,
@@ -632,7 +1190,8 @@ async fn request_nat_pmp_mapping(
         .await
         .with_context(|| {
             format!(
-                "send nat-pmp udp mapping request private_port={private_port} public_port={public_port} gateway={gateway}"
+                "send nat-pmp {:?} mapping request private_port={private_port} public_port={public_port} gateway={gateway}",
+                protocol
             )
         })?;
 
@@ -640,20 +1199,22 @@ async fn request_nat_pmp_mapping(
         .await
         .with_context(|| {
             format!(
-                "wait nat-pmp udp mapping response private_port={private_port} gateway={gateway}"
+                "wait nat-pmp {:?} mapping response private_port={private_port} gateway={gateway}",
+                protocol
             )
         })?
         .map_err(anyhow::Error::from)
         .with_context(|| {
             format!(
-                "read nat-pmp udp mapping response private_port={private_port} gateway={gateway}"
+                "read nat-pmp {:?} mapping response private_port={private_port} gateway={gateway}",
+                protocol
             )
         })?;
 
     match response {
         NatPmpResponse::UDP(mapping) | NatPmpResponse::TCP(mapping) => Ok(mapping.public_port()),
         NatPmpResponse::Gateway(_) => {
-            bail!("unexpected nat-pmp gateway response for udp mapping request")
+            bail!("unexpected nat-pmp gateway response for {:?} mapping request", protocol)
         }
     }
 }
@@ -689,6 +1250,22 @@ async fn remove_udp_mapping_nat_pmp(
 
 fn should_map_udp_listener(local_listener: &url::Url) -> bool {
     if local_listener.scheme() != "udp" {
+        return false;
+    }
+
+    let Some(host) = listener_ipv4_host(local_listener) else {
+        return false;
+    };
+
+    if host.is_loopback() || host.is_broadcast() {
+        return false;
+    }
+
+    host.is_unspecified() || host.is_private() || host.is_link_local()
+}
+
+fn should_map_tcp_listener(local_listener: &url::Url) -> bool {
+    if local_listener.scheme() != "tcp" {
         return false;
     }
 
@@ -761,6 +1338,82 @@ async fn remove_udp_mapping_igd(
         .remove_port(PortMappingProtocol::UDP, external_port)
         .await
         .with_context(|| format!("remove udp port mapping {local_listener}"))
+}
+
+async fn renew_tcp_mapping_nat_pmp(
+    gateway: Ipv4Addr,
+    local_addr: SocketAddr,
+    external_port: u16,
+    local_listener: &url::Url,
+) -> anyhow::Result<()> {
+    request_nat_pmp_mapping_with_protocol(
+        gateway,
+        local_addr.port(),
+        external_port,
+        UPNP_LEASE_DURATION_SECS,
+        NatPmpProtocol::TCP,
+    )
+    .await
+    .map(|_| ())
+    .with_context(|| format!("renew tcp port mapping {local_listener}"))
+}
+
+async fn remove_tcp_mapping_nat_pmp(
+    gateway: Ipv4Addr,
+    local_addr: SocketAddr,
+    external_port: u16,
+    local_listener: &url::Url,
+) -> anyhow::Result<()> {
+    request_nat_pmp_mapping_with_protocol(gateway, local_addr.port(), external_port, 0, NatPmpProtocol::TCP)
+        .await
+        .map(|_| ())
+        .with_context(|| format!("remove tcp port mapping {local_listener}"))
+}
+
+async fn renew_tcp_mapping_igd(
+    gateway: &TokioGateway,
+    local_addr: SocketAddr,
+    external_port: u16,
+    local_listener: &url::Url,
+) -> anyhow::Result<()> {
+    gateway
+        .add_port(
+            PortMappingProtocol::TCP,
+            external_port,
+            local_addr,
+            UPNP_LEASE_DURATION_SECS,
+            UPNP_DESCRIPTION,
+        )
+        .await
+        .with_context(|| format!("renew tcp port mapping {local_listener}"))
+}
+
+async fn remove_tcp_mapping_igd(
+    gateway: &TokioGateway,
+    external_port: u16,
+    local_listener: &url::Url,
+) -> anyhow::Result<()> {
+    gateway
+        .remove_port(PortMappingProtocol::TCP, external_port)
+        .await
+        .with_context(|| format!("remove tcp port mapping {local_listener}"))
+}
+
+/// Find the bind address of the physical network interface by connecting to the SSDP broadcast address.
+/// This helps avoid using virtual network interfaces (like those created by EasyTier).
+pub fn find_physical_interface_bind_addr() -> Option<SocketAddr> {
+    // Connect to the SSDP multicast address to determine which interface would be used
+    let sock = std::net::UdpSocket::bind("0.0.0.0:0").ok()?;
+    sock.connect("239.255.255.250:1900").ok()?;
+    let local_addr = sock.local_addr().ok()?;
+
+    // Skip loopback addresses
+    if local_addr.ip().is_loopback() {
+        return None;
+    }
+
+    tracing::debug!(?local_addr, "found physical interface bind addr");
+    Some(local_addr)
 }
 
 #[cfg(test)]

--- a/easytier/src/connector/tcp_hole_punch.rs
+++ b/easytier/src/connector/tcp_hole_punch.rs
@@ -1,4 +1,4 @@
-use std::{
+﻿use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     sync::Arc,
     time::{Duration, Instant},
@@ -9,7 +9,7 @@ use dashmap;
 use tokio::task::JoinSet;
 
 use crate::{
-    common::{PeerId, join_joinset_background, stun::StunInfoCollectorTrait, upnp},
+    common::{PeerId, join_joinset_background, stun::StunInfoCollectorTrait, upnp, global_ctx::GlobalCtxEvent},
     connector::udp_hole_punch::BackOff,
     peers::{
         peer_manager::PeerManager,
@@ -32,6 +32,30 @@ use crate::{
 use crate::connector::{should_background_p2p_with_peer, should_try_p2p_with_peer};
 
 pub const BLACKLIST_TIMEOUT_SEC: u64 = 3600;
+
+/// Custom error type for TCP hole punch that carries the allocated port
+/// so it can be reused on retry or cleaned up on failure.
+#[derive(Debug)]
+struct HolePunchError {
+    error: anyhow::Error,
+    allocated_port: Option<u16>,
+}
+
+impl std::fmt::Display for HolePunchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.error)
+    }
+}
+
+impl std::error::Error for HolePunchError {}
+
+impl HolePunchError {
+    fn new(error: anyhow::Error, port: Option<u16>) -> Self {
+        Self { error, allocated_port: port }
+    }
+}
+
+type HolePunchResult<T> = Result<T, HolePunchError>;
 
 fn handle_rpc_result<T>(
     ret: Result<T, rpc_types::error::Error>,
@@ -61,8 +85,8 @@ fn bind_addr_for_port(port: u16, is_v6: bool) -> SocketAddr {
         SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), port)
     } else {
         // Try to bind to the physical interface address to avoid using virtual network interfaces
-        let physical_addr = upnp::find_physical_interface_bind_addr()
-            .map(|addr| addr.ip())
+        let physical_addr = upnp::get_physical_ipv4_addr()
+            .map(|ip| IpAddr::V4(ip))
             .unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
         SocketAddr::new(physical_addr, port)
     }
@@ -78,6 +102,13 @@ async fn create_bound_socket(peer_mgr: &Arc<PeerManager>, is_v6: bool) -> Result
     } else {
         tokio::net::TcpSocket::new_v4()?
     };
+
+    // Set SO_REUSEADDR to allow rebinding to the same port
+    // This is required because STUN verification may also try to bind to this port
+    socket.set_reuseaddr(true)?;
+    #[cfg(unix)]
+    socket.set_reuseport(true)?;
+
     socket.bind(bind_addr_for_port(0, is_v6))?;
     let local_port = socket.local_addr()?.port();
     tracing::debug!(is_v6, local_port, "tcp hole punch created bound socket");
@@ -163,6 +194,8 @@ struct TcpHolePunchServer {
     // Track peers we're already connecting to, to avoid duplicate tasks
     // DashSet::insert returns true if value was newly inserted (atomic operation)
     connecting_peers: Arc<dashmap::DashSet<SocketAddr>>,
+    // Store active UPnP port mapping leases to keep them alive
+    port_mapping_leases: Arc<tokio::sync::Mutex<std::collections::HashMap<u16, upnp::TcpPortMappingLease>>>,
 }
 
 impl TcpHolePunchServer {
@@ -173,7 +206,15 @@ impl TcpHolePunchServer {
             peer_mgr,
             tasks,
             connecting_peers: Arc::new(dashmap::DashSet::new()),
+            port_mapping_leases: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
         })
+    }
+
+    /// Store a UPnP port mapping lease to keep it alive
+    async fn store_port_mapping_lease(&self, port: u16, lease: upnp::TcpPortMappingLease) {
+        let mut leases = self.port_mapping_leases.lock().await;
+        tracing::info!(?port, "storing UPnP port mapping lease on server");
+        leases.insert(port, lease);
     }
 }
 
@@ -195,7 +236,7 @@ impl TcpHolePunchRpc for TcpHolePunchServer {
                 .tcp_nat_type,
         )
         .unwrap_or(NatType::Unknown);
-        tracing::debug!(?my_tcp_nat_type, "tcp hole punch rpc received");
+        tracing::info!(?my_tcp_nat_type, "tcp hole punch rpc received");
         if matches!(my_tcp_nat_type, NatType::Unknown) {
             tracing::warn!(?my_tcp_nat_type, "tcp hole punch rpc rejected (unknown)");
             return Err(anyhow::anyhow!("tcp nat type unknown not supported").into());
@@ -213,23 +254,70 @@ impl TcpHolePunchRpc for TcpHolePunchServer {
 
         let is_v6 = a_mapped_addr.is_ipv6();
 
-        // Create bound socket (no TOCTOU - port stays locked)
-        let (socket, local_port) = create_bound_socket(&self.peer_mgr, is_v6).await?;
+        // NAT4 (Symmetric NAT) cannot be reached from outside.
+        // No point doing UPnP or STUN - just bind a port and connect directly.
+        let is_symmetric = is_symmetric_tcp_nat(my_tcp_nat_type);
 
-        let listener_url = format!("tcp://0.0.0.0:{}", local_port).parse().unwrap();
-        let (mapped_addr, _port_mapping_lease) = upnp::resolve_tcp_public_addr(
-            self.peer_mgr.get_global_ctx().clone(),
-            &listener_url,
-            local_port,
-        )
-        .await
-        .with_context(|| "failed to get tcp port mapping")?;
+        // Step 1: Create socket and bind to a port
+        let (socket, local_port, mapped_addr) = {
+            let _g = self.peer_mgr.get_global_ctx().net_ns.guard();
+            let socket = if is_v6 {
+                tokio::net::TcpSocket::new_v6().map_err(|e| anyhow::anyhow!(e))?
+            } else {
+                tokio::net::TcpSocket::new_v4().map_err(|e| anyhow::anyhow!(e))?
+            };
+            socket.set_reuseaddr(true).map_err(|e| anyhow::anyhow!(e))?;
+            #[cfg(unix)]
+            socket.set_reuseport(true).map_err(|e| anyhow::anyhow!(e))?;
+
+            // Check if NAT detection already created a TCP port mapping
+            let nat_detection_port = if !is_v6 {
+                self.peer_mgr.get_global_ctx().get_stun_info_collector().get_nat_detection_tcp_port()
+            } else {
+                None
+            };
+
+            // Bind to the NAT detection port if available, otherwise use port 0
+            let bind_port = nat_detection_port.unwrap_or(0);
+            socket.bind(bind_addr_for_port(bind_port, is_v6)).map_err(|e| anyhow::anyhow!(e))?;
+            let local_port = socket.local_addr().map_err(|e| anyhow::anyhow!(e))?.port();
+
+            if is_symmetric {
+                // Symmetric NAT: skip UPnP/STUN, return dummy mapped addr
+                // NAT4 will connect directly to NAT1's address
+                tracing::info!(
+                    ?my_tcp_nat_type,
+                    local_port,
+                    "symmetric NAT: skipping UPnP/STUN, will connect directly"
+                );
+                (socket, local_port, SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0))
+            } else {
+                // Non-symmetric NAT: do UPnP + STUN to get public address
+                let listener_url = format!("tcp://0.0.0.0:{}", local_port).parse().unwrap();
+                let (mapped_addr, port_mapping_lease) = upnp::resolve_tcp_public_addr(
+                    self.peer_mgr.get_global_ctx().clone(),
+                    &listener_url,
+                    local_port,
+                )
+                .await
+                .with_context(|| "failed to get tcp port mapping")?;
+
+                // Store the lease to keep UPnP mapping alive
+                if let Some(lease) = port_mapping_lease {
+                    self.store_port_mapping_lease(local_port, lease).await;
+                }
+
+                tracing::info!(?local_port, ?nat_detection_port, "tcp hole punch server reusing NAT detection port");
+                (socket, local_port, mapped_addr)
+            }
+        };
 
         tracing::info!(
             ?a_mapped_addr,
             local_port,
             ?mapped_addr,
-            "tcp hole punch rpc responding with listener mapped addr and start connecting"
+            ?my_tcp_nat_type,
+            "tcp hole punch rpc responding with mapped addr and start connecting"
         );
 
         // Atomic dedup: DashSet::insert returns true if value was newly inserted
@@ -265,6 +353,11 @@ struct TcpHolePunchConnectorData {
     // Track peers we're already connecting to, to avoid duplicate tasks
     // DashSet::insert returns true if value was newly inserted (atomic operation)
     connecting_peers: Arc<dashmap::DashSet<PeerId>>,
+    // Flag to force TCP hole punch even if peer already connected (e.g., via relay)
+    force_hole_punch: Arc<std::sync::atomic::AtomicBool>,
+    // Store active UPnP port mapping leases to keep them alive
+    // Key: local port, Value: lease (keeps mapping alive until dropped)
+    port_mapping_leases: Arc<tokio::sync::Mutex<std::collections::HashMap<u16, upnp::TcpPortMappingLease>>>,
 }
 
 impl TcpHolePunchConnectorData {
@@ -273,7 +366,38 @@ impl TcpHolePunchConnectorData {
             peer_mgr,
             blacklist: Arc::new(timedmap::TimedMap::new()),
             connecting_peers: Arc::new(dashmap::DashSet::new()),
+            force_hole_punch: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            port_mapping_leases: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
         })
+    }
+
+    fn set_force_hole_punch(&self, force: bool) {
+        self.force_hole_punch.store(force, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn should_force_hole_punch(&self) -> bool {
+        self.force_hole_punch.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Store a UPnP port mapping lease to keep it alive
+    async fn store_port_mapping_lease(&self, port: u16, lease: upnp::TcpPortMappingLease) {
+        let mut leases = self.port_mapping_leases.lock().await;
+        tracing::info!(?port, "storing UPnP port mapping lease");
+        leases.insert(port, lease);
+    }
+
+    /// Remove a UPnP port mapping lease (will delete the mapping)
+    async fn remove_port_mapping_lease(&self, port: &u16) {
+        let mut leases = self.port_mapping_leases.lock().await;
+        if leases.remove(port).is_some() {
+            tracing::info!(?port, "removed UPnP port mapping lease");
+        }
+    }
+
+    /// Check if we have a UPnP port mapping lease for the given port
+    async fn has_port_mapping_lease(&self, port: &u16) -> bool {
+        let leases = self.port_mapping_leases.lock().await;
+        leases.contains_key(port)
     }
 
     async fn punch_as_initiator(self: Arc<Self>, dst_peer_id: PeerId) -> Result<(), Error> {
@@ -286,12 +410,44 @@ impl TcpHolePunchConnectorData {
             return Ok(());
         }
 
-        let mut backoff = BackOff::new(vec![1000, 1000, 4000, 8000]);
+        // Allocate port ONCE and reuse across retries to avoid UPnP lease leaks
+        let mut reused_port: Option<u16> = None;
+
+            let mut backoff = BackOff::new(vec![1000, 1000, 4000, 8000]);
+        let mut success = false;
 
         loop {
             backoff.sleep_for_next_backoff().await;
-            if self.do_punch_as_initiator(dst_peer_id).await.is_ok() {
-                break;
+            match self.do_punch_as_initiator(dst_peer_id, reused_port).await {
+                Ok((port, _lease)) => {
+                    // Save port for potential cleanup if needed
+                    reused_port = Some(port);
+                    success = true;
+                    break;
+                }
+                Err(err) => {
+                    // Save port even on failure for reuse in next attempt
+                    if let Some(port) = err.allocated_port {
+                        if reused_port.is_none() {
+                            tracing::info!(?port, "saving port for reuse in next attempt");
+                            reused_port = Some(port);
+                        }
+                    }
+
+                    let e = err.error;
+                    // If NAT type is unknown, don't retry - will be picked up on next collect cycle
+                    if e.to_string().contains("NAT type unknown") {
+                        tracing::info!(dst_peer_id, "tcp hole punch waiting for NAT detection");
+                        break;
+                    }
+                    // For symmetric NAT, don't retry
+                    if e.to_string().contains("symmetric NAT") {
+                        tracing::info!(dst_peer_id, "tcp hole punch skipped (symmetric NAT)");
+                        break;
+                    }
+                    // For other errors, continue retrying
+                    tracing::warn!(dst_peer_id, ?e, "tcp hole punch attempt failed, retrying");
+                }
             }
 
             if self.blacklist.contains(&dst_peer_id) {
@@ -303,14 +459,22 @@ impl TcpHolePunchConnectorData {
             }
         }
 
+        // Clean up: remove UPnP mapping if hole punch didn't succeed
+        if !success {
+            if let Some(port) = reused_port {
+                tracing::info!(?port, "cleaning up UPnP mapping after failed hole punch");
+                self.remove_port_mapping_lease(&port).await;
+            }
+        }
+
         // Remove from connecting set
         self.connecting_peers.remove(&dst_peer_id);
 
         Ok(())
     }
 
-    #[tracing::instrument(skip(self), fields(dst_peer_id), err)]
-    async fn do_punch_as_initiator(&self, dst_peer_id: PeerId) -> Result<(), Error> {
+    #[tracing::instrument(skip(self), fields(dst_peer_id))]
+    async fn do_punch_as_initiator(&self, dst_peer_id: PeerId, reused_port: Option<u16>) -> HolePunchResult<(u16, Option<upnp::TcpPortMappingLease>)> {
         let global_ctx = self.peer_mgr.get_global_ctx();
         let my_tcp_nat_type = NatType::try_from(
             global_ctx
@@ -319,22 +483,99 @@ impl TcpHolePunchConnectorData {
                 .tcp_nat_type,
         )
         .unwrap_or(NatType::Unknown);
-        tracing::debug!(?my_tcp_nat_type, "tcp hole punch initiator start");
-        if is_symmetric_tcp_nat(my_tcp_nat_type) || my_tcp_nat_type == NatType::Unknown {
-            tracing::debug!("tcp hole punch initiator skipped (symmetric)");
-            return Ok(());
+        tracing::info!(?my_tcp_nat_type, "tcp hole punch initiator start");
+
+        // Skip only for symmetric NAT (NAT4)
+        if is_symmetric_tcp_nat(my_tcp_nat_type) {
+            tracing::info!("tcp hole punch initiator skipped (symmetric)");
+            return Err(HolePunchError::new(anyhow::anyhow!("symmetric NAT, skip"), None));
         }
 
-        // Create bound socket for simultaneous open (no TOCTOU)
-        let (socket, local_port) = create_bound_socket(&self.peer_mgr, false).await?;
-        let listener_url = format!("tcp://0.0.0.0:{}", local_port).parse().unwrap();
-        let (mapped_addr, _port_mapping_lease) = upnp::resolve_tcp_public_addr(
-            global_ctx.clone(),
-            &listener_url,
-            local_port,
-        )
-        .await
-        .with_context(|| "failed to get tcp port mapping")?;
+        // If NAT type is Unknown, return error to retry later
+        if my_tcp_nat_type == NatType::Unknown {
+            tracing::info!("tcp hole punch initiator skipped (unknown, waiting for NAT detection)");
+            return Err(HolePunchError::new(anyhow::anyhow!("NAT type unknown, retry later"), None));
+        }
+
+        // Step 1: Get or reuse port
+        let local_port = match reused_port {
+            Some(port) => {
+                tracing::info!(?port, "reusing existing port for retry");
+                port
+            }
+            None => {
+                // Check if NAT detection already created a TCP port mapping
+                let nat_detection_port = global_ctx.get_stun_info_collector().get_nat_detection_tcp_port();
+                if let Some(port) = nat_detection_port {
+                    tracing::info!(?port, "reusing NAT detection port for UPnP mapping");
+                    port
+                } else {
+                    // No existing mapping, allocate a new port
+                    let _g = self.peer_mgr.get_global_ctx().net_ns.guard();
+                    let temp_socket = match tokio::net::TcpSocket::new_v4() {
+                        Ok(s) => s,
+                        Err(e) => return Err(HolePunchError::new(anyhow::anyhow!("create socket failed: {:?}", e), None)),
+                    };
+                    if let Err(e) = temp_socket.bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0)) {
+                        return Err(HolePunchError::new(anyhow::anyhow!("bind failed: {:?}", e), None));
+                    }
+                    let port = match temp_socket.local_addr() {
+                        Ok(addr) => addr.port(),
+                        Err(e) => return Err(HolePunchError::new(anyhow::anyhow!("local_addr failed: {:?}", e), None)),
+                    };
+                    drop(temp_socket);
+                    port
+                }
+            }
+        };
+
+        // Step 2: UPnP mapping + STUN verification
+        // SKIP UPnP if reusing port (mapping already exists from first attempt)
+        let mapped_addr = if reused_port.is_some() {
+            // Reuse existing mapping - just do STUN to get mapped address
+            match global_ctx.get_stun_info_collector().get_tcp_port_mapping(local_port).await {
+                Ok(addr) => addr,
+                Err(e) => return Err(HolePunchError::new(anyhow::anyhow!("STUN failed: {:?}", e), Some(local_port))),
+            }
+        } else {
+            // First attempt - create UPnP mapping + STUN
+            let listener_url = format!("tcp://0.0.0.0:{}", local_port).parse().unwrap();
+            let (mapped_addr, port_mapping_lease) = match upnp::resolve_tcp_public_addr(
+                global_ctx.clone(),
+                &listener_url,
+                local_port,
+            ).await {
+                Ok(result) => result,
+                Err(e) => return Err(HolePunchError::new(anyhow::anyhow!("UPnP/STUN failed: {:?}", e), Some(local_port))),
+            };
+
+            // Store the lease to keep UPnP mapping alive
+            if let Some(lease) = port_mapping_lease {
+                self.store_port_mapping_lease(local_port, lease).await;
+            }
+
+            mapped_addr
+        };
+
+        // Step 3: Create persistent socket for hole punch (re-bind to same port)
+        let socket = {
+            let _g = self.peer_mgr.get_global_ctx().net_ns.guard();
+            let socket = match tokio::net::TcpSocket::new_v4() {
+                Ok(s) => s,
+                Err(e) => return Err(HolePunchError::new(anyhow::anyhow!("create socket failed: {:?}", e), Some(local_port))),
+            };
+            if let Err(e) = socket.set_reuseaddr(true) {
+                    return Err(HolePunchError::new(anyhow::anyhow!("set_reuseaddr failed: {:?}", e), Some(local_port)));
+            }
+            #[cfg(unix)]
+            if let Err(e) = socket.set_reuseport(true) {
+                    return Err(HolePunchError::new(anyhow::anyhow!("set_reuseport failed: {:?}", e), Some(local_port)));
+            }
+            if let Err(e) = socket.bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), local_port)) {
+                    return Err(HolePunchError::new(anyhow::anyhow!("bind failed: {:?}", e), Some(local_port)));
+            }
+            socket
+        };
 
         tracing::info!(
             dst_peer_id,
@@ -364,11 +605,14 @@ impl TcpHolePunchConnectorData {
                 },
             )
             .await;
-        let resp = handle_rpc_result(resp, dst_peer_id, &self.blacklist)?;
-        let remote_mapped_addr = resp
-            .listener_mapped_addr
-            .ok_or(anyhow::anyhow!("listener_mapped_addr is required"))?;
-        let remote_mapped_addr: SocketAddr = remote_mapped_addr.into();
+        let resp = match handle_rpc_result(resp, dst_peer_id, &self.blacklist) {
+            Ok(resp) => resp,
+            Err(e) => return Err(HolePunchError::new(anyhow::anyhow!("RPC error: {:?}", e), Some(local_port))),
+        };
+        let remote_mapped_addr = match resp.listener_mapped_addr {
+            Some(addr) => SocketAddr::from(addr),
+            None => return Err(HolePunchError::new(anyhow::anyhow!("listener_mapped_addr is required"), Some(local_port))),
+        };
         let remote_tcp_nat_type = NatType::try_from(resp.tcp_nat_type).unwrap_or(NatType::Unknown);
         tracing::info!(
             dst_peer_id,
@@ -377,43 +621,98 @@ impl TcpHolePunchConnectorData {
             "tcp hole punch initiator rpc returned"
         );
 
-        // If we are symmetric NAT (NAT4) and remote is FullCone (NAT1),
-        // add a small delay to let the remote side establish their mapping first
-        if is_symmetric_tcp_nat(my_tcp_nat_type) && remote_tcp_nat_type == NatType::FullCone {
+        // Key optimization: When remote is Symmetric NAT, skip simultaneous open
+        // because Symmetric NAT allocates different ports per destination.
+        // Instead, go directly to STUN traversal mode (NAT1 listens, NAT4 connects).
+        let skip_simultaneous_open = is_symmetric_tcp_nat(remote_tcp_nat_type);
+
+        if skip_simultaneous_open {
             tracing::info!(
                 dst_peer_id,
                 ?my_tcp_nat_type,
                 ?remote_tcp_nat_type,
-                "tcp hole punch initiator: symmetric NAT waiting for fullcone peer"
+                "tcp hole punch initiator: remote is symmetric, skipping simultaneous open"
             );
-            tokio::time::sleep(Duration::from_millis(500)).await;
-        }
 
-        // Use the pre-bound socket for simultaneous open
-        if let Ok(()) = try_connect_with_socket(
-            self.peer_mgr.clone(),
-            socket,
-            remote_mapped_addr,
-            local_port,
-            false,
-        )
-        .await
-        {
+            // When skipping simultaneous open, we need to listen on the port immediately
+            // so NAT4 can connect to us. Convert socket to listener.
+            if my_tcp_nat_type == NatType::FullCone {
+                tracing::info!(
+                    dst_peer_id,
+                    local_port,
+                    ?mapped_addr,
+                    "tcp hole punch initiator: NAT1 listening for NAT4 connection"
+                );
+
+                // Convert TcpSocket to TcpListener - port stays bound and now listens
+                let tcp_listener = match socket.listen(128) {
+                    Ok(l) => l,
+                    Err(e) => return Err(HolePunchError::new(anyhow::anyhow!("listen failed: {:?}", e), Some(local_port))),
+                };
+                let listener_url = format!("tcp://0.0.0.0:{}", local_port).parse().unwrap();
+                let mut listener = TcpTunnelListener::from_listener(tcp_listener, listener_url);
+
+                // Wait for NAT4 to connect (with timeout)
+                let accept_timeout = Duration::from_secs(15);
+                match tokio::time::timeout(accept_timeout, listener.accept()).await {
+                    Ok(Ok(tunnel)) => {
+                        tracing::info!(local_port, "listener accepted connection from NAT4");
+                        if let Err(e) = self.peer_mgr.add_tunnel_as_server(tunnel, false).await {
+                            tracing::error!(?e, "listener failed to add tunnel");
+                            return Err(HolePunchError::new(anyhow::anyhow!("failed to add tunnel: {:?}", e), Some(local_port)));
+                        }
+                        tracing::info!(local_port, "listener added tunnel successfully");
+                        return Ok((local_port, None));
+                    }
+                    Ok(Err(e)) => {
+                        tracing::warn!(?e, local_port, "listener accept error");
+                        return Err(HolePunchError::new(anyhow::anyhow!("accept error: {:?}", e), Some(local_port)));
+                    }
+                    Err(_) => {
+                        tracing::warn!(local_port, "listener accept timeout, NAT4 did not connect");
+                        return Err(HolePunchError::new(anyhow::anyhow!("accept timeout"), Some(local_port)));
+                    }
+                }
+            }
+        } else {
+            // If we are symmetric NAT (NAT4) and remote is FullCone (NAT1),
+            // add a small delay to let the remote side establish their mapping first
+            if is_symmetric_tcp_nat(my_tcp_nat_type) && remote_tcp_nat_type == NatType::FullCone {
+                tracing::info!(
+                    dst_peer_id,
+                    ?my_tcp_nat_type,
+                    ?remote_tcp_nat_type,
+                    "tcp hole punch initiator: symmetric NAT waiting for fullcone peer"
+                );
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+
+            // Try simultaneous open
+            if let Ok(()) = try_connect_with_socket(
+                self.peer_mgr.clone(),
+                socket,
+                remote_mapped_addr,
+                local_port,
+                false,
+            )
+            .await
+            {
+                tracing::info!(
+                    dst_peer_id,
+                    local_port,
+                    ?remote_mapped_addr,
+                    "tcp hole punch initiator connected to remote mapped addr with simultaneous connection"
+                );
+                return Ok((local_port, None));
+            }
+
             tracing::info!(
                 dst_peer_id,
                 local_port,
                 ?remote_mapped_addr,
-                "tcp hole punch initiator connected to remote mapped addr with simultaneous connection"
+                "tcp hole punch initiator simultaneous open failed"
             );
-            return Ok(());
         }
-
-        tracing::debug!(
-            dst_peer_id,
-            local_port,
-            ?remote_mapped_addr,
-            "tcp hole punch initiator simultaneous open failed"
-        );
 
         // If we are NAT1 (FullCone), try STUN traversal with a DIFFERENT port
         // Using a different port avoids conflicts between simultaneous open and listening
@@ -425,15 +724,24 @@ impl TcpHolePunchConnectorData {
             );
 
             // Create a bound socket for STUN traversal
-            let (stun_socket, stun_port) = create_bound_socket(&self.peer_mgr, false).await?;
+            let (stun_socket, stun_port) = match create_bound_socket(&self.peer_mgr, false).await {
+                Ok(result) => result,
+                Err(e) => return Err(HolePunchError::new(anyhow::anyhow!("create_bound_socket failed: {:?}", e), Some(local_port))),
+            };
             let stun_listener_url = format!("tcp://0.0.0.0:{}", stun_port).parse().unwrap();
-            let (public_addr, _stun_lease) = upnp::resolve_tcp_public_addr(
+            let (public_addr, stun_lease) = match upnp::resolve_tcp_public_addr(
                 global_ctx.clone(),
                 &stun_listener_url,
                 stun_port,
-            )
-            .await
-            .with_context(|| "failed to get tcp port mapping for STUN")?;
+            ).await {
+                Ok(result) => result,
+                Err(e) => return Err(HolePunchError::new(anyhow::anyhow!("STUN failed: {:?}", e), Some(stun_port))),
+            };
+
+            // Store the lease to keep UPnP mapping alive
+            if let Some(lease) = stun_lease {
+                self.store_port_mapping_lease(stun_port, lease).await;
+            }
 
             tracing::info!(
                 dst_peer_id,
@@ -443,7 +751,10 @@ impl TcpHolePunchConnectorData {
             );
 
             // Convert TcpSocket to TcpListener directly - port is never released
-            let tcp_listener = stun_socket.listen(128)?;
+            let tcp_listener = match stun_socket.listen(128) {
+                Ok(l) => l,
+                Err(e) => return Err(HolePunchError::new(anyhow::anyhow!("listen failed: {:?}", e), Some(stun_port))),
+            };
             let mut listener = TcpTunnelListener::from_listener(tcp_listener, stun_listener_url);
 
             // Report the public listening address to other nodes via RPC
@@ -490,50 +801,31 @@ impl TcpHolePunchConnectorData {
                 }
             }
 
-            // Spawn a task to accept connections on the STUN listener
-            // This keeps the listener alive and accepts incoming connections
-            let peer_mgr_clone = self.peer_mgr.clone();
-            tokio::spawn(async move {
-                let timeout = Duration::from_secs(30);
-                let start = tokio::time::Instant::now();
-
-                loop {
-                    if start.elapsed() >= timeout {
-                        tracing::info!(stun_port, "stun listener accept loop timeout, shutting down");
-                        break;
+            // Wait for NAT4 to connect (with timeout)
+            let accept_timeout = Duration::from_secs(15);
+            match tokio::time::timeout(accept_timeout, listener.accept()).await {
+                Ok(Ok(tunnel)) => {
+                    tracing::info!(stun_port, "stun listener accepted connection from NAT4");
+                    if let Err(e) = self.peer_mgr.add_tunnel_as_server(tunnel, false).await {
+                        tracing::error!(?e, "stun listener failed to add tunnel");
+                            return Err(HolePunchError::new(anyhow::anyhow!("failed to add tunnel: {:?}", e), Some(stun_port)));
                     }
-
-                    match tokio::time::timeout(Duration::from_secs(5), listener.accept()).await {
-                        Ok(Ok(tunnel)) => {
-                            tracing::info!(stun_port, "stun listener accepted connection");
-                            if let Err(e) = peer_mgr_clone.add_tunnel_as_server(tunnel, false).await {
-                                tracing::error!(?e, "stun listener failed to add tunnel");
-                            } else {
-                                tracing::info!(stun_port, "stun listener added tunnel successfully");
-                                break; // Successfully connected, exit loop
-                            }
-                        }
-                        Ok(Err(e)) => {
-                            tracing::warn!(?e, stun_port, "stun listener accept error");
-                            break;
-                        }
-                        Err(_) => {
-                            // Timeout, continue loop
-                            continue;
-                        }
-                    }
+                    tracing::info!(stun_port, "stun listener added tunnel successfully");
+                        return Ok((stun_port, None));
                 }
-
-                tracing::info!(stun_port, "stun listener accept loop exited");
-            });
-
-            return Ok(());
+                Ok(Err(e)) => {
+                    tracing::warn!(?e, stun_port, "stun listener accept error");
+                        return Err(HolePunchError::new(anyhow::anyhow!("accept error: {:?}", e), Some(stun_port)));
+                }
+                Err(_) => {
+                    tracing::warn!(stun_port, "stun listener accept timeout, NAT4 did not connect");
+                        return Err(HolePunchError::new(anyhow::anyhow!("accept timeout"), Some(stun_port)));
+                }
+            }
         }
 
-        Err(anyhow::anyhow!("tcp hole punch simultaneous open failed"))
+        Err(HolePunchError::new(anyhow::anyhow!("tcp hole punch simultaneous open failed"), Some(local_port)))
     }
-
-
 }
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
@@ -566,10 +858,22 @@ impl PeerTaskLauncher for TcpHolePunchPeerTaskLauncher {
                 .tcp_nat_type,
         )
         .unwrap_or(NatType::Unknown);
-        if is_symmetric_tcp_nat(my_tcp_nat_type) || my_tcp_nat_type == NatType::Unknown {
+
+        // Skip only for symmetric NAT (NAT4), not for Unknown
+        // Unknown means NAT detection hasn't completed yet, we should retry later
+        if is_symmetric_tcp_nat(my_tcp_nat_type) {
             tracing::trace!(
                 ?my_tcp_nat_type,
                 "tcp hole punch task collect skipped (symmetric)"
+            );
+            return vec![];
+        }
+
+        // If NAT type is Unknown, log and return empty (will retry on next loop)
+        if my_tcp_nat_type == NatType::Unknown {
+            tracing::trace!(
+                ?my_tcp_nat_type,
+                "tcp hole punch task collect skipped (unknown, waiting for NAT detection)"
             );
             return vec![];
         }
@@ -609,6 +913,8 @@ impl PeerTaskLauncher for TcpHolePunchPeerTaskLauncher {
                 continue;
             }
 
+            // Skip peers that are already connected
+            // Even with force_hole_punch, we don't want to punch again if already connected
             if data.peer_mgr.get_peer_map().has_peer(peer_id) {
                 tracing::trace!(peer_id, "tcp hole punch task collect skip already has peer");
                 continue;
@@ -626,6 +932,15 @@ impl PeerTaskLauncher for TcpHolePunchPeerTaskLauncher {
                     peer_id,
                     ?peer_tcp_nat_type,
                     "tcp hole punch task collect skip peer unknown"
+                );
+                continue;
+            }
+
+            // Skip peers that are already in the connecting set (another task is working on it)
+            if data.connecting_peers.contains(&peer_id) {
+                tracing::debug!(
+                    peer_id,
+                    "tcp hole punch task collect skip already connecting"
                 );
                 continue;
             }
@@ -708,6 +1023,31 @@ impl TcpHolePunchConnector {
             );
             return Ok(());
         }
+
+        // Subscribe to TCP NAT type detection events
+        let mut event_rx = self.peer_mgr.get_global_ctx().subscribe();
+        let p2p_demand_notify = self.peer_mgr.p2p_demand_notify();
+        let data = self.client.data();
+        tokio::spawn(async move {
+            loop {
+                match event_rx.recv().await {
+                    Ok(GlobalCtxEvent::TcpNatTypeDetected) => {
+                        tracing::info!("TCP NAT type detected, forcing TCP hole punch for all peers");
+                        // Set force flag to bypass has_peer check
+                        data.set_force_hole_punch(true);
+                        p2p_demand_notify.notify();
+                        // Reset force flag after a delay
+                        tokio::time::sleep(Duration::from_secs(30)).await;
+                        data.set_force_hole_punch(false);
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        tracing::warn!(?e, "event receiver error, stopping listener");
+                        break;
+                    }
+                }
+            }
+        });
 
         self.run_as_client().await?;
         self.run_as_server().await?;

--- a/easytier/src/connector/tcp_hole_punch.rs
+++ b/easytier/src/connector/tcp_hole_punch.rs
@@ -5,11 +5,11 @@ use std::{
 };
 
 use anyhow::{Context, Error};
-use rand::Rng as _;
+use dashmap;
 use tokio::task::JoinSet;
 
 use crate::{
-    common::{PeerId, join_joinset_background, stun::StunInfoCollectorTrait},
+    common::{PeerId, join_joinset_background, stun::StunInfoCollectorTrait, upnp},
     connector::udp_hole_punch::BackOff,
     peers::{
         peer_manager::PeerManager,
@@ -24,8 +24,8 @@ use crate::{
         rpc_types::{self, controller::BaseController},
     },
     tunnel::{
-        TunnelConnector as _, TunnelListener as _,
-        tcp::{TcpTunnelConnector, TcpTunnelListener},
+        TunnelListener as _,
+        tcp::TcpTunnelListener,
     },
 };
 
@@ -60,49 +60,60 @@ fn bind_addr_for_port(port: u16, is_v6: bool) -> SocketAddr {
     if is_v6 {
         SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), port)
     } else {
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port)
+        // Try to bind to the physical interface address to avoid using virtual network interfaces
+        let physical_addr = upnp::find_physical_interface_bind_addr()
+            .map(|addr| addr.ip())
+            .unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+        SocketAddr::new(physical_addr, port)
     }
 }
 
-async fn select_local_port(peer_mgr: &Arc<PeerManager>, is_v6: bool) -> Result<u16, Error> {
-    let bind_addr = bind_addr_for_port(0, is_v6);
-    tracing::trace!(?bind_addr, is_v6, "tcp hole punch select local port");
+/// Create a TcpSocket bound to an ephemeral port.
+/// The socket is NOT dropped, so the port remains locked.
+/// Returns (socket, local_port).
+async fn create_bound_socket(peer_mgr: &Arc<PeerManager>, is_v6: bool) -> Result<(tokio::net::TcpSocket, u16), Error> {
     let _g = peer_mgr.get_global_ctx().net_ns.guard();
-    let listener = tokio::net::TcpListener::bind(bind_addr).await?;
-    let port = listener.local_addr()?.port();
-    tracing::debug!(?bind_addr, port, "tcp hole punch selected local port");
-    Ok(port)
+    let socket = if is_v6 {
+        tokio::net::TcpSocket::new_v6()?
+    } else {
+        tokio::net::TcpSocket::new_v4()?
+    };
+    socket.bind(bind_addr_for_port(0, is_v6))?;
+    let local_port = socket.local_addr()?.port();
+    tracing::debug!(is_v6, local_port, "tcp hole punch created bound socket");
+    Ok((socket, local_port))
 }
 
-// tcp support simultaneous connect, so initiator and server can both use connect.
-async fn try_connect_to_remote(
+/// Connect to remote using a pre-bound socket.
+/// This avoids TOCTOU: the socket was bound earlier and port is still locked.
+/// Note: TcpSocket is consumed on first successful connect attempt.
+async fn try_connect_with_socket(
     peer_mgr: Arc<PeerManager>,
-    a_mapped_addr: SocketAddr,
+    socket: tokio::net::TcpSocket,
+    remote_addr: SocketAddr,
     local_port: u16,
     is_client: bool,
-    max_attempts: u32,
 ) -> Result<(), Error> {
     tracing::info!(
-        ?a_mapped_addr,
+        ?remote_addr,
         local_port,
-        "tcp hole punch server start connect loop"
+        "tcp hole punch start connect with pre-bound socket"
     );
 
-    let mut connector =
-        TcpTunnelConnector::new(format!("tcp://{}", a_mapped_addr).parse().unwrap());
-    connector.set_bind_addrs(vec![bind_addr_for_port(
-        local_port,
-        a_mapped_addr.is_ipv6(),
-    )]);
+    let _g = peer_mgr.get_global_ctx().net_ns.guard();
 
-    let start = tokio::time::Instant::now();
-    let mut attempts: u32 = 0;
-    while start.elapsed() < Duration::from_secs(10) && attempts < max_attempts {
-        attempts = attempts.wrapping_add(1);
-        let _g = peer_mgr.get_global_ctx().net_ns.guard();
-        if let Ok(Ok(tunnel)) =
-            tokio::time::timeout(Duration::from_secs(3), connector.connect()).await
-        {
+    // TcpSocket can only be used once for connect
+    match tokio::time::timeout(Duration::from_secs(10), socket.connect(remote_addr)).await {
+        Ok(Ok(stream)) => {
+            // Set TCP options
+            let _ = stream.set_nodelay(true);
+            let _ = socket2::SockRef::from(&stream).set_linger(Some(Duration::ZERO));
+
+            // Create tunnel from stream
+            let tunnel_url = format!("tcp://{}", remote_addr).parse().unwrap();
+            let tunnel = crate::tunnel::tcp::get_tunnel_with_tcp_stream(stream, tunnel_url)
+                .map_err(|e| anyhow::anyhow!("create tunnel failed: {:?}", e))?;
+
             let add_tunnel_ret = if is_client {
                 peer_mgr.add_client_tunnel(tunnel, false).await.map(|_| ())
             } else {
@@ -110,56 +121,59 @@ async fn try_connect_to_remote(
             };
             if let Err(e) = add_tunnel_ret {
                 tracing::error!(
-                    ?a_mapped_addr,
+                    ?remote_addr,
                     local_port,
-                    attempts,
                     ?e,
-                    "tcp hole punch server connected and added client tunnel failed"
+                    "tcp hole punch connected but add tunnel failed"
                 );
-                continue;
+                return Err(anyhow::anyhow!("add tunnel failed: {:?}", e));
             } else {
                 tracing::info!(
-                    ?a_mapped_addr,
+                    ?remote_addr,
                     local_port,
-                    attempts,
                     is_client,
-                    "tcp hole punch server connected and added tunnel"
+                    "tcp hole punch connected and added tunnel"
                 );
                 return Ok(());
             }
         }
-        tracing::trace!(
-            ?a_mapped_addr,
-            local_port,
-            attempts,
-            "tcp hole punch server connect attempt failed"
-        );
-        let sleep_ms = rand::thread_rng().gen_range(10..100);
-        tokio::time::sleep(Duration::from_millis(sleep_ms)).await;
+        Ok(Err(e)) => {
+            tracing::warn!(
+                ?remote_addr,
+                local_port,
+                ?e,
+                "tcp hole punch connect failed"
+            );
+            return Err(anyhow::anyhow!("connect failed: {:?}", e));
+        }
+        Err(_) => {
+            tracing::warn!(
+                ?remote_addr,
+                local_port,
+                "tcp hole punch connect timeout"
+            );
+            return Err(anyhow::anyhow!("connect timeout"));
+        }
     }
-
-    tracing::warn!(
-        ?a_mapped_addr,
-        local_port,
-        attempts,
-        "tcp hole punch server connect loop timeout"
-    );
-
-    Err(anyhow::anyhow!(
-        "tcp hole punch server connect loop timeout"
-    ))
 }
 
 struct TcpHolePunchServer {
     peer_mgr: Arc<PeerManager>,
     tasks: Arc<std::sync::Mutex<JoinSet<()>>>,
+    // Track peers we're already connecting to, to avoid duplicate tasks
+    // DashSet::insert returns true if value was newly inserted (atomic operation)
+    connecting_peers: Arc<dashmap::DashSet<SocketAddr>>,
 }
 
 impl TcpHolePunchServer {
     fn new(peer_mgr: Arc<PeerManager>) -> Arc<Self> {
         let tasks = Arc::new(std::sync::Mutex::new(JoinSet::new()));
         join_joinset_background(tasks.clone(), "tcp hole punch server".to_string());
-        Arc::new(Self { peer_mgr, tasks })
+        Arc::new(Self {
+            peer_mgr,
+            tasks,
+            connecting_peers: Arc::new(dashmap::DashSet::new()),
+        })
     }
 }
 
@@ -198,14 +212,18 @@ impl TcpHolePunchRpc for TcpHolePunchServer {
         }
 
         let is_v6 = a_mapped_addr.is_ipv6();
-        let local_port = select_local_port(&self.peer_mgr, is_v6).await?;
-        let mapped_addr = self
-            .peer_mgr
-            .get_global_ctx()
-            .get_stun_info_collector()
-            .get_tcp_port_mapping(local_port)
-            .await
-            .with_context(|| "failed to get tcp port mapping")?;
+
+        // Create bound socket (no TOCTOU - port stays locked)
+        let (socket, local_port) = create_bound_socket(&self.peer_mgr, is_v6).await?;
+
+        let listener_url = format!("tcp://0.0.0.0:{}", local_port).parse().unwrap();
+        let (mapped_addr, _port_mapping_lease) = upnp::resolve_tcp_public_addr(
+            self.peer_mgr.get_global_ctx().clone(),
+            &listener_url,
+            local_port,
+        )
+        .await
+        .with_context(|| "failed to get tcp port mapping")?;
 
         tracing::info!(
             ?a_mapped_addr,
@@ -214,13 +232,29 @@ impl TcpHolePunchRpc for TcpHolePunchServer {
             "tcp hole punch rpc responding with listener mapped addr and start connecting"
         );
 
-        let peer_mgr = self.peer_mgr.clone();
-        self.tasks.lock().unwrap().spawn(async move {
-            let _ = try_connect_to_remote(peer_mgr, a_mapped_addr, local_port, true, 5).await;
-        });
+        // Atomic dedup: DashSet::insert returns true if value was newly inserted
+        let peer_key = a_mapped_addr;
+        let connecting_peers = self.connecting_peers.clone();
+
+        if connecting_peers.insert(peer_key) {
+            // Successfully inserted - we are the first to try connecting to this peer
+            let peer_mgr = self.peer_mgr.clone();
+            let connecting_peers_clone = connecting_peers.clone();
+            self.tasks.lock().unwrap().spawn(async move {
+                let _ = try_connect_with_socket(peer_mgr, socket, a_mapped_addr, local_port, true).await;
+                connecting_peers_clone.remove(&peer_key);
+            });
+        } else {
+            // Already existed - another task is already connecting to this peer
+            tracing::debug!(
+                ?a_mapped_addr,
+                "tcp hole punch server already connecting to this peer, skipping duplicate task"
+            );
+        }
 
         Ok(TcpHolePunchResponse {
             listener_mapped_addr: Some(mapped_addr.into()),
+            tcp_nat_type: my_tcp_nat_type as i32,
         })
     }
 }
@@ -228,6 +262,9 @@ impl TcpHolePunchRpc for TcpHolePunchServer {
 struct TcpHolePunchConnectorData {
     peer_mgr: Arc<PeerManager>,
     blacklist: Arc<timedmap::TimedMap<PeerId, ()>>,
+    // Track peers we're already connecting to, to avoid duplicate tasks
+    // DashSet::insert returns true if value was newly inserted (atomic operation)
+    connecting_peers: Arc<dashmap::DashSet<PeerId>>,
 }
 
 impl TcpHolePunchConnectorData {
@@ -235,10 +272,20 @@ impl TcpHolePunchConnectorData {
         Arc::new(Self {
             peer_mgr,
             blacklist: Arc::new(timedmap::TimedMap::new()),
+            connecting_peers: Arc::new(dashmap::DashSet::new()),
         })
     }
 
     async fn punch_as_initiator(self: Arc<Self>, dst_peer_id: PeerId) -> Result<(), Error> {
+        // Atomic dedup: DashSet::insert returns true if value was newly inserted
+        if !self.connecting_peers.insert(dst_peer_id) {
+            tracing::debug!(
+                dst_peer_id,
+                "tcp hole punch initiator skipped (already connecting)"
+            );
+            return Ok(());
+        }
+
         let mut backoff = BackOff::new(vec![1000, 1000, 4000, 8000]);
 
         loop {
@@ -255,6 +302,9 @@ impl TcpHolePunchConnectorData {
                 break;
             }
         }
+
+        // Remove from connecting set
+        self.connecting_peers.remove(&dst_peer_id);
 
         Ok(())
     }
@@ -275,12 +325,16 @@ impl TcpHolePunchConnectorData {
             return Ok(());
         }
 
-        let local_port = select_local_port(&self.peer_mgr, false).await?;
-        let mapped_addr = global_ctx
-            .get_stun_info_collector()
-            .get_tcp_port_mapping(local_port)
-            .await
-            .with_context(|| "failed to get tcp port mapping")?;
+        // Create bound socket for simultaneous open (no TOCTOU)
+        let (socket, local_port) = create_bound_socket(&self.peer_mgr, false).await?;
+        let listener_url = format!("tcp://0.0.0.0:{}", local_port).parse().unwrap();
+        let (mapped_addr, _port_mapping_lease) = upnp::resolve_tcp_public_addr(
+            global_ctx.clone(),
+            &listener_url,
+            local_port,
+        )
+        .await
+        .with_context(|| "failed to get tcp port mapping")?;
 
         tracing::info!(
             dst_peer_id,
@@ -315,18 +369,33 @@ impl TcpHolePunchConnectorData {
             .listener_mapped_addr
             .ok_or(anyhow::anyhow!("listener_mapped_addr is required"))?;
         let remote_mapped_addr: SocketAddr = remote_mapped_addr.into();
+        let remote_tcp_nat_type = NatType::try_from(resp.tcp_nat_type).unwrap_or(NatType::Unknown);
         tracing::info!(
             dst_peer_id,
             ?remote_mapped_addr,
+            ?remote_tcp_nat_type,
             "tcp hole punch initiator rpc returned"
         );
 
-        if let Ok(()) = try_connect_to_remote(
+        // If we are symmetric NAT (NAT4) and remote is FullCone (NAT1),
+        // add a small delay to let the remote side establish their mapping first
+        if is_symmetric_tcp_nat(my_tcp_nat_type) && remote_tcp_nat_type == NatType::FullCone {
+            tracing::info!(
+                dst_peer_id,
+                ?my_tcp_nat_type,
+                ?remote_tcp_nat_type,
+                "tcp hole punch initiator: symmetric NAT waiting for fullcone peer"
+            );
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+
+        // Use the pre-bound socket for simultaneous open
+        if let Ok(()) = try_connect_with_socket(
             self.peer_mgr.clone(),
+            socket,
             remote_mapped_addr,
             local_port,
             false,
-            1,
         )
         .await
         {
@@ -343,60 +412,128 @@ impl TcpHolePunchConnectorData {
             dst_peer_id,
             local_port,
             ?remote_mapped_addr,
-            "tcp hole punch initiator sent syn to remote mapped addr"
+            "tcp hole punch initiator simultaneous open failed"
         );
 
-        let mut listener =
-            TcpTunnelListener::new(format!("tcp://0.0.0.0:{}", local_port).parse().unwrap());
-        {
-            let _g = self.peer_mgr.get_global_ctx().net_ns.guard();
-            listener.listen().await?;
-        }
-        tracing::info!(
-            dst_peer_id,
-            local_port,
-            url = %listener.local_url(),
-            "tcp hole punch initiator listening"
-        );
+        // If we are NAT1 (FullCone), try STUN traversal with a DIFFERENT port
+        // Using a different port avoids conflicts between simultaneous open and listening
+        if my_tcp_nat_type == NatType::FullCone {
+            tracing::info!(
+                dst_peer_id,
+                ?my_tcp_nat_type,
+                "tcp hole punch initiator trying STUN traversal for NAT1"
+            );
 
-        tokio::time::timeout(
-            Duration::from_secs(10),
-            self.accept_loop(&mut listener, dst_peer_id),
-        )
-        .await??;
+            // Create a bound socket for STUN traversal
+            let (stun_socket, stun_port) = create_bound_socket(&self.peer_mgr, false).await?;
+            let stun_listener_url = format!("tcp://0.0.0.0:{}", stun_port).parse().unwrap();
+            let (public_addr, _stun_lease) = upnp::resolve_tcp_public_addr(
+                global_ctx.clone(),
+                &stun_listener_url,
+                stun_port,
+            )
+            .await
+            .with_context(|| "failed to get tcp port mapping for STUN")?;
 
-        tracing::info!(
-            dst_peer_id,
-            "tcp hole punch initiator accepted and added server tunnel"
-        );
+            tracing::info!(
+                dst_peer_id,
+                stun_port,
+                ?public_addr,
+                "tcp hole punch initiator got public address via STUN for NAT1"
+            );
 
-        Ok(())
-    }
+            // Convert TcpSocket to TcpListener directly - port is never released
+            let tcp_listener = stun_socket.listen(128)?;
+            let mut listener = TcpTunnelListener::from_listener(tcp_listener, stun_listener_url);
 
-    async fn accept_loop(
-        &self,
-        listener: &mut TcpTunnelListener,
-        dst_peer_id: PeerId,
-    ) -> Result<(), Error> {
-        loop {
-            match listener.accept().await {
-                Ok(tunnel) => {
-                    if let Err(e) = self.peer_mgr.add_tunnel_as_server(tunnel, false).await {
-                        tracing::error!("tcp hole punch add tunnel error: {}", e);
-                        continue;
-                    }
+            // Report the public listening address to other nodes via RPC
+            let rpc_stub = self
+                .peer_mgr
+                .get_peer_rpc_mgr()
+                .rpc_client()
+                .scoped_client::<TcpHolePunchRpcClientFactory<BaseController>>(
+                    self.peer_mgr.my_peer_id(),
+                    dst_peer_id,
+                    global_ctx.get_network_name(),
+                );
 
+            // Send the public address to the remote peer
+            let report_resp = rpc_stub
+                .exchange_mapped_addr(
+                    BaseController {
+                        timeout_ms: 6000,
+                        ..Default::default()
+                    },
+                    TcpHolePunchRequest {
+                        connector_mapped_addr: Some(public_addr.into()),
+                    },
+                )
+                .await;
+
+            match report_resp {
+                Ok(_) => {
                     tracing::info!(
                         dst_peer_id,
-                        "tcp hole punch initiator accepted and added server tunnel"
+                        stun_port,
+                        ?public_addr,
+                        "tcp hole punch initiator reported public listening address for NAT1"
                     );
                 }
                 Err(e) => {
-                    tracing::error!("tcp hole punch accept error: {}", e);
+                    tracing::warn!(
+                        dst_peer_id,
+                        stun_port,
+                        ?public_addr,
+                        ?e,
+                        "tcp hole punch initiator failed to report public listening address"
+                    );
                 }
             }
+
+            // Spawn a task to accept connections on the STUN listener
+            // This keeps the listener alive and accepts incoming connections
+            let peer_mgr_clone = self.peer_mgr.clone();
+            tokio::spawn(async move {
+                let timeout = Duration::from_secs(30);
+                let start = tokio::time::Instant::now();
+
+                loop {
+                    if start.elapsed() >= timeout {
+                        tracing::info!(stun_port, "stun listener accept loop timeout, shutting down");
+                        break;
+                    }
+
+                    match tokio::time::timeout(Duration::from_secs(5), listener.accept()).await {
+                        Ok(Ok(tunnel)) => {
+                            tracing::info!(stun_port, "stun listener accepted connection");
+                            if let Err(e) = peer_mgr_clone.add_tunnel_as_server(tunnel, false).await {
+                                tracing::error!(?e, "stun listener failed to add tunnel");
+                            } else {
+                                tracing::info!(stun_port, "stun listener added tunnel successfully");
+                                break; // Successfully connected, exit loop
+                            }
+                        }
+                        Ok(Err(e)) => {
+                            tracing::warn!(?e, stun_port, "stun listener accept error");
+                            break;
+                        }
+                        Err(_) => {
+                            // Timeout, continue loop
+                            continue;
+                        }
+                    }
+                }
+
+                tracing::info!(stun_port, "stun listener accept loop exited");
+            });
+
+            return Ok(());
         }
+
+        Err(anyhow::anyhow!("tcp hole punch simultaneous open failed"))
     }
+
+
 }
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]

--- a/easytier/src/instance/instance.rs
+++ b/easytier/src/instance/instance.rs
@@ -650,6 +650,7 @@ pub struct Instance {
 impl Instance {
     pub fn new(config: impl ConfigLoader + 'static) -> Self {
         let global_ctx = Arc::new(GlobalCtx::new(config));
+        global_ctx.set_global_ctx_after_init();
 
         tracing::info!(
             "[INIT] instance creating. config: {}",

--- a/easytier/src/instance_manager.rs
+++ b/easytier/src/instance_manager.rs
@@ -563,6 +563,10 @@ fn handle_event(
                         }
                     }
 
+                    GlobalCtxEvent::TcpNatTypeDetected => {
+                        event!(debug, "[{}] TCP NAT type detected", instance_id);
+                    }
+
                     GlobalCtxEvent::CredentialChanged => {
                         event!(info, "[{}] credential changed", instance_id);
                     }

--- a/easytier/src/proto/peer_rpc.proto
+++ b/easytier/src/proto/peer_rpc.proto
@@ -273,7 +273,10 @@ service UdpHolePunchRpc {
 
 message TcpHolePunchRequest { common.SocketAddr connector_mapped_addr = 1; }
 
-message TcpHolePunchResponse { common.SocketAddr listener_mapped_addr = 1; }
+message TcpHolePunchResponse {
+  common.SocketAddr listener_mapped_addr = 1;
+  common.NatType tcp_nat_type = 2;
+}
 
 service TcpHolePunchRpc {
   rpc ExchangeMappedAddr(TcpHolePunchRequest) returns (TcpHolePunchResponse);

--- a/easytier/src/tunnel/tcp.rs
+++ b/easytier/src/tunnel/tcp.rs
@@ -29,6 +29,16 @@ impl TcpTunnelListener {
         }
     }
 
+    /// Create a TcpTunnelListener from an existing TcpListener.
+    /// This avoids TOCTOU when converting from TcpSocket to listener.
+    pub fn from_listener(listener: TcpListener, addr: url::Url) -> Self {
+        TcpTunnelListener {
+            addr,
+            listener: Some(listener),
+            socket_mark: None,
+        }
+    }
+
     pub fn set_socket_mark(&mut self, socket_mark: Option<u32>) {
         self.socket_mark = socket_mark;
     }
@@ -106,7 +116,7 @@ impl TunnelListener for TcpTunnelListener {
     }
 }
 
-fn get_tunnel_with_tcp_stream(
+pub fn get_tunnel_with_tcp_stream(
     stream: TcpStream,
     remote_url: url::Url,
 ) -> Result<Box<dyn Tunnel>, super::TunnelError> {


### PR DESCRIPTION
## 核心修复

### 1. STUN traversal 回退机制
当 simultaneous open 失败后，NAT1 (FullCone) 会：
- 创建新的监听端口
- 通过 STUN 获取公网地址
- 等待 NAT4 (Symmetric) 连接

```rust
// Simultaneous open 失败后尝试 STUN traversal
if my_tcp_nat_type == NatType::FullCone {
    // 创建新端口 → STUN 获取公网地址 → 监听等待 NAT4 连接
}
2. UPnP 映射生命周期管理
// 持有 lease 引用，drop 时自动清理
struct TcpPortMappingLease {
    stop_tx: Option<oneshot::Sender<()>>, // drop 时发送停止信号
}
3. 防止重复任务
// connecting_peers 去重检查
if data.connecting_peers.contains(&peer_id) {
    continue; // 跳过已在连接中的 peer
}
4. 端口复用
// 复用 NAT 检测阶段创建的端口映射
fn get_nat_detection_tcp_port(&self) -> Option<u16> {
    let tcp_result = self.tcp_nat_test_result.read().unwrap();
    tcp_result.as_ref().map(|r| r.source_addr.port())
}
测试验证
- ✅ Simultaneous open 失败后 NAT1 能监听端口等待 NAT4 连接
- ✅ UPnP 映射不再重复创建
- ✅ hole punch 失败后正确清理 UPnP 映射
- ✅ 同一 peer 不会发起重复的 hole punch 任务