### PR TITLE
chore: Update hotpath

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4007,9 +4007,9 @@ dependencies = [
 
 [[package]]
 name = "hotpath"
-version = "0.19.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467479f30ae7262ad93eff1f6653a58ecfca4b44dd9ff82ef4b469ba1ad00017"
+checksum = "1ff6b552a6afa29d9e33f8d555bee9093c142dd449501ae128e6494a303f03dc"
 dependencies = [
  "arc-swap",
  "cfg-if",
@@ -4036,9 +4036,9 @@ dependencies = [
 
 [[package]]
 name = "hotpath-macros"
-version = "0.19.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edb8da2a00454786fbb75ab24c4f72380afeb9b5136776caa7737df9895bfa7"
+checksum = "4f15322569d3cfadf84c0de7ef72be435b8f4b4839ee4ace78a7eaca48a87ded"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4047,15 +4047,15 @@ dependencies = [
 
 [[package]]
 name = "hotpath-macros-meta"
-version = "0.19.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e804ccbbd13922ff16b752ab72043d15ea38411a03a82917b8ea5b36b6b45655"
+checksum = "b3675e29d16c844ccad12763672b33e51d9a000c346720c4f354f7a3bdc649a8"
 
 [[package]]
 name = "hotpath-meta"
-version = "0.19.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f76b1b9a176e5677878243b0c9052d2e0a62405359bd6990bbd85b59cafa2aa"
+checksum = "d558d972ddc9483fb4e713af3dd41634edf895c7cb18ed13dc58c56431d42e27"
 dependencies = [
  "hotpath-macros-meta",
 ]

--- a/easytier/Cargo.toml
+++ b/easytier/Cargo.toml
@@ -58,7 +58,7 @@ chrono = { version = "0.4.37", features = ["serde"] }
 guarden = "0.2"
 quanta = "0.12"
 
-hotpath = { version = "0.19", default-features = false, optional = true }
+hotpath = { version = "0.21", default-features = false, optional = true }
 
 delegate = "0.13.5"
 

--- a/easytier/src/hotpath_off.rs
+++ b/easytier/src/hotpath_off.rs
@@ -38,3 +38,15 @@ macro_rules! rw_lock {
         $expr
     };
 }
+
+/// Type-level mirror of `hotpath::wrap` for type positions: with the feature
+/// off, `channel!` returns the original endpoints, so the wrapped endpoint
+/// types are the plain channel types.
+pub(crate) mod wrap {
+    pub(crate) mod tokio {
+        pub(crate) mod sync {
+            pub(crate) use ::tokio::sync::mpsc;
+        }
+    }
+    pub(crate) use ::flume;
+}

--- a/easytier/src/lib.rs
+++ b/easytier/src/lib.rs
@@ -13,6 +13,8 @@ use clap_complete::{Generator, Shell};
 extern crate self as hotpath;
 #[cfg(not(feature = "hotpath"))]
 mod hotpath_off;
+#[cfg(not(feature = "hotpath"))]
+pub(crate) use hotpath_off::wrap;
 
 // `hotpath-alloc` registers a global profiling allocator, which is mutually
 // exclusive with the `jemalloc`/`mimalloc` global allocators.

--- a/easytier/src/peers/mod.rs
+++ b/easytier/src/peers/mod.rs
@@ -56,8 +56,8 @@ type BoxNicPacketFilter = Box<dyn NicPacketFilter + Send + Sync>;
 // pub fn create_packet_recv_chan() -> (PacketRecvChan, PacketRecvChanReceiver) {
 //     tachyonix::channel(128)
 // }
-pub type PacketRecvChan = tokio::sync::mpsc::Sender<ZCPacket>;
-pub type PacketRecvChanReceiver = tokio::sync::mpsc::Receiver<ZCPacket>;
+pub type PacketRecvChan = hotpath::wrap::tokio::sync::mpsc::Sender<ZCPacket>;
+pub type PacketRecvChanReceiver = hotpath::wrap::tokio::sync::mpsc::Receiver<ZCPacket>;
 pub fn create_packet_recv_chan() -> (PacketRecvChan, PacketRecvChanReceiver) {
     hotpath::channel!(tokio::sync::mpsc::channel(128))
 }

--- a/easytier/src/tests/ipv6_test.rs
+++ b/easytier/src/tests/ipv6_test.rs
@@ -49,7 +49,7 @@ async fn test_route_peer_info_ipv6() {
 #[tokio::test]
 async fn test_peer_manager_ipv6() {
     let global_ctx = get_mock_global_ctx();
-    let (packet_sender, _packet_receiver) = tokio::sync::mpsc::channel(100);
+    let (packet_sender, _packet_receiver) = crate::peers::create_packet_recv_chan();
     let peer_mgr = crate::peers::peer_manager::PeerManager::new(
         RouteAlgoType::Ospf,
         global_ctx.clone(),

--- a/easytier/src/tunnel/fake_tcp/stack.rs
+++ b/easytier/src/tunnel/fake_tcp/stack.rs
@@ -89,7 +89,7 @@ impl AddrTuple {
 
 #[derive(Default)]
 struct StackState {
-    tuples: HashMap<AddrTuple, flume::Sender<Bytes>>,
+    tuples: HashMap<AddrTuple, hotpath::wrap::flume::Sender<Bytes>>,
     closed: bool,
 }
 
@@ -133,7 +133,7 @@ pub enum State {
 pub struct Socket {
     shared: Arc<Shared>,
     tun: Arc<dyn Tun>,
-    incoming: flume::Receiver<Bytes>,
+    incoming: hotpath::wrap::flume::Receiver<Bytes>,
     local_addr: SocketAddr,
     remote_addr: SocketAddr,
     local_mac: MacAddr,
@@ -162,7 +162,7 @@ impl Socket {
         remote_mac: Option<MacAddr>,
         ack: Option<u32>,
         state: State,
-    ) -> (Socket, flume::Sender<Bytes>) {
+    ) -> (Socket, hotpath::wrap::flume::Sender<Bytes>) {
         let (incoming_tx, incoming_rx) = hotpath::channel!(flume::bounded(MPMC_BUFFER_LEN));
 
         (
@@ -505,7 +505,7 @@ impl Stack {
         shared: Arc<Shared>,
         mut tuples_purge: broadcast::Receiver<AddrTuple>,
     ) {
-        let mut tuples: HashMap<AddrTuple, flume::Sender<Bytes>> = HashMap::new();
+        let mut tuples: HashMap<AddrTuple, hotpath::wrap::flume::Sender<Bytes>> = HashMap::new();
 
         loop {
             let mut buf = BytesMut::new();

--- a/easytier/src/tunnel/mpsc.rs
+++ b/easytier/src/tunnel/mpsc.rs
@@ -9,7 +9,8 @@ use crate::proto::common::TunnelInfo;
 
 use super::{Tunnel, TunnelError, ZCPacketSink, ZCPacketStream, packet_def::ZCPacket};
 
-use tokio::sync::mpsc::{Receiver, Sender, channel, error::TrySendError};
+use hotpath::wrap::tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::mpsc::{channel, error::TrySendError};
 use tokio_util::task::AbortOnDropHandle;
 // use tachyonix::{channel, Receiver, Sender, TrySendError};
 

--- a/easytier/src/tunnel/ring.rs
+++ b/easytier/src/tunnel/ring.rs
@@ -11,7 +11,8 @@ use async_trait::async_trait;
 use futures::{Sink, SinkExt, Stream, StreamExt};
 use once_cell::sync::Lazy;
 
-use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
+use hotpath::wrap::tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tokio::sync::mpsc::unbounded_channel;
 
 use uuid::Uuid;
 

--- a/easytier/src/tunnel/udp.rs
+++ b/easytier/src/tunnel/udp.rs
@@ -13,11 +13,10 @@ use futures::{StreamExt, stream::FuturesUnordered};
 use rand::{Rng, SeedableRng};
 use zerocopy::{AsBytes, FromBytes};
 
+use hotpath::wrap::tokio::sync::mpsc::{Receiver, Sender, UnboundedReceiver, UnboundedSender};
 use tokio::{
     net::UdpSocket,
-    sync::mpsc::{
-        Receiver, Sender, UnboundedReceiver, UnboundedSender, channel, unbounded_channel,
-    },
+    sync::mpsc::{channel, unbounded_channel},
     task::JoinSet,
 };
 use tokio_util::task::AbortOnDropHandle;
@@ -1185,7 +1184,7 @@ mod tests {
         let dst_addr = "127.0.0.1:1".parse().unwrap();
         let ring_for_send_udp = Arc::new(RingTunnel::new(8));
         let ring_for_recv_udp = Arc::new(RingTunnel::new(8));
-        let (close_event_sender, _close_event_recv) = tokio::sync::mpsc::unbounded_channel();
+        let (close_event_sender, _close_event_recv) = hotpath::channel!(tokio::sync::mpsc::unbounded_channel());
         let mut conn = UdpConnection::new(
             socket,
             7,

--- a/easytier/src/tunnel/wireguard.rs
+++ b/easytier/src/tunnel/wireguard.rs
@@ -465,8 +465,8 @@ impl WgPeer {
     }
 }
 
-type ConnSender = tokio::sync::mpsc::UnboundedSender<Box<dyn Tunnel>>;
-type ConnReceiver = tokio::sync::mpsc::UnboundedReceiver<Box<dyn Tunnel>>;
+type ConnSender = hotpath::wrap::tokio::sync::mpsc::UnboundedSender<Box<dyn Tunnel>>;
+type ConnReceiver = hotpath::wrap::tokio::sync::mpsc::UnboundedReceiver<Box<dyn Tunnel>>;
 
 pub struct WgTunnelListener {
     addr: url::Url,


### PR DESCRIPTION
Hi, @fanyang89  I noticed you started restoring the lib, this PR updates it to the newest version. The primary difference is new wrap api used by `hotpath::channel!`. Instead of inserting proxy channels to observe messages, macro now returns new instrumented types. For the price of toggling types depending on feature flag, you'll now get precise delay values, perf histogram, and massively smaller profiling overhead:

```
tokio channel: 100000 send/recv cycles per mode
  baseline (raw)    1071.2 ns/op
  wrap (default)    1124.9 ns/op  (+53.7 ns/op vs baseline)
  proxy = true      6987.4 ns/op  (+5916.2 ns/op vs baseline)
```

I did not document it yet but there's also a new `HOTPATH_TIME_SAMPLING_RATE=0.1` config, you can use to remove two Instant calls per measurement, and further reduce profiling overhead. lmk if you notice the impact on the criterion benchmark. 