### PR TITLE
fix: preserve secure relay sessions during cleanup

### DIFF
--- a/easytier/src/peers/peer_conn.rs
+++ b/easytier/src/peers/peer_conn.rs
@@ -174,7 +174,8 @@ impl TunnelFilter for PeerSessionTunnelFilter {
             return Some(data);
         }
 
-        let Some(session) = self.session.load_full() else {
+        let session_guard = self.session.load();
+        let Some(session) = session_guard.as_deref() else {
             return Some(data);
         };
         if let Err(e) = session.encrypt_payload(my_peer_id, peer_id, &mut data) {
@@ -221,7 +222,8 @@ impl TunnelFilter for PeerSessionTunnelFilter {
             return Some(Ok(data));
         }
 
-        let Some(session) = self.session.load_full() else {
+        let session_guard = self.session.load();
+        let Some(session) = session_guard.as_deref() else {
             return Some(Ok(data));
         };
 

--- a/easytier/src/peers/peer_conn.rs
+++ b/easytier/src/peers/peer_conn.rs
@@ -1,3 +1,4 @@
+use arc_swap::ArcSwapOption;
 use crossbeam::atomic::AtomicCell;
 use futures::{StreamExt, TryFutureExt};
 use std::{
@@ -11,11 +12,7 @@ use std::{
 };
 
 #[cfg(feature = "hotpath")]
-use hotpath::wrap::std::sync::Mutex as StdMutex;
-#[cfg(feature = "hotpath")]
 use hotpath::wrap::tokio::sync::Mutex;
-#[cfg(not(feature = "hotpath"))]
-use std::sync::Mutex as StdMutex;
 #[cfg(not(feature = "hotpath"))]
 use tokio::sync::Mutex;
 
@@ -107,7 +104,7 @@ struct PeerSessionTunnelFilter {
     enabled: bool,
     my_peer_id: Arc<AtomicCell<PeerId>>,
     peer_id: Arc<AtomicCell<Option<PeerId>>>,
-    session: Arc<StdMutex<Option<Arc<PeerSession>>>>,
+    session: Arc<ArcSwapOption<PeerSession>>,
 }
 
 impl PeerSessionTunnelFilter {
@@ -116,7 +113,7 @@ impl PeerSessionTunnelFilter {
             enabled,
             my_peer_id: Arc::new(AtomicCell::new(PeerId::default())),
             peer_id: Arc::new(AtomicCell::new(None)),
-            session: Arc::new(hotpath::mutex!(std::sync::Mutex::new(None))),
+            session: Arc::new(ArcSwapOption::empty()),
         }
     }
 
@@ -125,7 +122,7 @@ impl PeerSessionTunnelFilter {
             enabled,
             my_peer_id: Arc::new(AtomicCell::new(my_peer_id)),
             peer_id: Arc::new(AtomicCell::new(None)),
-            session: Arc::new(hotpath::mutex!(std::sync::Mutex::new(None))),
+            session: Arc::new(ArcSwapOption::empty()),
         }
     }
 
@@ -138,7 +135,7 @@ impl PeerSessionTunnelFilter {
     }
 
     fn set_session(&self, session: Arc<PeerSession>) {
-        *self.session.lock().unwrap() = Some(session);
+        self.session.store(Some(session));
     }
 
     fn should_skip_encrypt(&self, hdr: &crate::tunnel::packet_def::PeerManagerHeader) -> bool {
@@ -172,16 +169,14 @@ impl TunnelFilter for PeerSessionTunnelFilter {
             return Some(data);
         };
 
-        let mut guard = self.session.lock().unwrap();
-        let Some(session) = guard.as_mut() else {
-            return Some(data);
-        };
-
         let my_peer_id = self.my_peer_id.load();
-        if my_peer_id != hdr.from_peer_id.get() {
+        if my_peer_id != hdr.from_peer_id.get() || hdr.to_peer_id.get() != peer_id {
             return Some(data);
         }
 
+        let Some(session) = self.session.load_full() else {
+            return Some(data);
+        };
         if let Err(e) = session.encrypt_payload(my_peer_id, peer_id, &mut data) {
             tracing::warn!(
                 ?my_peer_id,
@@ -226,8 +221,7 @@ impl TunnelFilter for PeerSessionTunnelFilter {
             return Some(Ok(data));
         }
 
-        let mut guard = self.session.lock().unwrap();
-        let Some(session) = guard.as_mut() else {
+        let Some(session) = self.session.load_full() else {
             return Some(Ok(data));
         };
 
@@ -1651,6 +1645,45 @@ pub mod tests {
             )
             .map(|metric| metric.value)
             .unwrap_or(0)
+    }
+
+    #[test]
+    fn peer_session_filter_skips_relay_packet_for_next_hop() {
+        let my_peer_id = 10;
+        let next_hop_peer_id = 20;
+        let dst_peer_id = 30;
+        let filter = PeerSessionTunnelFilter::new_with_peer(my_peer_id, true);
+        filter.set_peer_id(next_hop_peer_id);
+
+        let session = Arc::new(PeerSession::new(
+            next_hop_peer_id,
+            PeerSession::new_root_key(),
+            1,
+            0,
+            "aes-gcm".to_string(),
+            "aes-gcm".to_string(),
+            None,
+        ));
+        session.invalidate();
+        filter.set_session(session);
+
+        let mut packet = ZCPacket::new_with_payload(b"relay payload");
+        packet.fill_peer_manager_hdr(my_peer_id, dst_peer_id, PacketType::Data as u8);
+        packet
+            .mut_peer_manager_header()
+            .unwrap()
+            .set_encrypted(true);
+        let original_len = packet.buf_len();
+
+        let packet = filter
+            .before_send(packet)
+            .expect("relay packet should bypass next-hop session");
+
+        let hdr = packet.peer_manager_header().unwrap();
+        assert_eq!(hdr.from_peer_id.get(), my_peer_id);
+        assert_eq!(hdr.to_peer_id.get(), dst_peer_id);
+        assert!(hdr.is_encrypted());
+        assert_eq!(packet.buf_len(), original_len);
     }
 
     #[tokio::test]

--- a/easytier/src/peers/peer_session.rs
+++ b/easytier/src/peers/peer_session.rs
@@ -2,11 +2,12 @@ use std::sync::{
     Arc, RwLock,
     atomic::{AtomicBool, Ordering},
 };
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use anyhow::anyhow;
 use crossbeam::atomic::AtomicCell;
 use dashmap::DashMap;
+use hotpath::instant::Instant;
 
 use super::secure_datagram::{SecureDatagramDirection, SecureDatagramSession};
 use crate::{
@@ -499,7 +500,6 @@ mod tests {
         ));
         store.insert_session(key.clone(), session);
 
-        std::thread::sleep(Duration::from_millis(1));
         store.evict_unused_sessions_idle(Duration::from_millis(0));
 
         assert!(

--- a/easytier/src/peers/peer_session.rs
+++ b/easytier/src/peers/peer_session.rs
@@ -2,8 +2,10 @@ use std::sync::{
     Arc, RwLock,
     atomic::{AtomicBool, Ordering},
 };
+use std::time::{Duration, Instant};
 
 use anyhow::anyhow;
+use crossbeam::atomic::AtomicCell;
 use dashmap::DashMap;
 
 use super::secure_datagram::{SecureDatagramDirection, SecureDatagramSession};
@@ -11,6 +13,8 @@ use crate::{
     common::{PeerId, shrink_dashmap},
     tunnel::packet_def::ZCPacket,
 };
+
+const SESSION_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 
 pub struct UpsertResponderSessionReturn {
     pub session: Arc<PeerSession>,
@@ -44,7 +48,25 @@ impl SessionKey {
 
 #[derive(Clone)]
 pub struct PeerSessionStore {
-    sessions: Arc<DashMap<SessionKey, Arc<PeerSession>>>,
+    sessions: Arc<DashMap<SessionKey, PeerSessionEntry>>,
+}
+
+struct PeerSessionEntry {
+    session: Arc<PeerSession>,
+    last_used_at: AtomicCell<Instant>,
+}
+
+impl PeerSessionEntry {
+    fn new(session: Arc<PeerSession>) -> Self {
+        Self {
+            session,
+            last_used_at: AtomicCell::new(Instant::now()),
+        }
+    }
+
+    fn touch(&self) {
+        self.last_used_at.store(Instant::now());
+    }
 }
 
 impl Default for PeerSessionStore {
@@ -61,7 +83,11 @@ impl PeerSessionStore {
     }
 
     pub fn get(&self, key: &SessionKey) -> Option<Arc<PeerSession>> {
-        let session = self.sessions.get(key)?.clone();
+        let session = {
+            let entry = self.sessions.get(key)?;
+            entry.touch();
+            entry.session.clone()
+        };
         if session.is_valid() {
             Some(session)
         } else {
@@ -75,12 +101,20 @@ impl PeerSessionStore {
     }
 
     pub fn insert_session(&self, key: SessionKey, session: Arc<PeerSession>) {
-        self.sessions.insert(key, session);
+        self.sessions.insert(key, PeerSessionEntry::new(session));
     }
 
     pub fn evict_unused_sessions(&self) {
-        self.sessions
-            .retain(|_key, session| Arc::strong_count(session) > 1);
+        self.evict_unused_sessions_idle(SESSION_IDLE_TIMEOUT);
+    }
+
+    pub fn evict_unused_sessions_idle(&self, idle: Duration) {
+        let now = Instant::now();
+        self.sessions.retain(|_key, entry| {
+            entry.session.is_valid()
+                && (Arc::strong_count(&entry.session) > 1
+                    || now.saturating_duration_since(entry.last_used_at.load()) < idle)
+        });
         shrink_dashmap(&self.sessions, None);
     }
 
@@ -93,11 +127,14 @@ impl PeerSessionStore {
         recv_algorithm: String,
         peer_static_pubkey: Option<[u8; 32]>,
     ) -> Result<UpsertResponderSessionReturn, anyhow::Error> {
-        tracing::event!(tracing::Level::INFO, "upsert_responder_session {:?}", key);
+        tracing::event!(tracing::Level::INFO, ?key, "upsert_responder_session");
         let existing = self
             .sessions
             .get(key)
-            .map(|v| v.clone())
+            .map(|v| {
+                v.touch();
+                v.session.clone()
+            })
             .filter(|s| s.is_valid());
         match existing {
             None => {
@@ -113,7 +150,8 @@ impl PeerSessionStore {
                     recv_algorithm,
                     peer_static_pubkey,
                 ));
-                self.sessions.insert(key.clone(), session.clone());
+                self.sessions
+                    .insert(key.clone(), PeerSessionEntry::new(session.clone()));
                 Ok(UpsertResponderSessionReturn {
                     session,
                     action: PeerSessionAction::Create,
@@ -178,16 +216,14 @@ impl PeerSessionStore {
             PeerSessionAction::Sync | PeerSessionAction::Create => {
                 let root_key = root_key_32.ok_or_else(|| anyhow!("missing root_key"))?;
                 if let Some(existing) = self.sessions.get(key)
-                    && !existing.is_valid()
+                    && !existing.session.is_valid()
                 {
                     drop(existing);
                     self.sessions.remove(key);
                 }
-                let session = self
-                    .sessions
-                    .entry(key.clone())
-                    .or_insert_with(|| {
-                        Arc::new(PeerSession::new(
+                let session = {
+                    let entry = self.sessions.entry(key.clone()).or_insert_with(|| {
+                        PeerSessionEntry::new(Arc::new(PeerSession::new(
                             key.peer_id,
                             root_key,
                             b_session_generation,
@@ -195,9 +231,11 @@ impl PeerSessionStore {
                             send_algorithm.clone(),
                             recv_algorithm.clone(),
                             peer_static_pubkey,
-                        ))
-                    })
-                    .clone();
+                        )))
+                    });
+                    entry.touch();
+                    entry.session.clone()
+                };
                 session.check_encrypt_algo_same(&send_algorithm, &recv_algorithm)?;
                 session.check_or_set_peer_static_pubkey(peer_static_pubkey)?;
                 session.sync_root_key(
@@ -419,6 +457,80 @@ mod tests {
         assert_eq!(
             PeerSession::SYNC_RX_GRACE_AFTER_MS,
             SecureDatagramSession::SYNC_RX_GRACE_AFTER_MS
+        );
+    }
+
+    #[test]
+    fn peer_session_store_keeps_recent_session_without_external_refs() {
+        let store = PeerSessionStore::new();
+        let key = SessionKey::new("net".to_string(), 20);
+        let session = Arc::new(PeerSession::new(
+            20,
+            PeerSession::new_root_key(),
+            1,
+            0,
+            "aes-gcm".to_string(),
+            "aes-gcm".to_string(),
+            None,
+        ));
+        store.insert_session(key.clone(), session);
+
+        assert!(store.get(&key).is_some());
+        store.evict_unused_sessions();
+
+        assert!(
+            store.get(&key).is_some(),
+            "recent relay sessions should survive the periodic GC"
+        );
+    }
+
+    #[test]
+    fn peer_session_store_evicts_idle_session_without_external_refs() {
+        let store = PeerSessionStore::new();
+        let key = SessionKey::new("net".to_string(), 20);
+        let session = Arc::new(PeerSession::new(
+            20,
+            PeerSession::new_root_key(),
+            1,
+            0,
+            "aes-gcm".to_string(),
+            "aes-gcm".to_string(),
+            None,
+        ));
+        store.insert_session(key.clone(), session);
+
+        std::thread::sleep(Duration::from_millis(1));
+        store.evict_unused_sessions_idle(Duration::from_millis(0));
+
+        assert!(
+            store.get(&key).is_none(),
+            "idle sessions without external users should still be collected"
+        );
+    }
+
+    #[test]
+    fn peer_session_store_evicts_invalid_recent_session() {
+        let store = PeerSessionStore::new();
+        let key = SessionKey::new("net".to_string(), 20);
+        let session = Arc::new(PeerSession::new(
+            20,
+            PeerSession::new_root_key(),
+            1,
+            0,
+            "aes-gcm".to_string(),
+            "aes-gcm".to_string(),
+            None,
+        ));
+        store.insert_session(key.clone(), session);
+
+        let session = store.get(&key).unwrap();
+        session.invalidate();
+        drop(session);
+        store.evict_unused_sessions();
+
+        assert!(
+            !store.sessions.contains_key(&key),
+            "invalid sessions should not be kept by recent activity"
         );
     }
 }

--- a/easytier/src/tests/three_node.rs
+++ b/easytier/src/tests/three_node.rs
@@ -4340,7 +4340,7 @@ pub async fn relay_peer_session_cleanup() {
     insts[0]
         .get_peer_manager()
         .get_peer_session_store()
-        .evict_unused_sessions();
+        .evict_unused_sessions_idle(Duration::from_millis(0));
 
     wait_for_condition(
         || async { !relay_map_1.has_session(inst3_peer_id) },


### PR DESCRIPTION
## Summary
- Skip peer-session encryption for relay packets whose final destination is beyond the current next hop, so already-encrypted relay traffic is forwarded unchanged.
- Track peer-session recency in `PeerSessionStore` so valid recently used secure relay sessions survive periodic GC even when the store is the only owner.
- Keep explicit idle-session eviction available for cleanup paths and update the relay cleanup test to force that behavior.

## Why
Secure relay traffic can rely on peer-session state that is only held by the session store between packets. The previous GC policy removed sessions based only on `Arc::strong_count`, which could drop a still-active relay session. In the next-hop path, the tunnel filter could also try to apply the next-hop session to packets whose final destination was another peer.

## Tests
- `cargo fmt --all -- --check`
- `cargo test -p easytier peer_session_store_ --lib`
- `cargo test -p easytier peer_session_filter_skips_relay_packet_for_next_hop --lib`
- `docker exec rust bash -lc 'cd /data/project/EasyTier-peer-session && cargo test -p easytier relay_peer_session_cleanup --features full -- --nocapture --test-threads=1'`