### PR TITLE
fix(macos): make full tunnel (0.0.0.0/0 via exit node) actually work

### DIFF
--- a/easytier/src/arch/macos.rs
+++ b/easytier/src/arch/macos.rs
@@ -1,0 +1,135 @@
+use std::net::Ipv4Addr;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// The IPv4 default route of the physical network, i.e. the route underlay
+/// traffic should take to escape any TUN-based routing (easytier's own full
+/// tunnel or third-party VPNs).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DefaultRouteV4 {
+    pub gateway: Ipv4Addr,
+    pub iface: String,
+}
+
+fn is_virtual_iface(name: &str) -> bool {
+    name.starts_with("utun")
+        || name.starts_with("tun")
+        || name.starts_with("tap")
+        || name.starts_with("feth")
+        || name.starts_with("bridge")
+        || name.starts_with("lo")
+}
+
+fn parse_default_route_v4(netstat_output: &str) -> Option<DefaultRouteV4> {
+    for line in netstat_output.lines() {
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        if fields.len() < 4 || fields[0] != "default" {
+            continue;
+        }
+        let iface = fields[3];
+        if is_virtual_iface(iface) {
+            continue;
+        }
+        let Ok(gateway) = fields[1].parse::<Ipv4Addr>() else {
+            continue;
+        };
+        if gateway.is_unspecified() || gateway.is_loopback() {
+            continue;
+        }
+        return Some(DefaultRouteV4 {
+            gateway,
+            iface: iface.to_string(),
+        });
+    }
+    None
+}
+
+const CACHE_TTL: Duration = Duration::from_secs(10);
+// A failed lookup (e.g. a transient netstat hiccup while roaming) is retried
+// much sooner: callers fall back to unbound sockets while this is cached, so
+// staying in that state for the full TTL would reopen the routing loop the
+// binding exists to prevent.
+const CACHE_TTL_FAILURE: Duration = Duration::from_secs(1);
+
+static DEFAULT_ROUTE_CACHE: Mutex<Option<(Instant, Option<DefaultRouteV4>)>> = Mutex::new(None);
+
+/// Returns the physical (non-TUN) IPv4 default route, cached for a short TTL
+/// so it is cheap enough to call on every socket creation.
+pub fn get_default_route_v4() -> Option<DefaultRouteV4> {
+    let mut cache = DEFAULT_ROUTE_CACHE.lock().unwrap();
+    if let Some((refreshed_at, route)) = cache.as_ref() {
+        let ttl = if route.is_some() {
+            CACHE_TTL
+        } else {
+            CACHE_TTL_FAILURE
+        };
+        if refreshed_at.elapsed() < ttl {
+            return route.clone();
+        }
+    }
+
+    let route = std::process::Command::new("netstat")
+        .args(["-rn", "-f", "inet"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| parse_default_route_v4(&String::from_utf8_lossy(&output.stdout)));
+    if route.is_none() {
+        tracing::warn!("no physical ipv4 default route found");
+    }
+    *cache = Some((Instant::now(), route.clone()));
+    route
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_picks_first_physical_default_route() {
+        // Real netstat -rn output from a machine with dual physical uplinks
+        // and a third-party VPN (utun5) owning split routes.
+        let output = r#"Routing tables
+
+Internet:
+Destination        Gateway            Flags               Netif Expire
+default            192.168.0.1        UGScg                 en0
+default            192.168.0.1        UGScIg               en12
+1                  198.18.0.1         UGSc                utun5
+128.0/1            198.18.0.1         UGSc                utun5
+127.0.0.1          127.0.0.1          UH                    lo0
+"#;
+        assert_eq!(
+            parse_default_route_v4(output),
+            Some(DefaultRouteV4 {
+                gateway: "192.168.0.1".parse().unwrap(),
+                iface: "en0".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_skips_virtual_default_routes() {
+        let output = r#"Destination        Gateway            Flags               Netif Expire
+default            198.18.0.1         UGSc                utun5
+default            10.8.0.1           UGSc                 tun0
+default            192.168.1.1        UGScg                 en1
+"#;
+        assert_eq!(
+            parse_default_route_v4(output),
+            Some(DefaultRouteV4 {
+                gateway: "192.168.1.1".parse().unwrap(),
+                iface: "en1".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_returns_none_without_physical_default_route() {
+        let output = r#"Destination        Gateway            Flags               Netif Expire
+default            198.18.0.1         UGSc                utun5
+default            link#14            UCS                   en0
+"#;
+        assert_eq!(parse_default_route_v4(output), None);
+    }
+}

--- a/easytier/src/arch/mod.rs
+++ b/easytier/src/arch/mod.rs
@@ -1,2 +1,5 @@
 #[cfg(target_os = "windows")]
 pub mod windows;
+
+#[cfg(target_os = "macos")]
+pub mod macos;

--- a/easytier/src/common/global_ctx.rs
+++ b/easytier/src/common/global_ctx.rs
@@ -289,6 +289,7 @@ impl GlobalCtx {
         let (event_bus, _) = tokio::sync::broadcast::channel(16);
 
         let stun_info_collector = StunInfoCollector::new_with_default_servers();
+        stun_info_collector.set_bind_device(config_fs.get_flags().bind_device);
 
         if let Some(stun_servers) = config_fs.get_stun_servers() {
             stun_info_collector.set_stun_servers(stun_servers);
@@ -1072,6 +1073,12 @@ pub mod tests {
         let config_fs = TomlConfigLoader::default();
         config_fs.set_inst_name(format!("test_{}", config_fs.get_id()));
         config_fs.set_network_identity(network_identy.unwrap_or_default());
+
+        // tests talk over loopback; binding sockets to the physical
+        // default-route interface (macOS) would break them
+        let mut flags = config_fs.get_flags();
+        flags.bind_device = false;
+        config_fs.set_flags(flags);
 
         let ctx = Arc::new(GlobalCtx::new(config_fs));
         ctx.replace_stun_info_collector(Box::new(MockStunInfoCollector {

--- a/easytier/src/common/ifcfg/darwin.rs
+++ b/easytier/src/common/ifcfg/darwin.rs
@@ -134,3 +134,191 @@ impl IfConfiguerTrait for MacIfConfiger {
         .await
     }
 }
+
+impl MacIfConfiger {
+    /// Add a gateway-form route (UGSc). Unlike `-interface` routes, these do
+    /// not break IP_BOUND_IF-scoped sockets: the kernel can still route
+    /// interface-scoped traffic around them, which is essential for underlay
+    /// sockets while broad routes hijack the address space.
+    pub async fn add_ipv4_route_via_gateway(
+        &self,
+        address: Ipv4Addr,
+        cidr_prefix: u8,
+        gateway: Ipv4Addr,
+    ) -> Result<(), Error> {
+        run_shell_cmd(
+            format!(
+                "route -n add {} -netmask {} {}",
+                address,
+                cidr_to_subnet_mask(cidr_prefix),
+                gateway
+            )
+            .as_str(),
+        )
+        .await
+    }
+
+    /// Remove a route by destination and mask, regardless of its form.
+    pub async fn remove_ipv4_route_any(
+        &self,
+        address: Ipv4Addr,
+        cidr_prefix: u8,
+    ) -> Result<(), Error> {
+        run_shell_cmd(
+            format!(
+                "route -n delete {} -netmask {}",
+                address,
+                cidr_to_subnet_mask(cidr_prefix)
+            )
+            .as_str(),
+        )
+        .await
+    }
+
+    /// Look up the routing-table entry for exactly `address/cidr_prefix`.
+    ///
+    /// `route get` always answers with its longest-prefix match (querying a
+    /// missing 1.0.0.0/8 returns the default route), so exactness is enforced
+    /// here by comparing the reported destination/mask against the query.
+    /// Returns None when no entry with exactly this destination/mask exists,
+    /// letting callers verify ownership (gateway/interface) before deleting.
+    pub async fn query_ipv4_route_exact(
+        &self,
+        address: Ipv4Addr,
+        cidr_prefix: u8,
+    ) -> Option<RouteGetEntry> {
+        let mask = cidr_to_subnet_mask(cidr_prefix);
+        let output = tokio::process::Command::new("route")
+            .args(["-n", "get", &address.to_string(), "-netmask", &mask.to_string()])
+            .output()
+            .await
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let entry = parse_route_get_output(&String::from_utf8_lossy(&output.stdout))?;
+        if entry.destination == address && entry.mask == mask {
+            Some(entry)
+        } else {
+            None
+        }
+    }
+}
+
+/// A routing-table entry as reported by `route -n get`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteGetEntry {
+    pub destination: Ipv4Addr,
+    pub mask: Ipv4Addr,
+    /// None for interface-form / on-link entries (no IPv4 gateway).
+    pub gateway: Option<Ipv4Addr>,
+    pub iface: Option<String>,
+}
+
+/// Parse the plain-text output of `route -n get`. `destination`/`mask` may be
+/// the literal `default` (0.0.0.0); a HOST entry carries no mask line
+/// (implicit /32); `gateway` is absent for interface-form routes and non-IP
+/// (`link#N`, MAC) for on-link clones.
+fn parse_route_get_output(output: &str) -> Option<RouteGetEntry> {
+    fn parse_quad(s: &str) -> Option<Ipv4Addr> {
+        if s == "default" {
+            return Some(Ipv4Addr::UNSPECIFIED);
+        }
+        // route(8) may abbreviate trailing zero octets ("128.0" == 128.0.0.0)
+        let parts: Vec<&str> = s.split('.').collect();
+        if parts.is_empty() || parts.len() > 4 {
+            return None;
+        }
+        let mut octets = [0u8; 4];
+        for (i, part) in parts.iter().enumerate() {
+            octets[i] = part.parse().ok()?;
+        }
+        Some(Ipv4Addr::from(octets))
+    }
+
+    let mut destination = None;
+    let mut mask = None;
+    let mut gateway = None;
+    let mut iface = None;
+    let mut is_host = false;
+    for line in output.lines() {
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        let value = value.trim();
+        match key.trim() {
+            "destination" => destination = parse_quad(value),
+            "mask" => mask = parse_quad(value),
+            "gateway" => gateway = value.parse().ok(),
+            "interface" => iface = Some(value.to_string()),
+            "flags" => is_host = value.contains("HOST"),
+            _ => {}
+        }
+    }
+    let mask = match mask {
+        Some(m) => m,
+        // HOST entries have an implicit /32; anything else without a mask
+        // line has an unknown shape — report no entry rather than guessing
+        None if is_host => Ipv4Addr::BROADCAST,
+        None => return None,
+    };
+    Some(RouteGetEntry {
+        destination: destination?,
+        mask,
+        gateway,
+        iface,
+    })
+}
+
+#[cfg(test)]
+mod route_get_tests {
+    use super::*;
+
+    #[test]
+    fn parses_gateway_form_split_route() {
+        let out = "   route to: 1.0.0.0\ndestination: 1.0.0.0\n       mask: 255.0.0.0\n    gateway: 10.126.126.13\n  interface: utun6\n      flags: <UP,GATEWAY,DONE,STATIC,PRCLONING,GLOBAL>\n";
+        assert_eq!(
+            parse_route_get_output(out),
+            Some(RouteGetEntry {
+                destination: "1.0.0.0".parse().unwrap(),
+                mask: "255.0.0.0".parse().unwrap(),
+                gateway: Some("10.126.126.13".parse().unwrap()),
+                iface: Some("utun6".to_string()),
+            })
+        );
+    }
+
+    #[test]
+    fn parses_lpm_fallback_to_default() {
+        // querying a missing 1.0.0.0/8 answers with the default route; the
+        // reported destination/mask expose the mismatch for the caller
+        let out = "   route to: 1.0.0.0\ndestination: default\n       mask: default\n    gateway: 192.168.2.1\n  interface: en0\n";
+        let entry = parse_route_get_output(out).unwrap();
+        assert_eq!(entry.destination, Ipv4Addr::UNSPECIFIED);
+        assert_eq!(entry.mask, Ipv4Addr::UNSPECIFIED);
+    }
+
+    #[test]
+    fn parses_host_entry_without_mask_line() {
+        let out = "   route to: 192.168.2.1\ndestination: 192.168.2.1\n  interface: en0\n      flags: <UP,HOST,DONE,LLINFO,WASCLONED,IFSCOPE,IFREF,ROUTER>\n";
+        let entry = parse_route_get_output(out).unwrap();
+        assert_eq!(entry.mask, Ipv4Addr::BROADCAST);
+        assert_eq!(entry.gateway, None);
+    }
+
+    #[test]
+    fn parses_interface_form_without_gateway() {
+        let out = "   route to: 192.168.2.0\ndestination: 192.168.2.0\n       mask: 255.255.255.0\n  interface: en0\n      flags: <UP,DONE,CLONING,STATIC>\n";
+        let entry = parse_route_get_output(out).unwrap();
+        assert_eq!(entry.gateway, None);
+        assert_eq!(entry.iface.as_deref(), Some("en0"));
+    }
+
+    #[test]
+    fn rejects_garbage_and_unknown_shapes() {
+        assert_eq!(parse_route_get_output("route: not in table\n"), None);
+        // destination without mask and without HOST flag: unknown shape
+        let out = "destination: 10.0.0.0\n  interface: en0\n";
+        assert_eq!(parse_route_get_output(out), None);
+    }
+}

--- a/easytier/src/common/stun.rs
+++ b/easytier/src/common/stun.rs
@@ -22,6 +22,7 @@ use stun_codec::rfc5389::methods::BINDING;
 use stun_codec::{Message, MessageClass, MessageDecoder, MessageEncoder};
 
 use crate::common::error::Error;
+use crate::tunnel::common::bind_underlay_udp_socket;
 
 use super::dns::resolve_txt_record;
 use super::stun_codec_ext::*;
@@ -602,13 +603,15 @@ impl StunNatTypeDetectResult {
 pub struct UdpNatTypeDetector {
     stun_server_hosts: Vec<String>,
     max_ip_per_domain: u32,
+    bind_device: bool,
 }
 
 impl UdpNatTypeDetector {
-    pub fn new(stun_server_hosts: Vec<String>, max_ip_per_domain: u32) -> Self {
+    pub fn new(stun_server_hosts: Vec<String>, max_ip_per_domain: u32, bind_device: bool) -> Self {
         Self {
             stun_server_hosts,
             max_ip_per_domain,
+            bind_device,
         }
     }
 
@@ -617,7 +620,13 @@ impl UdpNatTypeDetector {
         source_port: u16,
         stun_server: SocketAddr,
     ) -> Result<BindRequestResponse, Error> {
-        let udp = Arc::new(UdpSocket::bind(format!("0.0.0.0:{}", source_port)).await?);
+        let udp = Arc::new(
+            bind_underlay_udp_socket(
+                format!("0.0.0.0:{}", source_port).parse().unwrap(),
+                self.bind_device,
+            )
+            .await?,
+        );
         let client_builder = StunClientBuilder::new(udp.clone());
         client_builder
             .new_stun_client(stun_server)
@@ -629,7 +638,17 @@ impl UdpNatTypeDetector {
         &self,
         source_port: u16,
     ) -> Result<StunNatTypeDetectResult, Error> {
-        let udp = Arc::new(UdpSocket::bind(format!("0.0.0.0:{}", source_port)).await?);
+        // NAT detection results (nat type + public ip) are announced to peers
+        // and drive hole-punch strategy, so the probe sockets must take the
+        // same physical path as the punch sockets — a probe captured by a
+        // full-tunnel TUN route would report the exit node's address instead
+        let udp = Arc::new(
+            bind_underlay_udp_socket(
+                format!("0.0.0.0:{}", source_port).parse().unwrap(),
+                self.bind_device,
+            )
+            .await?,
+        );
         self.detect_nat_type_with_socket(udp).await
     }
 
@@ -690,15 +709,17 @@ struct TcpStunClient {
     conn_timeout: Duration,
     io_timeout: Duration,
     source_port: u16,
+    bind_device: bool,
 }
 
 impl TcpStunClient {
-    pub fn new(stun_server: SocketAddr, source_port: u16) -> Self {
+    pub fn new(stun_server: SocketAddr, source_port: u16, bind_device: bool) -> Self {
         Self {
             stun_server,
             conn_timeout: Duration::from_millis(1500),
             io_timeout: Duration::from_millis(3000),
             source_port,
+            bind_device,
         }
     }
 
@@ -794,6 +815,12 @@ impl TcpStunClient {
             let _ = socket2_socket.set_reuse_port(true);
         }
 
+        crate::tunnel::common::bind_socket2_to_underlay_device(
+            &socket2_socket,
+            bind_addr.is_ipv4(),
+            self.bind_device,
+        );
+
         socket2_socket.bind(&SockAddr::from(bind_addr))?;
 
         let socket = tokio::net::TcpSocket::from_std_stream(socket2_socket.into());
@@ -848,13 +875,15 @@ impl TcpStunClient {
 pub struct TcpNatTypeDetector {
     stun_server_hosts: Vec<String>,
     max_ip_per_domain: u32,
+    bind_device: bool,
 }
 
 impl TcpNatTypeDetector {
-    pub fn new(stun_server_hosts: Vec<String>, max_ip_per_domain: u32) -> Self {
+    pub fn new(stun_server_hosts: Vec<String>, max_ip_per_domain: u32, bind_device: bool) -> Self {
         Self {
             stun_server_hosts,
             max_ip_per_domain,
+            bind_device,
         }
     }
 
@@ -881,9 +910,13 @@ impl TcpNatTypeDetector {
             Some(source_port)
         };
         for server in stun_servers.iter() {
-            let resp = TcpStunClient::new(*server, selected_source_port.unwrap_or(0))
-                .bind_request()
-                .await;
+            let resp = TcpStunClient::new(
+                *server,
+                selected_source_port.unwrap_or(0),
+                self.bind_device,
+            )
+            .bind_request()
+            .await;
             if let Ok(resp) = resp {
                 if selected_source_port.is_none() {
                     selected_source_port = Some(resp.local_addr.port());
@@ -930,6 +963,7 @@ pub struct StunInfoCollector {
     redetect_notify: Arc<tokio::sync::Notify>,
     tasks: std::sync::Mutex<JoinSet<()>>,
     started: AtomicBool,
+    bind_device: AtomicBool,
 }
 
 #[async_trait::async_trait]
@@ -979,7 +1013,13 @@ impl StunInfoCollectorTrait for StunInfoCollector {
     }
 
     async fn get_udp_port_mapping(&self, local_port: u16) -> Result<SocketAddr, Error> {
-        let udp = Arc::new(UdpSocket::bind(format!("0.0.0.0:{}", local_port)).await?);
+        let udp = Arc::new(
+            bind_underlay_udp_socket(
+                format!("0.0.0.0:{}", local_port).parse().unwrap(),
+                self.bind_device(),
+            )
+            .await?,
+        );
         self.get_udp_port_mapping_with_socket(udp).await
     }
 
@@ -1060,7 +1100,10 @@ impl StunInfoCollectorTrait for StunInfoCollector {
         }
 
         for server in stun_servers.iter() {
-            let Ok(ret) = TcpStunClient::new(*server, local_port).bind_request().await else {
+            let Ok(ret) = TcpStunClient::new(*server, local_port, self.bind_device())
+                .bind_request()
+                .await
+            else {
                 tracing::warn!(?server, "tcp stun bind request failed");
                 continue;
             };
@@ -1091,7 +1134,22 @@ impl StunInfoCollector {
             redetect_notify: Arc::new(tokio::sync::Notify::new()),
             tasks: std::sync::Mutex::new(JoinSet::new()),
             started: AtomicBool::new(false),
+            // default off under cfg(test) so unit tests talking to loopback
+            // mock stun servers are not scoped to the physical interface
+            bind_device: AtomicBool::new(!cfg!(test)),
         }
+    }
+
+    /// Whether probe sockets should be bound to the physical default-route
+    /// interface (see bind_underlay_udp_socket). Synced from the instance
+    /// `bind_device` flag at GlobalCtx construction.
+    pub fn set_bind_device(&self, bind_device: bool) {
+        self.bind_device
+            .store(bind_device, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn bind_device(&self) -> bool {
+        self.bind_device.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     pub fn new_with_default_servers() -> Self {
@@ -1183,6 +1241,7 @@ impl StunInfoCollector {
         let udp_nat_test_result = self.udp_nat_test_result.clone();
         let nat_test_time = self.nat_test_result_time.clone();
         let redetect_notify = self.redetect_notify.clone();
+        let bind_device = self.bind_device();
         self.tasks.lock().unwrap().spawn(async move {
             loop {
                 let udp_servers = stun_servers.read().unwrap().clone();
@@ -1193,7 +1252,7 @@ impl StunInfoCollector {
                     .map(|x| x.to_string())
                     .collect();
 
-                let udp_detector = UdpNatTypeDetector::new(udp_servers, 1);
+                let udp_detector = UdpNatTypeDetector::new(udp_servers, 1, bind_device);
                 let mut udp_ret = udp_detector.detect_nat_type(0).await;
                 tracing::debug!(?udp_ret, "finish udp nat type detect");
 
@@ -1243,6 +1302,7 @@ impl StunInfoCollector {
         let tcp_nat_test_result = self.tcp_nat_test_result.clone();
         let nat_test_time = self.nat_test_result_time.clone();
         let redetect_notify = self.redetect_notify.clone();
+        let bind_device = self.bind_device();
         self.tasks.lock().unwrap().spawn(async move {
             loop {
                 let tcp_servers = tcp_stun_servers.read().unwrap().clone();
@@ -1253,7 +1313,7 @@ impl StunInfoCollector {
                     .map(|x| x.to_string())
                     .collect();
 
-                let tcp_detector = TcpNatTypeDetector::new(tcp_servers, 1);
+                let tcp_detector = TcpNatTypeDetector::new(tcp_servers, 1, bind_device);
                 let tcp_ret = tcp_detector.detect_nat_type(0).await;
                 tracing::debug!(?tcp_ret, "finish tcp nat type detect");
 
@@ -1394,7 +1454,7 @@ mod tests {
         });
 
         let stun_servers = vec!["127.0.0.1:55555".to_string(), "127.0.0.1:55535".to_string()];
-        let detector = UdpNatTypeDetector::new(stun_servers, 1);
+        let detector = UdpNatTypeDetector::new(stun_servers, 1, false);
         let ret = detector.detect_nat_type(0).await;
         println!("{:#?}, {:?}", ret, ret.as_ref().unwrap().nat_type());
         assert_eq!(ret.unwrap().nat_type(), NatType::Restricted);
@@ -1403,7 +1463,7 @@ mod tests {
     #[tokio::test]
     async fn test_txt_public_stun_server() {
         let stun_servers = vec!["txt:stun.easytier.cn".to_string()];
-        let detector = UdpNatTypeDetector::new(stun_servers, 1);
+        let detector = UdpNatTypeDetector::new(stun_servers, 1, false);
         timeout(Duration::from_secs(30), async {
             loop {
                 let ret = detector.detect_nat_type(0).await;
@@ -1427,7 +1487,7 @@ mod tests {
             "stun.fitauto.ru".to_string(),
             "stun.hot-chilli.net".to_string(),
         ];
-        let detector = TcpNatTypeDetector::new(stun_servers, 3);
+        let detector = TcpNatTypeDetector::new(stun_servers, 3, false);
         let ret = detector.detect_nat_type(0).await;
         println!("{:#?}, {:?}", ret, ret.as_ref().map(|x| x.nat_type()));
         if let Ok(resp) = ret {
@@ -1471,7 +1531,7 @@ mod tests {
         let (server2, _t2) = spawn_tcp_stun_server().await;
 
         let stun_servers = vec![server1.to_string(), server2.to_string()];
-        let detector = TcpNatTypeDetector::new(stun_servers, 1);
+        let detector = TcpNatTypeDetector::new(stun_servers, 1, false);
 
         let ret = detector.detect_nat_type(0).await.unwrap();
         assert!(ret.stun_resps.len() >= 2);
@@ -1546,7 +1606,7 @@ mod tests {
         });
         let stun_servers = vec!["127.0.0.1:55355".to_string()];
 
-        let detector = UdpNatTypeDetector::new(stun_servers, 1);
+        let detector = UdpNatTypeDetector::new(stun_servers, 1, false);
         let ret = detector.detect_nat_type(0).await;
         println!("{:#?}, {:?}", ret, ret.as_ref().unwrap().nat_type());
         assert_eq!(ret.unwrap().nat_type(), NatType::Restricted);

--- a/easytier/src/connector/direct.rs
+++ b/easytier/src/connector/direct.rs
@@ -325,9 +325,12 @@ impl DirectConnectorManagerData {
         let local_socket = {
             let _g = self.global_ctx.net_ns.guard();
             Arc::new(
-                UdpSocket::bind("0.0.0.0:0")
-                    .await
-                    .with_context(|| format!("failed to bind local socket for {}", remote_url))?,
+                crate::tunnel::common::bind_underlay_udp_socket(
+                    "0.0.0.0:0".parse().unwrap(),
+                    self.global_ctx.config.get_flags().bind_device,
+                )
+                .await
+                .with_context(|| format!("failed to bind local socket for {}", remote_url))?,
             )
         };
         let connector_addr = self

--- a/easytier/src/connector/mod.rs
+++ b/easytier/src/connector/mod.rs
@@ -71,6 +71,9 @@ async fn set_bind_addr_for_peer_connector(
     if is_ipv4 {
         let mut bind_addrs = vec![];
         for ipv4 in ips.interface_ipv4s {
+            if is_local_ip_on_tun_iface(std::net::IpAddr::V4(ipv4.into())) {
+                continue;
+            }
             let socket_addr = SocketAddrV4::new(ipv4.into(), 0).into();
             bind_addrs.push(socket_addr);
         }
@@ -82,12 +85,39 @@ async fn set_bind_addr_for_peer_connector(
             if global_ctx.is_ip_easytier_managed_ipv6(&ipv6) {
                 continue;
             }
+            if is_local_ip_on_tun_iface(std::net::IpAddr::V6(ipv6)) {
+                continue;
+            }
             let socket_addr = SocketAddrV6::new(ipv6, 0, 0, 0).into();
             bind_addrs.push(socket_addr);
         }
         connector.set_bind_addrs(bind_addrs);
     }
     let _ = connector;
+}
+
+/// On macOS, connectors race a connection from every local interface IP and
+/// keep the first that succeeds. IPs owned by utun devices (other VPNs, or a
+/// stale easytier tun) must not join that race: connecting through another
+/// tunnel adds an extra detour at best and a routing loop at worst.
+fn is_local_ip_on_tun_iface(#[allow(unused_variables)] ip: std::net::IpAddr) -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        use network_interface::NetworkInterfaceConfig;
+        let Ok(ifaces) = network_interface::NetworkInterface::show() else {
+            return false;
+        };
+        for iface in ifaces {
+            if !iface.name.starts_with("utun") {
+                continue;
+            }
+            if iface.addr.iter().any(|addr| addr.ip() == ip) {
+                tracing::debug!(?ip, iface = %iface.name, "skip TUN-owned local ip for peer connector bind");
+                return true;
+            }
+        }
+    }
+    false
 }
 
 struct ResolvedConnectorAddr {

--- a/easytier/src/connector/udp_hole_punch/both_easy_sym.rs
+++ b/easytier/src/connector/udp_hole_punch/both_easy_sym.rs
@@ -77,8 +77,11 @@ impl PunchBothEasySymHoleServer {
             .ok_or(anyhow::anyhow!("public_ip is required"))?;
         let transaction_id = request.transaction_id;
 
-        let udp_array =
-            UdpSocketArray::new(socket_count, self.common.get_global_ctx().net_ns.clone());
+        let udp_array = UdpSocketArray::new(
+            socket_count,
+            self.common.get_global_ctx().net_ns.clone(),
+            self.common.get_global_ctx().config.get_flags().bind_device,
+        );
         udp_array.start().await?;
         udp_array.add_intreast_tid(transaction_id);
         let peer_mgr = self.common.get_peer_mgr();
@@ -207,6 +210,7 @@ impl PunchBothEasySymHoleClient {
         let udp_array = UdpSocketArray::new(
             UDP_ARRAY_SIZE_FOR_BOTH_EASY_SYM,
             self.peer_mgr.get_global_ctx().net_ns.clone(),
+            self.peer_mgr.get_global_ctx().config.get_flags().bind_device,
         );
         udp_array.start().await?;
 

--- a/easytier/src/connector/udp_hole_punch/common.rs
+++ b/easytier/src/connector/udp_hole_punch/common.rs
@@ -21,6 +21,7 @@ use crate::{
     proto::common::NatType,
     tunnel::{
         Tunnel, TunnelConnCounter, TunnelListener as _,
+        common::bind_underlay_udp_socket,
         packet_def::{UDP_TUNNEL_HEADER_SIZE, UDPTunnelHeader, UdpPacketType},
         udp::{UdpTunnelConnector, UdpTunnelListener, new_hole_punch_packet},
     },
@@ -203,6 +204,7 @@ pub(crate) struct UdpSocketArray {
     sockets: Arc<DashMap<SocketAddr, Arc<UdpSocket>>>,
     max_socket_count: usize,
     net_ns: NetNS,
+    bind_device: bool,
     tasks: Arc<std::sync::Mutex<JoinSet<()>>>,
 
     intreast_tids: Arc<DashSet<u32>>,
@@ -210,7 +212,7 @@ pub(crate) struct UdpSocketArray {
 }
 
 impl UdpSocketArray {
-    pub fn new(max_socket_count: usize, net_ns: NetNS) -> Self {
+    pub fn new(max_socket_count: usize, net_ns: NetNS, bind_device: bool) -> Self {
         let tasks = Arc::new(std::sync::Mutex::new(JoinSet::new()));
         join_joinset_background(tasks.clone(), "UdpSocketArray".to_owned());
 
@@ -218,6 +220,7 @@ impl UdpSocketArray {
             sockets: Arc::new(DashMap::new()),
             max_socket_count,
             net_ns,
+            bind_device,
             tasks,
 
             intreast_tids: Arc::new(DashSet::new()),
@@ -291,7 +294,10 @@ impl UdpSocketArray {
         while self.sockets.len() < self.max_socket_count {
             let socket = {
                 let _g = self.net_ns.guard();
-                Arc::new(UdpSocket::bind("0.0.0.0:0").await?)
+                Arc::new(
+                    bind_underlay_udp_socket("0.0.0.0:0".parse().unwrap(), self.bind_device)
+                        .await?,
+                )
             };
 
             self.add_new_socket(socket).await?;
@@ -375,8 +381,15 @@ impl UdpHolePunchListener {
         port: Option<u16>,
     ) -> Result<Self, Error> {
         let socket = {
-            let _g = peer_mgr.get_global_ctx().net_ns.guard();
-            Arc::new(UdpSocket::bind((Ipv4Addr::UNSPECIFIED, port.unwrap_or(0))).await?)
+            let global_ctx = peer_mgr.get_global_ctx();
+            let _g = global_ctx.net_ns.guard();
+            Arc::new(
+                bind_underlay_udp_socket(
+                    (Ipv4Addr::UNSPECIFIED, port.unwrap_or(0)).into(),
+                    global_ctx.config.get_flags().bind_device,
+                )
+                .await?,
+            )
         };
         let local_port = socket.local_addr()?.port();
         let listen_url: url::Url = format!("udp://0.0.0.0:{local_port}").parse().unwrap();
@@ -718,7 +731,13 @@ async fn check_udp_socket_local_addr(
     global_ctx: ArcGlobalCtx,
     remote_mapped_addr: SocketAddr,
 ) -> Result<(), Error> {
-    let socket = UdpSocket::bind("0.0.0.0:0").await?;
+    // bind the probe the same way real punch sockets are bound, so the local
+    // addr it reports reflects the route those sockets will actually take
+    let socket = bind_underlay_udp_socket(
+        "0.0.0.0:0".parse().unwrap(),
+        global_ctx.config.get_flags().bind_device,
+    )
+    .await?;
     socket.connect(remote_mapped_addr).await?;
     if let Ok(local_addr) = socket.local_addr()
         && let Some(err) = easytier_managed_local_addr_error(&global_ctx, local_addr)

--- a/easytier/src/connector/udp_hole_punch/cone.rs
+++ b/easytier/src/connector/udp_hole_punch/cone.rs
@@ -2,7 +2,6 @@ use std::{sync::Arc, time::Duration};
 
 use anyhow::Context;
 use quanta::Instant;
-use tokio::net::UdpSocket;
 use tokio_util::task::AbortOnDropHandle;
 
 use crate::{
@@ -10,6 +9,7 @@ use crate::{
     connector::udp_hole_punch::common::{
         HOLE_PUNCH_PACKET_BODY_LEN, UdpSocketArray, try_connect_with_socket,
     },
+    tunnel::common::bind_underlay_udp_socket,
     connector::udp_hole_punch::handle_rpc_result,
     peers::peer_manager::PeerManager,
     proto::{
@@ -111,7 +111,11 @@ impl PunchConeHoleClient {
         let tid = rand::random();
 
         let global_ctx = self.peer_mgr.get_global_ctx();
-        let udp_array = UdpSocketArray::new(1, global_ctx.net_ns.clone());
+        let udp_array = UdpSocketArray::new(
+            1,
+            global_ctx.net_ns.clone(),
+            global_ctx.config.get_flags().bind_device,
+        );
 
         let rpc_stub = self
             .peer_mgr
@@ -141,7 +145,13 @@ impl PunchConeHoleClient {
 
         let local_socket = {
             let _g = self.peer_mgr.get_global_ctx().net_ns.guard();
-            Arc::new(UdpSocket::bind("0.0.0.0:0").await?)
+            Arc::new(
+                bind_underlay_udp_socket(
+                    "0.0.0.0:0".parse().unwrap(),
+                    global_ctx.config.get_flags().bind_device,
+                )
+                .await?,
+            )
         };
         let local_addr = local_socket
             .local_addr()

--- a/easytier/src/connector/udp_hole_punch/sym_to_cone.rs
+++ b/easytier/src/connector/udp_hole_punch/sym_to_cone.rs
@@ -12,7 +12,7 @@ use anyhow::Context;
 use guarden::defer;
 use quanta::Instant;
 use rand::{Rng, seq::SliceRandom};
-use tokio::{net::UdpSocket, sync::RwLock};
+use tokio::sync::RwLock;
 use tokio_util::task::AbortOnDropHandle;
 use tracing::Level;
 
@@ -237,6 +237,7 @@ impl PunchSymToConeHoleClient {
         let udp_array = Arc::new(UdpSocketArray::new(
             UDP_ARRAY_SIZE_FOR_HARD_SYM,
             self.peer_mgr.get_global_ctx().net_ns.clone(),
+            self.peer_mgr.get_global_ctx().config.get_flags().bind_device,
         ));
         udp_array.start().await?;
         wlocked.replace(udp_array.clone());
@@ -451,7 +452,13 @@ impl PunchSymToConeHoleClient {
         if self.try_direct_connect.load(Ordering::Relaxed)
             && let Ok(tunnel) = try_connect_with_socket(
                 global_ctx.clone(),
-                Arc::new(UdpSocket::bind("0.0.0.0:0").await?),
+                Arc::new(
+                    crate::tunnel::common::bind_underlay_udp_socket(
+                        "0.0.0.0:0".parse().unwrap(),
+                        global_ctx.config.get_flags().bind_device,
+                    )
+                    .await?,
+                ),
                 remote_mapped_addr.into(),
             )
             .await

--- a/easytier/src/instance/virtual_nic.rs
+++ b/easytier/src/instance/virtual_nic.rs
@@ -1046,6 +1046,7 @@ impl NicCtx {
         cur_proxy_cidrs: &mut BTreeSet<cidr::Ipv4Cidr>,
         added: Vec<cidr::Ipv4Cidr>,
         removed: Vec<cidr::Ipv4Cidr>,
+        #[allow(unused_variables)] tun_ipv4: Option<std::net::Ipv4Addr>,
     ) {
         tracing::debug!(?added, ?removed, "applying proxy_cidrs route changes");
 
@@ -1054,6 +1055,26 @@ impl NicCtx {
             if !cur_proxy_cidrs.contains(&cidr) {
                 continue;
             }
+
+            // macOS: 0.0.0.0/0 was installed as split routes, remove those
+            #[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
+            if cidr.network_length() == 0 && cidr.first_address() == std::net::Ipv4Addr::UNSPECIFIED {
+                tracing::info!("macOS: removing split default routes from TUN");
+                for (octet, prefix) in MACOS_SPLIT_DEFAULT_ROUTES {
+                    remove_macos_route_if_on_iface(
+                        std::net::Ipv4Addr::new(octet, 0, 0, 0),
+                        prefix,
+                        ifname,
+                    )
+                    .await;
+                }
+                // also clean the old-style /1 split left by earlier builds
+                remove_macos_route_if_on_iface(std::net::Ipv4Addr::new(0, 0, 0, 0), 1, ifname)
+                    .await;
+                cur_proxy_cidrs.remove(&cidr);
+                continue;
+            }
+
             let _g = net_ns.guard();
             let ret = ifcfg
                 .remove_ipv4_route(ifname, cidr.first_address(), cidr.network_length())
@@ -1074,6 +1095,62 @@ impl NicCtx {
             if cur_proxy_cidrs.contains(&cidr) {
                 continue;
             }
+
+            // macOS: adding 0.0.0.0/0 conflicts with the existing system default
+            // route, so install the clash/mihomo-style split instead. Two
+            // hard-won constraints from live debugging:
+            //  - any route whose destination is 0.0.0.0 (e.g. 0.0.0.0/1) is
+            //    marked RTF_GLOBAL by the kernel and breaks sends from
+            //    IP_BOUND_IF-scoped underlay sockets (EHOSTUNREACH), killing
+            //    STUN and hole punching — hence the split starts at 1.0.0.0/8
+            //    and skips the reserved 0.0.0.0/8;
+            //  - gateway-form routes (via the TUN's own address) are used to
+            //    match the empirically verified working configuration.
+            #[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
+            if cidr.network_length() == 0 && cidr.first_address() == std::net::Ipv4Addr::UNSPECIFIED {
+                if let Some(tun_ip) = tun_ipv4 {
+                    let mac_ifcfg = crate::common::ifcfg::IfConfiger {};
+                    let mut installed = vec![];
+                    let mut first_err = None;
+                    for (octet, prefix) in MACOS_SPLIT_DEFAULT_ROUTES {
+                        let dst = std::net::Ipv4Addr::new(octet, 0, 0, 0);
+                        match mac_ifcfg.add_ipv4_route_via_gateway(dst, prefix, tun_ip).await {
+                            Ok(()) => installed.push((dst, prefix)),
+                            Err(e) => {
+                                first_err = Some((dst, prefix, e));
+                                break;
+                            }
+                        }
+                    }
+                    if let Some((dst, prefix, e)) = first_err {
+                        // all-or-nothing: half a split default route silently
+                        // un-tunnels part of the address space, which is worse
+                        // than a fully absent one. Roll back (ownership-checked)
+                        // and leave 0/0 out of cur_proxy_cidrs so the periodic
+                        // reconcile retries the whole set.
+                        tracing::warn!(
+                            ?dst,
+                            prefix,
+                            ?e,
+                            "macOS: split default route add failed, rolling back the set"
+                        );
+                        for (dst, prefix) in installed {
+                            remove_macos_route_if_on_iface(dst, prefix, ifname).await;
+                        }
+                        continue;
+                    }
+                    tracing::info!(?tun_ip, "macOS: installed split default routes for TUN routing");
+                } else {
+                    for (octet, prefix) in MACOS_SPLIT_DEFAULT_ROUTES {
+                        let dst = std::net::Ipv4Addr::new(octet, 0, 0, 0);
+                        let _ = ifcfg.add_ipv4_route(ifname, dst, prefix, None).await;
+                    }
+                    tracing::warn!("macOS: tun has no ipv4, split default routes use interface form");
+                }
+                cur_proxy_cidrs.insert(cidr);
+                continue;
+            }
+
             let _g = net_ns.guard();
             let ret = ifcfg
                 .add_ipv4_route(ifname, cidr.first_address(), cidr.network_length(), None)
@@ -1142,6 +1219,17 @@ impl NicCtx {
         self.tasks.spawn(async move {
             let mut cur_proxy_cidrs = BTreeSet::<cidr::Ipv4Cidr>::new();
 
+            // macOS: host routes protecting underlay endpoints from the broad
+            // full-tunnel TUN routes; reconciled periodically so endpoints of
+            // closed conns get pruned and gateway changes are followed
+            #[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
+            let mut bypass = macos_bypass::BypassRouteManager::new(macos_bypass::SysRouteOps);
+            #[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
+            let mut bypass_reconcile = tokio::time::interval_at(
+                tokio::time::Instant::now() + BYPASS_RECONCILE_INTERVAL,
+                BYPASS_RECONCILE_INTERVAL,
+            );
+
             // Initial sync: get current proxy_cidrs state and apply routes
             let (_, added, removed) = ProxyCidrsMonitor::diff_proxy_cidrs(
                 peer_mgr.as_ref(),
@@ -1149,6 +1237,12 @@ impl NicCtx {
                 &cur_proxy_cidrs,
             )
             .await;
+
+            // macOS: install bypass routes before the TUN routes start capturing traffic
+            #[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
+            sync_macos_bypass_routes(&mut bypass, &cur_proxy_cidrs, &added, &global_ctx, &peer_mgr)
+                .await;
+
             Self::apply_route_changes(
                 &ifcfg,
                 &ifname,
@@ -1156,11 +1250,51 @@ impl NicCtx {
                 &mut cur_proxy_cidrs,
                 added,
                 removed,
+                global_ctx.get_ipv4().map(|ip| ip.address()),
             )
             .await;
 
             loop {
-                let event = match event_receiver.recv().await {
+                #[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
+                let received = tokio::select! {
+                    r = event_receiver.recv() => r,
+                    _ = bypass_reconcile.tick() => {
+                        // the periodic reconcile also retries route changes
+                        // that previously failed (e.g. a rolled-back split
+                        // default route set)
+                        let (_, added, removed) = ProxyCidrsMonitor::diff_proxy_cidrs(
+                            peer_mgr.as_ref(),
+                            &global_ctx,
+                            &cur_proxy_cidrs,
+                        )
+                        .await;
+                        sync_macos_bypass_routes(
+                            &mut bypass,
+                            &cur_proxy_cidrs,
+                            &added,
+                            &global_ctx,
+                            &peer_mgr,
+                        )
+                        .await;
+                        if !added.is_empty() || !removed.is_empty() {
+                            Self::apply_route_changes(
+                                &ifcfg,
+                                &ifname,
+                                &net_ns,
+                                &mut cur_proxy_cidrs,
+                                added,
+                                removed,
+                                global_ctx.get_ipv4().map(|ip| ip.address()),
+                            )
+                            .await;
+                        }
+                        continue;
+                    }
+                };
+                #[cfg(not(all(target_os = "macos", not(feature = "macos-ne"))))]
+                let received = event_receiver.recv().await;
+
+                let event = match received {
                     Ok(event) => event,
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => {
                         tracing::debug!("event bus closed, stopping proxy_cidrs route updater");
@@ -1182,11 +1316,34 @@ impl NicCtx {
                     }
                 };
 
-                // Only handle ProxyCidrsUpdated events
                 let (added, removed) = match event {
                     GlobalCtxEvent::ProxyCidrsUpdated(added, removed) => (added, removed),
+                    // a fresh underlay conn (e.g. a just-punched p2p endpoint)
+                    // must be protected before its traffic loops into the TUN
+                    #[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
+                    GlobalCtxEvent::PeerConnAdded(conn) => {
+                        if cur_proxy_cidrs.iter().any(|c| c.network_length() <= 1)
+                            && let Some(ip) = conn_remote_ipv4(&conn)
+                            && is_bypass_candidate_ipv4(ip, &physical_onlink_v4_subnets(), &global_ctx)
+                            && let Some(route) = crate::arch::macos::get_default_route_v4()
+                        {
+                            bypass.add_one(ip, route.gateway).await;
+                        }
+                        continue;
+                    }
                     _ => continue,
                 };
+
+                // macOS: refresh bypass routes before applying main route changes
+                #[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
+                sync_macos_bypass_routes(
+                    &mut bypass,
+                    &cur_proxy_cidrs,
+                    &added,
+                    &global_ctx,
+                    &peer_mgr,
+                )
+                .await;
 
                 Self::apply_route_changes(
                     &ifcfg,
@@ -1195,9 +1352,14 @@ impl NicCtx {
                     &mut cur_proxy_cidrs,
                     added,
                     removed,
+                    global_ctx.get_ipv4().map(|ip| ip.address()),
                 )
                 .await;
             }
+
+            // remove bypass routes when the updater stops
+            #[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
+            bypass.clear().await;
         });
 
         Ok(())
@@ -1424,11 +1586,556 @@ impl NicCtx {
     }
 }
 
+/// Delete the exact route `dst/prefix` only if the routing table shows it on
+/// our own TUN interface — true for both the gateway-form entries (the TUN's
+/// own address resolves on the TUN) and the no-ipv4 interface-form fallback.
+/// Never touches an identical route owned by someone else: another VPN's
+/// clash-style split routes point at that VPN's own utun, and deleting them
+/// would cut the machine off the network.
+#[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
+async fn remove_macos_route_if_on_iface(dst: std::net::Ipv4Addr, prefix: u8, ifname: &str) {
+    let mac_ifcfg = crate::common::ifcfg::IfConfiger {};
+    match mac_ifcfg.query_ipv4_route_exact(dst, prefix).await {
+        // no exact entry (or unknown shape): nothing of ours to remove
+        None => {}
+        Some(entry) if entry.iface.as_deref() == Some(ifname) => {
+            if let Err(e) = mac_ifcfg.remove_ipv4_route_any(dst, prefix).await {
+                tracing::warn!(?dst, prefix, ?e, "failed to remove split route");
+            }
+        }
+        Some(entry) => {
+            tracing::warn!(
+                ?dst,
+                prefix,
+                iface = ?entry.iface,
+                "route exists but is not on our TUN, leaving it alone"
+            );
+        }
+    }
+}
+
+#[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
+const BYPASS_RECONCILE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// The clash/mihomo-style default-route split: (first octet, prefix length).
+/// Covers 1.0.0.0-255.255.255.255; 0.0.0.0/8 is reserved and deliberately
+/// skipped so no route has destination 0.0.0.0 (see apply_route_changes).
+#[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
+const MACOS_SPLIT_DEFAULT_ROUTES: [(u8, u8); 8] = [
+    (1, 8),
+    (2, 7),
+    (4, 6),
+    (8, 5),
+    (16, 4),
+    (32, 3),
+    (64, 2),
+    (128, 1),
+];
+
+#[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
+mod macos_bypass {
+    use std::collections::{BTreeMap, BTreeSet};
+    use std::net::Ipv4Addr;
+
+    use crate::common::error::Error;
+
+    /// Exact /32 lookup result used for ownership checks before deletion.
+    pub(super) enum HostRouteQuery {
+        /// No /32 entry exists for this destination.
+        Missing,
+        /// An entry exists; `gateway` is None for non-gateway (interface /
+        /// on-link) forms, which are by definition not ours.
+        Entry { gateway: Option<Ipv4Addr> },
+    }
+
+    /// Routing-table operations behind the bypass manager, abstracted so the
+    /// ownership/retry state machine below is unit-testable without touching
+    /// the real routing table.
+    pub(super) trait RouteOps {
+        async fn add_host_route_via_gateway(
+            &self,
+            ip: Ipv4Addr,
+            gateway: Ipv4Addr,
+        ) -> Result<(), Error>;
+        async fn remove_host_route(&self, ip: Ipv4Addr) -> Result<(), Error>;
+        async fn query_host_route(&self, ip: Ipv4Addr) -> HostRouteQuery;
+    }
+
+    pub(super) struct SysRouteOps;
+
+    impl RouteOps for SysRouteOps {
+        async fn add_host_route_via_gateway(
+            &self,
+            ip: Ipv4Addr,
+            gateway: Ipv4Addr,
+        ) -> Result<(), Error> {
+            let ifcfg = crate::common::ifcfg::IfConfiger {};
+            ifcfg.add_ipv4_route_via_gateway(ip, 32, gateway).await
+        }
+        async fn remove_host_route(&self, ip: Ipv4Addr) -> Result<(), Error> {
+            let ifcfg = crate::common::ifcfg::IfConfiger {};
+            ifcfg.remove_ipv4_route_any(ip, 32).await
+        }
+        async fn query_host_route(&self, ip: Ipv4Addr) -> HostRouteQuery {
+            let ifcfg = crate::common::ifcfg::IfConfiger {};
+            match ifcfg.query_ipv4_route_exact(ip, 32).await {
+                None => HostRouteQuery::Missing,
+                Some(entry) => HostRouteQuery::Entry {
+                    gateway: entry.gateway,
+                },
+            }
+        }
+    }
+
+    /// Host routes (/32 via the physical gateway) that let easytier's own
+    /// underlay traffic escape the broad split default routes installed for
+    /// full tunnel (MACOS_SPLIT_DEFAULT_ROUTES). Without them, packets to
+    /// peer endpoints would be captured by the TUN and loop back into
+    /// easytier.
+    ///
+    /// Ownership rules: only routes this instance successfully installed are
+    /// deleted, and deletion re-checks that the table still shows the gateway
+    /// we recorded. An identical /32 owned by someone else (another VPN
+    /// protecting the same endpoint) is never torn down — deleting it would
+    /// pull that software's underlay traffic into our tunnel.
+    pub(super) struct BypassRouteManager<O: RouteOps> {
+        ops: O,
+        installed: BTreeMap<Ipv4Addr, Ipv4Addr>, // dst ip -> gateway we installed
+    }
+
+    impl<O: RouteOps> BypassRouteManager<O> {
+        pub(super) fn new(ops: O) -> Self {
+            Self {
+                ops,
+                installed: BTreeMap::new(),
+            }
+        }
+
+        pub(super) async fn sync(&mut self, desired: &BTreeSet<Ipv4Addr>, gateway: Ipv4Addr) {
+            let stale: Vec<(Ipv4Addr, Ipv4Addr)> = self
+                .installed
+                .iter()
+                .filter(|(ip, gw)| !desired.contains(ip) || **gw != gateway)
+                .map(|(ip, gw)| (*ip, *gw))
+                .collect();
+            for (ip, gw) in stale {
+                self.remove_one(ip, gw).await;
+            }
+            for ip in desired {
+                self.add_one(*ip, gateway).await;
+            }
+        }
+
+        pub(super) async fn add_one(&mut self, ip: Ipv4Addr, gateway: Ipv4Addr) {
+            if let Some(old_gw) = self.installed.get(&ip).copied() {
+                if old_gw == gateway {
+                    return;
+                }
+                if !self.remove_one(ip, old_gw).await {
+                    // the old entry could not be removed; keep it on the books
+                    // and let a later reconcile retry the gateway switch
+                    return;
+                }
+            }
+            match self.ops.add_host_route_via_gateway(ip, gateway).await {
+                Ok(()) => {
+                    tracing::info!(?ip, ?gateway, "added underlay bypass route");
+                    self.installed.insert(ip, gateway);
+                }
+                Err(e) => {
+                    // do NOT track failed adds: an EEXIST here may be another
+                    // VPN's bypass for the same endpoint, which must never be
+                    // deleted by us. The cost is that a /32 leaked by a
+                    // crashed previous run is not adopted; that leftover is
+                    // harmless (it points at the physical gateway) and clears
+                    // on reboot.
+                    tracing::warn!(
+                        ?ip,
+                        ?gateway,
+                        ?e,
+                        "failed to add bypass route, leaving any existing entry alone"
+                    );
+                }
+            }
+        }
+
+        /// Remove `ip`'s /32 if the table still shows the gateway we
+        /// installed. Returns true when the entry is off our books (deleted,
+        /// already gone, or replaced by a foreign route), false when deletion
+        /// failed and should be retried by a later reconcile.
+        async fn remove_one(&mut self, ip: Ipv4Addr, expected_gw: Ipv4Addr) -> bool {
+            match self.ops.query_host_route(ip).await {
+                HostRouteQuery::Missing => {
+                    self.installed.remove(&ip);
+                    true
+                }
+                HostRouteQuery::Entry { gateway: Some(gw) } if gw == expected_gw => {
+                    match self.ops.remove_host_route(ip).await {
+                        Ok(()) => {
+                            self.installed.remove(&ip);
+                            true
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                ?ip,
+                                ?expected_gw,
+                                ?e,
+                                "failed to remove bypass route, will retry"
+                            );
+                            false
+                        }
+                    }
+                }
+                HostRouteQuery::Entry { gateway } => {
+                    // not the entry we installed (replaced or foreign): drop
+                    // it from our books without deleting
+                    tracing::warn!(
+                        ?ip,
+                        ?expected_gw,
+                        current_gateway = ?gateway,
+                        "bypass route replaced by a foreign entry, leaving it alone"
+                    );
+                    self.installed.remove(&ip);
+                    true
+                }
+            }
+        }
+
+        /// Best-effort removal of everything we installed. Entries whose
+        /// deletion fails stay on the books, so a later reconcile (or the
+        /// next `clear`) retries them.
+        pub(super) async fn clear(&mut self) {
+            let entries: Vec<(Ipv4Addr, Ipv4Addr)> =
+                self.installed.iter().map(|(ip, gw)| (*ip, *gw)).collect();
+            for (ip, gw) in entries {
+                self.remove_one(ip, gw).await;
+            }
+            if !self.installed.is_empty() {
+                tracing::warn!(remaining = ?self.installed, "some bypass routes could not be removed");
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::sync::Mutex;
+
+        #[derive(Default)]
+        struct FakeOps {
+            // simulated routing table: ip -> gateway (None = non-gateway entry)
+            table: Mutex<BTreeMap<Ipv4Addr, Option<Ipv4Addr>>>,
+            fail_remove: Mutex<std::collections::BTreeSet<Ipv4Addr>>,
+            removed: Mutex<Vec<Ipv4Addr>>,
+        }
+
+        impl RouteOps for FakeOps {
+            async fn add_host_route_via_gateway(
+                &self,
+                ip: Ipv4Addr,
+                gateway: Ipv4Addr,
+            ) -> Result<(), Error> {
+                let mut table = self.table.lock().unwrap();
+                if table.contains_key(&ip) {
+                    return Err(Error::ShellCommandError("File exists".into()));
+                }
+                table.insert(ip, Some(gateway));
+                Ok(())
+            }
+            async fn remove_host_route(&self, ip: Ipv4Addr) -> Result<(), Error> {
+                if self.fail_remove.lock().unwrap().contains(&ip) {
+                    return Err(Error::ShellCommandError("simulated failure".into()));
+                }
+                self.table.lock().unwrap().remove(&ip);
+                self.removed.lock().unwrap().push(ip);
+                Ok(())
+            }
+            async fn query_host_route(&self, ip: Ipv4Addr) -> HostRouteQuery {
+                match self.table.lock().unwrap().get(&ip) {
+                    None => HostRouteQuery::Missing,
+                    Some(gw) => HostRouteQuery::Entry { gateway: *gw },
+                }
+            }
+        }
+
+        fn ip(s: &str) -> Ipv4Addr {
+            s.parse().unwrap()
+        }
+
+        #[tokio::test]
+        async fn eexist_add_is_not_tracked_and_never_deleted() {
+            let ops = FakeOps::default();
+            // someone else's /32 for the same endpoint pre-exists
+            ops.table
+                .lock()
+                .unwrap()
+                .insert(ip("1.2.3.4"), Some(ip("10.0.0.1")));
+            let mut mgr = BypassRouteManager::new(ops);
+            mgr.add_one(ip("1.2.3.4"), ip("192.168.0.1")).await;
+            assert!(mgr.installed.is_empty());
+            mgr.clear().await;
+            assert!(mgr.ops.removed.lock().unwrap().is_empty());
+            assert!(mgr.ops.table.lock().unwrap().contains_key(&ip("1.2.3.4")));
+        }
+
+        #[tokio::test]
+        async fn failed_removal_is_retained_and_retried() {
+            let mut mgr = BypassRouteManager::new(FakeOps::default());
+            mgr.add_one(ip("1.2.3.4"), ip("192.168.0.1")).await;
+            mgr.ops.fail_remove.lock().unwrap().insert(ip("1.2.3.4"));
+            mgr.sync(&BTreeSet::new(), ip("192.168.0.1")).await;
+            assert_eq!(mgr.installed.len(), 1); // kept for retry
+            mgr.ops.fail_remove.lock().unwrap().clear();
+            mgr.sync(&BTreeSet::new(), ip("192.168.0.1")).await;
+            assert!(mgr.installed.is_empty());
+            assert!(!mgr.ops.table.lock().unwrap().contains_key(&ip("1.2.3.4")));
+        }
+
+        #[tokio::test]
+        async fn foreign_replacement_is_not_deleted() {
+            let mut mgr = BypassRouteManager::new(FakeOps::default());
+            mgr.add_one(ip("1.2.3.4"), ip("192.168.0.1")).await;
+            // someone replaced our route with theirs
+            mgr.ops
+                .table
+                .lock()
+                .unwrap()
+                .insert(ip("1.2.3.4"), Some(ip("10.9.9.9")));
+            mgr.clear().await;
+            assert!(mgr.installed.is_empty()); // off the books...
+            assert!(mgr.ops.table.lock().unwrap().contains_key(&ip("1.2.3.4"))); // ...but not deleted
+        }
+
+        #[tokio::test]
+        async fn gateway_change_reinstalls_route() {
+            let mut mgr = BypassRouteManager::new(FakeOps::default());
+            let desired: BTreeSet<Ipv4Addr> = [ip("1.2.3.4")].into();
+            mgr.sync(&desired, ip("192.168.0.1")).await;
+            mgr.sync(&desired, ip("192.168.5.1")).await;
+            assert_eq!(mgr.installed.get(&ip("1.2.3.4")), Some(&ip("192.168.5.1")));
+            assert_eq!(
+                mgr.ops.table.lock().unwrap().get(&ip("1.2.3.4")),
+                Some(&Some(ip("192.168.5.1")))
+            );
+        }
+    }
+}
+
+/// Resolve a URI to IPv4 addresses (supports IP literals and hostname DNS resolution)
+#[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
+async fn resolve_uri_to_ipv4s(uri: &url::Url) -> Vec<std::net::Ipv4Addr> {
+    use std::net::Ipv4Addr;
+    let mut ips = Vec::new();
+    if let Some(host) = uri.host_str() {
+        if let Ok(ip) = host.parse::<Ipv4Addr>() {
+            ips.push(ip);
+            return ips;
+        }
+        if let Ok(addrs) = tokio::net::lookup_host(format!("{}:0", host)).await {
+            for addr in addrs {
+                if let std::net::SocketAddr::V4(v4) = addr {
+                    ips.push(*v4.ip());
+                }
+            }
+        }
+    }
+    ips
+}
+
+/// Extract the underlay remote IPv4 of a peer connection (the on-wire
+/// endpoint, i.e. the hole-punched address for punched conns).
+#[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
+fn conn_remote_ipv4(
+    conn: &crate::proto::api::instance::PeerConnInfo,
+) -> Option<std::net::Ipv4Addr> {
+    let url = conn.tunnel.as_ref()?.effective_remote_addr()?;
+    let parsed = url::Url::parse(&url.url).ok()?;
+    // note: for non-special schemes like udp:// the url crate reports the
+    // host as an opaque domain even when it is an IP literal, so parse the
+    // host string instead of matching url::Host::Ipv4
+    parsed.host_str()?.parse().ok()
+}
+
+/// IPv4 subnets directly connected on physical (non-TUN) interfaces. IPs
+/// inside them are reachable via connected routes that already beat the /1
+/// TUN routes, so they need no bypass.
+#[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
+fn physical_onlink_v4_subnets() -> Vec<(std::net::Ipv4Addr, std::net::Ipv4Addr)> {
+    use network_interface::NetworkInterfaceConfig;
+    let mut subnets = vec![];
+    let Ok(ifaces) = network_interface::NetworkInterface::show() else {
+        return subnets;
+    };
+    for iface in ifaces {
+        if iface.name.starts_with("utun") || iface.name.starts_with("lo") {
+            continue;
+        }
+        for addr in iface.addr {
+            if let network_interface::Addr::V4(v4) = addr
+                && let Some(netmask) = v4.netmask
+            {
+                subnets.push((v4.ip, netmask));
+            }
+        }
+    }
+    subnets
+}
+
+#[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
+fn is_in_any_v4_subnet(
+    ip: std::net::Ipv4Addr,
+    subnets: &[(std::net::Ipv4Addr, std::net::Ipv4Addr)],
+) -> bool {
+    subnets
+        .iter()
+        .any(|(addr, mask)| u32::from(ip) & u32::from(*mask) == u32::from(*addr) & u32::from(*mask))
+}
+
+#[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
+fn is_bypass_candidate_ipv4(
+    ip: std::net::Ipv4Addr,
+    onlink_subnets: &[(std::net::Ipv4Addr, std::net::Ipv4Addr)],
+    global_ctx: &crate::common::global_ctx::ArcGlobalCtx,
+) -> bool {
+    !ip.is_loopback()
+        && !ip.is_unspecified()
+        && !ip.is_multicast()
+        && !is_in_any_v4_subnet(ip, onlink_subnets)
+        && global_ctx
+            .get_ipv4()
+            .is_none_or(|net| !net.network().contains(&ip))
+}
+
+/// All remote IPv4 endpoints easytier's underlay may talk to: configured
+/// peers and live peer connections (including hole-punched endpoints that
+/// appear in no config). STUN probes need no bypass — their sockets are
+/// interface-bound (see bind_underlay_udp_socket).
+#[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
+async fn collect_underlay_bypass_ips(
+    global_ctx: &crate::common::global_ctx::ArcGlobalCtx,
+    peer_mgr: &std::sync::Arc<crate::peers::peer_manager::PeerManager>,
+) -> std::collections::BTreeSet<std::net::Ipv4Addr> {
+    let mut ips = std::collections::BTreeSet::new();
+
+    for peer in global_ctx.config.get_peers() {
+        let resolved = resolve_uri_to_ipv4s(&peer.uri).await;
+        if resolved.is_empty() {
+            tracing::warn!(uri = %peer.uri, "failed to resolve peer URI for bypass route");
+        }
+        ips.extend(resolved);
+    }
+
+    let peer_map = peer_mgr.get_peer_map();
+    for peer_id in peer_map.list_peers_with_conn().await {
+        for conn in peer_map.list_peer_conns(peer_id).await.unwrap_or_default() {
+            ips.extend(conn_remote_ipv4(&conn));
+        }
+    }
+
+    let onlink_subnets = physical_onlink_v4_subnets();
+    ips.retain(|ip| is_bypass_candidate_ipv4(*ip, &onlink_subnets, global_ctx));
+    ips
+}
+
+/// Reconcile bypass host routes with the current desired endpoint set. Only
+/// active while broad TUN routes (prefix <= 1) are installed or about to be.
+#[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
+async fn sync_macos_bypass_routes(
+    bypass: &mut macos_bypass::BypassRouteManager<impl macos_bypass::RouteOps>,
+    cur_proxy_cidrs: &BTreeSet<cidr::Ipv4Cidr>,
+    pending_added: &[cidr::Ipv4Cidr],
+    global_ctx: &crate::common::global_ctx::ArcGlobalCtx,
+    peer_mgr: &std::sync::Arc<crate::peers::peer_manager::PeerManager>,
+) {
+    let full_tunnel = cur_proxy_cidrs
+        .iter()
+        .chain(pending_added.iter())
+        .any(|c| c.network_length() <= 1);
+    if !full_tunnel {
+        bypass.clear().await;
+        return;
+    }
+
+    let Some(route) = crate::arch::macos::get_default_route_v4() else {
+        // transient loss of the default route (e.g. wifi roaming) should not
+        // tear down routes that may come back into effect
+        tracing::warn!("no physical default route, skip bypass route sync");
+        return;
+    };
+    let ips = collect_underlay_bypass_ips(global_ctx, peer_mgr).await;
+    tracing::debug!(?ips, gateway = ?route.gateway, "syncing underlay bypass routes");
+    bypass.sync(&ips, route.gateway).await;
+}
+
 #[cfg(test)]
 mod tests {
     use crate::common::{error::Error, global_ctx::tests::get_mock_global_ctx};
 
     use super::VirtualNic;
+
+    #[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
+    #[test]
+    fn test_is_in_any_v4_subnet() {
+        let subnets = vec![
+            ("192.168.0.20".parse().unwrap(), "255.255.255.0".parse().unwrap()),
+            ("10.0.0.1".parse().unwrap(), "255.0.0.0".parse().unwrap()),
+        ];
+        assert!(super::is_in_any_v4_subnet(
+            "192.168.0.1".parse().unwrap(),
+            &subnets
+        ));
+        assert!(super::is_in_any_v4_subnet(
+            "10.200.1.1".parse().unwrap(),
+            &subnets
+        ));
+        assert!(!super::is_in_any_v4_subnet(
+            "192.168.2.1".parse().unwrap(),
+            &subnets
+        ));
+        assert!(!super::is_in_any_v4_subnet(
+            "220.203.172.102".parse().unwrap(),
+            &subnets
+        ));
+    }
+
+    #[cfg(all(target_os = "macos", not(feature = "macos-ne")))]
+    #[test]
+    fn test_conn_remote_ipv4() {
+        use crate::proto::{
+            api::instance::PeerConnInfo,
+            common::{TunnelInfo, Url},
+        };
+
+        let mk = |remote: Option<&str>, resolved: Option<&str>| PeerConnInfo {
+            tunnel: Some(TunnelInfo {
+                tunnel_type: "udp".to_string(),
+                local_addr: None,
+                remote_addr: remote.map(|u| Url { url: u.to_string() }),
+                resolved_remote_addr: resolved.map(|u| Url { url: u.to_string() }),
+            }),
+            ..Default::default()
+        };
+
+        // resolved addr (the on-wire endpoint) wins over the configured one
+        assert_eq!(
+            super::conn_remote_ipv4(&mk(
+                Some("udp://example.com:11010"),
+                Some("udp://220.203.172.102:23456")
+            )),
+            Some("220.203.172.102".parse().unwrap())
+        );
+        assert_eq!(
+            super::conn_remote_ipv4(&mk(Some("tcp://8.219.8.190:11010"), None)),
+            Some("8.219.8.190".parse().unwrap())
+        );
+        // hostname-only url has no ipv4 to bypass
+        assert_eq!(
+            super::conn_remote_ipv4(&mk(Some("tcp://example.com:11010"), None)),
+            None
+        );
+        assert_eq!(super::conn_remote_ipv4(&PeerConnInfo::default()), None);
+    }
+
 
     async fn run_test_helper() -> Result<VirtualNic, Error> {
         let mut dev = VirtualNic::new(get_mock_global_ctx());

--- a/easytier/src/tunnel/common.rs
+++ b/easytier/src/tunnel/common.rs
@@ -448,25 +448,29 @@ fn setup_socket2_ext(
     // #[cfg(all(unix, not(target_os = "solaris"), not(target_os = "illumos")))]
     // socket2_socket.set_reuse_port(true)?;
 
-    if bind_addr.ip().is_unspecified() {
-        return Ok(());
-    }
-
     // linux/mac does not use interface of bind_addr to send packet, so we need to bind device
     // win can handle this with bind correctly
+    // NOTE: unlike the linux branch below, this runs even for wildcard bind_addr —
+    // underlay sockets rely on it to escape TUN routes (see bind_underlay_udp_socket).
     #[cfg(any(target_os = "ios", target_os = "macos"))]
     if let Some(dev_name) = bind_dev {
         // use IP_BOUND_IF to bind device
-        unsafe {
-            let dev_idx = nix::libc::if_nametoindex(dev_name.as_str().as_ptr() as *const i8);
-            tracing::warn!(?dev_idx, ?dev_name, "bind device");
-            if bind_addr.is_ipv4() {
-                socket2_socket.bind_device_by_index_v4(std::num::NonZeroU32::new(dev_idx))?;
-            } else {
-                socket2_socket.bind_device_by_index_v6(std::num::NonZeroU32::new(dev_idx))?;
-            }
-            tracing::warn!(?dev_idx, ?dev_name, "bind device doen");
+        let dev_idx = std::ffi::CString::new(dev_name.as_str())
+            .ok()
+            .map(|name| unsafe { nix::libc::if_nametoindex(name.as_ptr()) })
+            .unwrap_or(0);
+        tracing::debug!(?dev_idx, ?dev_name, "bind device");
+        if dev_idx == 0 {
+            tracing::warn!(?dev_name, "bind device failed, interface not found");
+        } else if bind_addr.is_ipv4() {
+            socket2_socket.bind_device_by_index_v4(std::num::NonZeroU32::new(dev_idx))?;
+        } else {
+            socket2_socket.bind_device_by_index_v6(std::num::NonZeroU32::new(dev_idx))?;
         }
+    }
+
+    if bind_addr.ip().is_unspecified() {
+        return Ok(());
     }
 
     #[cfg(any(
@@ -572,6 +576,75 @@ pub fn bind<B: Bindable>(
     let socket = socket2::Socket::new(socket2::Domain::for_address(addr), B::TYPE, B::PROTOCOL)?;
     setup_socket2_ext(&socket, &addr, dev, only_v6, socket_mark)?;
     B::finalize(socket)
+}
+
+/// Binds a UDP socket carrying underlay (tunnel transport) traffic, e.g. hole
+/// punch sockets and direct-connect probes.
+///
+/// On macOS a wildcard-bound socket follows the routing table, so when broad
+/// routes point at a TUN device (easytier full tunnel or another VPN), the
+/// tunnel's own packets would be captured by that TUN and loop back into
+/// easytier. When `bind_device` is enabled, bind the socket to the physical
+/// default-route interface via IP_BOUND_IF to keep underlay traffic on the
+/// physical network. Falls back to a plain bind if no physical default route
+/// is found or the device bind fails.
+pub async fn bind_underlay_udp_socket(
+    addr: SocketAddr,
+    #[allow(unused_variables)] bind_device: bool,
+) -> Result<UdpSocket, TunnelError> {
+    #[cfg(target_os = "macos")]
+    if bind_device && addr.is_ipv4() {
+        if let Some(route) = crate::arch::macos::get_default_route_v4() {
+            match bind::<UdpSocket>()
+                .addr(addr)
+                .dev(BindDev::Custom(route.iface.clone()))
+                .call()
+            {
+                Ok(socket) => return Ok(socket),
+                Err(e) => {
+                    tracing::warn!(
+                        ?e,
+                        iface = %route.iface,
+                        "bind underlay udp socket to default route iface failed, fallback to unbound"
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(UdpSocket::bind(addr).await?)
+}
+
+/// Apply the underlay device binding (IP_BOUND_IF to the physical
+/// default-route interface) to a raw socket2 socket before it is bound or
+/// connected. No-op on non-macOS platforms, when `bind_device` is disabled,
+/// or when no physical default route is found.
+pub fn bind_socket2_to_underlay_device(
+    socket2_socket: &socket2::Socket,
+    is_ipv4: bool,
+    bind_device: bool,
+) {
+    #[cfg(target_os = "macos")]
+    if bind_device && is_ipv4 {
+        let Some(route) = crate::arch::macos::get_default_route_v4() else {
+            return;
+        };
+        let dev_idx = std::ffi::CString::new(route.iface.as_str())
+            .ok()
+            .map(|name| unsafe { nix::libc::if_nametoindex(name.as_ptr()) })
+            .unwrap_or(0);
+        let Some(idx) = std::num::NonZeroU32::new(dev_idx) else {
+            tracing::warn!(iface = %route.iface, "bind underlay device failed, interface not found");
+            return;
+        };
+        if let Err(e) = socket2_socket.bind_device_by_index_v4(Some(idx)) {
+            tracing::warn!(?e, iface = %route.iface, "bind underlay device failed");
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (socket2_socket, is_ipv4, bind_device);
+    }
 }
 
 pub fn reserve_buf(buf: &mut BytesMut, min_size: usize, max_size: usize) {


### PR DESCRIPTION
## 修复macOS exit-node 全隧道

复现:exit node 侧 `--enable-exit-node`,macOS 客户端 `--manual-routes 0.0.0.0/0 --exit-nodes <peer-ip>`,会遇到三个问题:

1. `0.0.0.0/0` 路由装不上:`apply_route_changes` 对所有 cidr 统一执行 `route -n add <addr> -netmask <mask> -interface utunX`(`ifcfg/darwin.rs`),0/0 与系统已有默认路由冲突而失败,只留一条 warn 日志,全隧道静默变成 no-op。
2. 就算装上路由(例如照 Windows `splitDefault` 拆成 0/1+128/1),EasyTier 自己的打洞、直连、STUN 流量也会被自己的 TUN 按路由表吸走,形成环路:p2p 全部失败,退化为relay。
3. STUN 探测同样走隧道出口,把出口节点的公网 IP 当成自己的公告给所有 peer,对端向错误地址打洞,必定失败。

下面按 commit 说明。

## Commit 1 — `fix(macos): support IP_BOUND_IF on wildcard binds and add underlay socket helpers`

**原代码问题**:`setup_socket2_ext`(`tunnel/common.rs`)里 `if bind_addr.ip().is_unspecified() { return Ok(()); }` 位于 macOS/iOS 的 `IP_BOUND_IF` 分支之前,而 EasyTier 的 underlay socket 几乎全部绑 `0.0.0.0:0`——**`bind_device` 在 macOS 上对这些 socket 从未生效过,绑设备逻辑是死代码**。
UB:`if_nametoindex(dev_name.as_str().as_ptr() as *const i8)` 把非 NUL 结尾的 Rust `String` 当 C 字符串传(越界读),接口名解析可能随机失败,改用 `CString`。

**方案**:`IP_BOUND_IF` 分支挪到 early-return 之前(仅动 macOS/iOS cfg 块,其余平台分支顺序不变)。新增 `arch/macos.rs`:用 `netstat -rn -f inet` 解析第一条非虚拟接口(排除 utun/tun/tap/feth/bridge/lo)的 IPv4 默认路由,10 秒 TTL 缓存,基于它提供两个 helper:

- `bind_underlay_udp_socket(addr, bind_device)`:UDP socket 绑到物理默认路由接口;绑定失败或找不到物理默认路由时回退普通 bind,不比现状差;
- `bind_socket2_to_underlay_device(...)`:同语义,作用于裸 socket2(TCP STUN 用),非 macOS 为 no-op。


## Commit 2 — `fix(macos): bind underlay sockets to the physical default-route interface`

**原代码问题**:所有 underlay socket 创建点都是裸 `bind("0.0.0.0:0")`,没有逃逸 TUN 的机制:打洞的 `UdpSocketArray` / `UdpHolePunchListener` / cone 客户端 local socket / `check_udp_socket_local_addr` 探针、`DirectConnectorManagerData` 的直连 socket、`UdpNatTypeDetector` / `TcpStunClient` / `get_udp_port_mapping` 的 STUN 探测。STUN 的破坏面最大:NAT 类型与公网映射地址会公告给 peer 并决定打洞策略,公告错了,对端就往错误地址打;且只影响需要打洞的 peer(公网 peer 走 TCP 直连不受影响),排查时极具误导性。

**方案**:上述创建点全部改走 commit 1 的 helper。开关复用既有 `flags.bind_device`(默认 `true`,`--bind-device false` 整体关闭),`GlobalCtx::new` 时同步给 `StunInfoCollector`(内部一个 `AtomicBool`,`cfg(test)` 下默认关)。另外:

- connector 多接口竞速(`set_bind_addr_for_peer_connector`)排除 utun 持有的本地 IP——从别家 VPN 的 TUN 地址拨号,好则绕路,坏则环路;
- mock GlobalCtx 强制 `bind_device = false`(单测走 loopback,绑物理接口会挂)。

**行为变化说明**:此前 `bind_device=true` 在 macOS 对 wildcard socket 是 no-op,本 commit 使其真正生效——非全隧道场景 underlay UDP 也会钉在默认路由接口(与路由表默认选择通常一致,但从"随路由表"变为"钉住")。不接受可 `--bind-device false`。

## Commit 3 — `fix(macos): install 0.0.0.0/0 as split gateway routes with underlay bypass`

**原代码问题与内核坑**:除 0/0 与系统默认路由冲突之外,实测发现:**XNU 给"目标地址为 0.0.0.0 的路由"(`default`、`0.0.0.0/1` 均算,接口型网关型均算)打 `RTF_GLOBAL` 标志(`netstat -rn` 的 `g`),scoped socket(`IP_BOUND_IF` / 绑源 IP)的 sendto 无法绕过它,直接 `EHOSTUNREACH`**。照搬 Windows 的 0/1+128/1 拆法,commit 1/2 的全部绑定会被 0.0.0.0/1 这一条路由废掉,STUN 和打洞依然全灭。实证链:同机对照 clash/mihomo——其 `128.0/1` 无 `g` 标志、scoped 发送正常、全表刻意没有 0.0.0.0 目标路由;我们的 /1 换接口型、网关型均复现失败,跳过 0.0.0.0 目标后恢复。

**方案(两部分)**:

1. 拆分默认路由:`apply_route_changes` 特判 `0.0.0.0/0`,装 clash 同款 8 条网关型路由(via TUN 自身 IPv4):`1/8, 2/7, 4/6, 8/5, 16/4, 32/3, 64/2, 128/1`,精确覆盖 1.0.0.0–255.255.255.255,刻意跳过保留段 0.0.0.0/8,使全表不出现 0.0.0.0 目标路由;网关型(UGSc)是实测能与 scoped socket 共存的形态。移除侧对称删 8 条,并清理旧版可能残留的 0.0.0.0/1。`darwin.rs` 新增 `add_ipv4_route_via_gateway` / `remove_ipv4_route_any`。
2. `/32` underlay bypass:UDP 打洞和 STUN 靠 `IP_BOUND_IF` 逃逸,但按本地 IP bind 的 TCP/WS 连接器流量仍按路由表走,需要路由层保护。全隧道生效期间,对"配置的 peers + 活跃连接的 on-wire 远端"维护 `/32` host 路由(via 物理网关):初装先于 TUN 路由;`PeerConnAdded` 事件即时保护刚打洞成功的新端点;15 秒 reconcile 修剪断连端点、跟随网关变化;非全隧道或 updater 退出时全部清除;瞬时丢失默认路由(Wi-Fi 漫游)不误拆;物理直连子网内地址、组播/环回/自身虚拟网段不加。