### PR TITLE
fix(web): use dynamic listener ports for new networks

### DIFF
--- a/easytier-web/frontend-lib/src/components/Config.vue
+++ b/easytier-web/frontend-lib/src/components/Config.vue
@@ -21,8 +21,7 @@ const props = defineProps<{
 
 defineEmits(['runNetwork'])
 
-const curNetwork = defineModel('curNetwork', {
-  type: Object as () => NetworkConfig,
+const curNetwork = defineModel<NetworkConfig>('curNetwork', {
   default: DEFAULT_NETWORK_CONFIG,
 })
 
@@ -41,6 +40,19 @@ const protos: { [proto: string]: number } = {
   txt: 0,
   srv: 0,
 }
+
+const listenerProtos: { [proto: string]: number } = {
+  ...protos,
+  tcp: 0,
+  udp: 0,
+  wg: 0,
+  ws: 0,
+  wss: 0,
+  quic: 0,
+  faketcp: 0,
+}
+
+const portlessProtos = ['txt', 'srv']
 
 const inetSuggestions = ref([''])
 
@@ -320,8 +332,8 @@ const instanceRecvBpsLimitInput = computed<string>({
               <div class="flex flex-row gap-x-9 flex-wrap">
                 <div class="flex flex-col gap-2 grow p-fluid">
                   <label for="listener_urls">{{ t('listener_urls') }}</label>
-                  <UrlListInput v-model="curNetwork.listener_urls" :protos="protos" :add-label="t('add_listener_url')"
-                    placeholder="0.0.0.0" />
+                  <UrlListInput v-model="curNetwork.listener_urls" :protos="listenerProtos"
+                    :portless-protos="portlessProtos" :add-label="t('add_listener_url')" placeholder="0.0.0.0" />
                 </div>
               </div>
 

--- a/easytier-web/frontend-lib/src/components/UrlInput.vue
+++ b/easytier-web/frontend-lib/src/components/UrlInput.vue
@@ -8,17 +8,19 @@ import { useI18n } from 'vue-i18n'
 const props = defineProps<{
     placeholder?: string
     protos: { [proto: string]: number }
+    portlessProtos?: string[]
 }>()
 
 const { t } = useI18n()
 const url = defineModel<string>({ required: true })
 const editing = ref(false)
 const hostFocused = ref(false)
+const fallbackPort = 0
 
 const parseUrl = (val: string | null | undefined): { proto: string; host: string; port: number | null } => {
     const getValidPort = (portStr: string, proto: string) => {
         const p = parseInt(portStr)
-        return isNaN(p) ? (props.protos[proto] ?? 11010) : p
+        return isNaN(p) ? (props.protos[proto] ?? fallbackPort) : p
     }
     const parseByPattern = (input: string) => {
         const trimmed = input.trim()
@@ -52,7 +54,7 @@ const parseUrl = (val: string | null | undefined): { proto: string; host: string
     }
 
     if (!val) {
-        return { proto: 'tcp', host: '', port: props.protos['tcp'] ?? 11010 }
+        return { proto: 'tcp', host: '', port: props.protos['tcp'] ?? fallbackPort }
     }
     const parsedByPattern = parseByPattern(val)
     if (parsedByPattern) {
@@ -63,6 +65,9 @@ const parseUrl = (val: string | null | undefined): { proto: string; host: string
 
 const internalValue = ref(parseUrl(url.value))
 const defaultHost = '0.0.0.0'
+const isPortlessProto = (proto: string) => {
+    return props.portlessProtos?.includes(proto) ?? props.protos[proto] === 0
+}
 
 const buildUrlValue = (value: { proto: string, host: string, port: number | null }, forceDefaultHost = false) => {
     const proto = value.proto || 'tcp'
@@ -71,10 +76,9 @@ const buildUrlValue = (value: { proto: string, host: string, port: number | null
     if (!host) {
         return null
     }
-    // Omit port when the protocol uses no port (protos value = 0), or when the
-    // original URL had no explicit port (port === null) – avoids overwriting an
-    // implicit standard port (e.g. 443 for wss) with an EasyTier default (11012).
-    if (props.protos[proto] === 0 || value.port === null) {
+    // Omit port for portless protocols or when the original URL had no explicit
+    // port, avoiding overwriting an implicit standard port (e.g. 443 for wss).
+    if (isPortlessProto(proto) || value.port === null) {
         return `${proto}://${host}`
     }
     return `${proto}://${host}:${value.port}`
@@ -103,7 +107,11 @@ const onDialogConfirm = () => {
 }
 
 const isNoPortProto = computed(() => {
-    return props.protos[internalValue.value.proto] === 0
+    return isPortlessProto(internalValue.value.proto)
+})
+
+const portInputMin = computed(() => {
+    return props.protos[internalValue.value.proto] === 0 ? 0 : 1
 })
 
 // Sync from external
@@ -163,8 +171,8 @@ const onProtoChange = (newProto: string) => {
                 <InputGroupAddon>
                     <span style="font-weight: bold">:</span>
                 </InputGroupAddon>
-                <InputNumber v-model="internalValue.port" :format="false" :min="1" :max="65535" class="max-w-24"
-                    :placeholder="String(protos[internalValue.proto] ?? 11010)" fluid />
+                <InputNumber v-model="internalValue.port" :format="false" :min="portInputMin" :max="65535"
+                    class="max-w-24" :placeholder="String(protos[internalValue.proto] ?? fallbackPort)" fluid />
             </template>
             <!-- Rendered in both responsive branches; keep action slot content free of side effects and duplicate IDs. -->
             <slot name="actions"></slot>
@@ -194,8 +202,8 @@ const onProtoChange = (newProto: string) => {
                 </div>
                 <div v-if="!isNoPortProto" class="flex flex-col gap-2">
                     <label>{{ t('port') }}</label>
-                    <InputNumber v-model="internalValue.port" :format="false" :min="1" :max="65535" class="w-full"
-                        :placeholder="String(protos[internalValue.proto] ?? 11010)" />
+                    <InputNumber v-model="internalValue.port" :format="false" :min="portInputMin" :max="65535" class="w-full"
+                        :placeholder="String(protos[internalValue.proto] ?? fallbackPort)" />
                 </div>
             </div>
             <template #footer>

--- a/easytier-web/frontend-lib/src/components/UrlListInput.vue
+++ b/easytier-web/frontend-lib/src/components/UrlListInput.vue
@@ -4,6 +4,7 @@ import UrlInput from './UrlInput.vue'
 
 const props = defineProps<{
     protos: { [proto: string]: number }
+    portlessProtos?: string[]
     addLabel: string
     placeholder?: string
     defaultUrl?: string
@@ -12,7 +13,7 @@ const props = defineProps<{
 const list = defineModel<string[]>({ required: true })
 
 const addUrl = () => {
-    list.value.push(props.defaultUrl || 'tcp://0.0.0.0:11010')
+    list.value.push(props.defaultUrl || 'tcp://0.0.0.0:0')
 }
 
 const removeUrl = (index: number) => {
@@ -23,7 +24,8 @@ const removeUrl = (index: number) => {
 <template>
     <div class="flex flex-col gap-y-2 w-full">
         <div v-for="(_, index) in list" :key="index" class="flex gap-2 items-center w-full">
-            <UrlInput v-model="list[index]" :protos="protos" :placeholder="placeholder">
+            <UrlInput v-model="list[index]" :protos="protos" :portless-protos="portlessProtos"
+                :placeholder="placeholder">
                 <template #actions>
                     <Button icon="pi pi-trash" severity="danger" text rounded @click="removeUrl(index)" />
                 </template>

--- a/easytier-web/frontend-lib/src/types/network.ts
+++ b/easytier-web/frontend-lib/src/types/network.ts
@@ -98,9 +98,9 @@ export function DEFAULT_NETWORK_CONFIG(): NetworkConfig {
     advanced_settings: false,
 
     listener_urls: [
-      'tcp://0.0.0.0:11010',
-      'udp://0.0.0.0:11010',
-      'wg://0.0.0.0:11011',
+      'tcp://0.0.0.0:0',
+      'udp://0.0.0.0:0',
+      'wg://0.0.0.0:0',
     ],
     latency_first: false,
     dev_name: '',

--- a/easytier-web/frontend-lib/tests/config-ui.spec.ts
+++ b/easytier-web/frontend-lib/tests/config-ui.spec.ts
@@ -2,6 +2,7 @@ import { mount, type VueWrapper } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, nextTick, reactive } from 'vue'
 import Config from '../src/components/Config.vue'
+import UrlListInput from '../src/components/UrlListInput.vue'
 import {
   DEFAULT_NETWORK_CONFIG,
   toBackendNetworkConfig,
@@ -218,6 +219,9 @@ const UrlListInputStub = defineComponent({
     modelValue: Array,
     id: String,
     addLabel: String,
+    defaultUrl: String,
+    portlessProtos: Array,
+    protos: Object,
   },
   emits: ['update:modelValue'],
   setup(props, { attrs, emit }) {
@@ -227,6 +231,9 @@ const UrlListInputStub = defineComponent({
       value: (props.modelValue ?? []).join(','),
       'data-stub': 'url-list-input',
       'data-add-label': props.addLabel,
+      'data-default-url': props.defaultUrl,
+      'data-portless-protos': JSON.stringify(props.portlessProtos ?? []),
+      'data-protos': JSON.stringify(props.protos ?? {}),
       onInput: (event: Event) => emit('update:modelValue', splitList((event.target as HTMLInputElement).value)),
     })
   },
@@ -403,6 +410,14 @@ describe('Config.vue network config projection', () => {
     expect(input(wrapper, 'input[data-add-label="add_listener_url"]').value).toBe('tcp://0.0.0.0:12010')
     expect(input(wrapper, 'input[data-add-label="add_mapped_listener"]').value).toBe('tcp://127.0.0.1:22000')
 
+    const listenerInput = input(wrapper, 'input[data-add-label="add_listener_url"]')
+    expect(JSON.parse(listenerInput.dataset.protos ?? '{}')).toMatchObject({
+      tcp: 0,
+      udp: 0,
+      wg: 0,
+    })
+    expect(JSON.parse(listenerInput.dataset.portlessProtos ?? '[]')).toStrictEqual(['txt', 'srv'])
+
     expect(wrapper.find<HTMLSelectElement>('select[data-stub="select-button"]').element.value).toBe('udp')
     expect(input(wrapper, 'input[placeholder="port_forwards_bind_addr"]').value).toBe('0.0.0.0')
     expect(input(wrapper, 'input[placeholder="port_forwards_dst_addr"]').value).toBe('10.0.0.2')
@@ -559,5 +574,28 @@ describe('Config.vue network config projection', () => {
 
     expect(wrapper.emitted('runNetwork')?.[0]).toEqual([curNetwork])
     expect((wrapper.emitted('runNetwork')?.[0][0] as NetworkConfig).network_name).toBe('mesh-running')
+  })
+})
+
+describe('UrlListInput.vue defaults', () => {
+  it('adds a dynamic listener URL when no explicit default URL is provided', async () => {
+    const urls: string[] = []
+    const wrapper = mount(UrlListInput, {
+      props: {
+        addLabel: 'add_listener_url',
+        modelValue: urls,
+        protos: { tcp: 0 },
+      },
+      global: {
+        stubs: {
+          Button: ButtonStub,
+          UrlInput: true,
+        },
+      },
+    })
+
+    await wrapper.find('.border-dashed').trigger('click')
+
+    expect(urls).toStrictEqual(['tcp://0.0.0.0:0'])
   })
 })

--- a/easytier-web/frontend-lib/tests/remote-management-config.spec.ts
+++ b/easytier-web/frontend-lib/tests/remote-management-config.spec.ts
@@ -226,3 +226,13 @@ describe('RemoteManagement config save', () => {
     }
   })
 })
+
+describe('default network config', () => {
+  it('uses dynamic listener ports', () => {
+    expect(DEFAULT_NETWORK_CONFIG().listener_urls).toStrictEqual([
+      'tcp://0.0.0.0:0',
+      'udp://0.0.0.0:0',
+      'wg://0.0.0.0:0',
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- change default GUI listener URLs to bind port 0 for tcp, udp, and wg
- make UrlListInput add dynamic listener URLs by default instead of tcp://0.0.0.0:11010
- use listener-specific protocol defaults so listener port placeholders show 0 while peer URLs keep their existing defaults
- add coverage for default listener config, listener protocol defaults, and UrlListInput fallback behavior

## Tests
- pnpm test:config-ui
- pnpm build