### PR TITLE
feat(gui,web): add secure mode toggle to GUI network config

### DIFF
--- a/easytier-web/frontend-lib/src/components/Config.vue
+++ b/easytier-web/frontend-lib/src/components/Config.vue
@@ -195,6 +195,13 @@ const instanceRecvBpsLimitInput = computed<string>({
     }
   },
 })
+
+const secureModeEnabled = computed<boolean>({
+  get: () => curNetwork.value.secure_mode?.enabled ?? false,
+  set: (value) => {
+    curNetwork.value.secure_mode = { ...(curNetwork.value.secure_mode ?? {}), enabled: value }
+  },
+})
 </script>
 
 <template>
@@ -269,6 +276,12 @@ const instanceRecvBpsLimitInput = computed<string>({
                       <Checkbox v-model="curNetwork[flag.field]" :input-id="flag.field" :binary="true" />
                       <label :for="flag.field" class="ml-2"> {{ t(flag.field) }} </label>
                       <span class="pi pi-question-circle ml-2 self-center" v-tooltip="t(flag.help)"></span>
+                    </div>
+
+                    <div class="basis-[20rem] flex items-center">
+                      <Checkbox v-model="secureModeEnabled" input-id="secure_mode" :binary="true" />
+                      <label for="secure_mode" class="ml-2"> {{ t('secure_mode') }} </label>
+                      <span class="pi pi-question-circle ml-2 self-center" v-tooltip="t('secure_mode_help')"></span>
                     </div>
 
                   </div>

--- a/easytier-web/frontend-lib/src/locales/cn.yaml
+++ b/easytier-web/frontend-lib/src/locales/cn.yaml
@@ -15,6 +15,8 @@ virtual_ipv4: 虚拟IPv4地址
 virtual_ipv4_dhcp: DHCP
 network_name: 网络名称
 network_secret: 网络密码
+secure_mode: 安全模式
+secure_mode_help: 使用每个节点独立的 X25519 密钥对进行端到端认证加密（通过公钥校验对端身份），比默认基于网络密码的加密更强。与“禁用加密”不同：“禁用加密”只是把默认流量加密整体开关，而“安全模式”升级的是对端身份认证与密钥交换方式。同一网络内所有节点必须设置一致，否则连接会被拒绝。等同于命令行的 --secure-mode 参数。
 public_server_url: 公共服务器地址
 peer_urls: 对等节点地址
 proxy_cidrs: 子网代理CIDR

--- a/easytier-web/frontend-lib/src/locales/en.yaml
+++ b/easytier-web/frontend-lib/src/locales/en.yaml
@@ -15,6 +15,8 @@ virtual_ipv4: Virtual IPv4
 virtual_ipv4_dhcp: DHCP
 network_name: Network Name
 network_secret: Network Secret
+secure_mode: Secure Mode
+secure_mode_help: Authenticated end-to-end encryption using a per-node X25519 key pair (peers are verified by public key) — a stronger scheme than the default network-secret encryption. Unlike "Disable Encryption", which only turns the default traffic encryption on or off, Secure Mode upgrades how peers authenticate and exchange keys. All peers in the network must use the same setting or the connection is rejected. Same as the --secure-mode CLI flag.
 public_server_url: Public Server URL
 peer_urls: Peer URLs
 proxy_cidrs: Subnet Proxy CIDRs

--- a/easytier-web/frontend-lib/src/types/network.ts
+++ b/easytier-web/frontend-lib/src/types/network.ts
@@ -83,6 +83,7 @@ export function DEFAULT_NETWORK_CONFIG(): NetworkConfig {
     network_name: 'easytier',
     network_secret: '',
     credential_file: '',
+    secure_mode: { enabled: false },
 
     networking_method: NetworkingMethod.Manual,
     public_server_url: '',


### PR DESCRIPTION
## What this PR fixes
  EasyTier's CLI has a `--secure-mode` flag (nodes authenticate and encrypt end-to-end
  using their own X25519 keys). The problem: there was no way to turn it on in the GUI.

  As a result, if a peer node is started with `--secure-mode`, the GUI can never connect
  to it and just fails with:

  > secret key error: same-network peers must use the same secure mode

  All nodes in the same network must have the same "secure mode" setting, but the GUI's was
  permanently off with no way to enable it.

  ## What changed

  Added a "Secure Mode" toggle in the **Advanced Settings** of the config screen, right next
  to "Disable Encryption".

  - When enabled, the config carries `secure_mode.enabled = true`, which is equivalent to the
    CLI's `--secure-mode`.
  - Desktop and Android share the same config component, so both platforms get it.

  ## Clarified the difference between the two (in the help text)

  "Secure Mode" and the neighboring "Disable Encryption" are easy to confuse, so the tooltip
  now spells it out:

  - **Disable Encryption**: only turns the default (network-secret-based) traffic encryption
    on or off.
  - **Secure Mode**: upgrades *how peers authenticate each other and exchange keys* — using
    each node's own X25519 key pair, verifying peers by public key. A stronger scheme than the
    default.

  Both require every node in the network to use the same setting, otherwise the connection is
  rejected.

  ## Where it lives in the UI

  Config screen → Advanced Settings → Feature Switch section, side by side with "Disable Encryption".
  
  
<img width="599" height="907" alt="image" src="https://github.com/user-attachments/assets/873efea8-f242-4355-96fa-88537b2565a1" />

