### PR TITLE
fix(rpc): handle closed bidirect transport channels

### DIFF
--- a/easytier/src/proto/rpc_impl/bidirect.rs
+++ b/easytier/src/proto/rpc_impl/bidirect.rs
@@ -160,10 +160,20 @@ impl BidirectRpcManager {
                     continue;
                 };
                 if peer_manager_header.packet_type == PacketType::RpcReq as u8 {
-                    server_tx.send(o).await.unwrap();
+                    if let Err(e) = server_tx.send(o).await {
+                        tracing::error!(error = ?e, "send rpc request to server failed");
+                        e_clone.lock().unwrap().replace(Error::from(e));
+                        r_clone.store(false, std::sync::atomic::Ordering::Relaxed);
+                        break;
+                    }
                     continue;
                 } else if peer_manager_header.packet_type == PacketType::RpcResp as u8 {
-                    client_tx.send(o).await.unwrap();
+                    if let Err(e) = client_tx.send(o).await {
+                        tracing::error!(error = ?e, "send rpc response to client failed");
+                        e_clone.lock().unwrap().replace(Error::from(e));
+                        r_clone.store(false, std::sync::atomic::Ordering::Relaxed);
+                        break;
+                    }
                     continue;
                 }
             }

--- a/easytier/src/proto/rpc_impl/bidirect.rs
+++ b/easytier/src/proto/rpc_impl/bidirect.rs
@@ -163,7 +163,6 @@ impl BidirectRpcManager {
                     if let Err(e) = server_tx.send(o).await {
                         tracing::error!(error = ?e, "send rpc request to server failed");
                         e_clone.lock().unwrap().replace(Error::from(e));
-                        r_clone.store(false, std::sync::atomic::Ordering::Relaxed);
                         break;
                     }
                     continue;
@@ -171,7 +170,6 @@ impl BidirectRpcManager {
                     if let Err(e) = client_tx.send(o).await {
                         tracing::error!(error = ?e, "send rpc response to client failed");
                         e_clone.lock().unwrap().replace(Error::from(e));
-                        r_clone.store(false, std::sync::atomic::Ordering::Relaxed);
                         break;
                     }
                     continue;


### PR DESCRIPTION
## Summary
- replace `unwrap()` when routing inbound RPC requests and responses to local transports
- record the closed-channel error and stop the dispatcher task instead of panicking
- port only the relevant handling from b4e8df85675d6d723bcef52dc04d8dc1878b9292; its core refactor is intentionally excluded

## Validation
- `cargo fmt --check`
- `cargo test -p easytier test_bidirect_rpc_manager --lib`