### PR TITLE
fix(web): 将 GET /api/v1/sessions 限定为当前登录用户

### DIFF
--- a/easytier-web/src/client_manager/mod.rs
+++ b/easytier-web/src/client_manager/mod.rs
@@ -161,6 +161,10 @@ impl ClientManager {
         self.storage.list_clients()
     }
 
+    pub async fn list_sessions_by_user_id(&self, user_id: UserIdInDb) -> Vec<StorageToken> {
+        self.storage.list_user_client_tokens(user_id)
+    }
+
     pub async fn list_all_sessions(&self) -> Vec<StorageToken> {
         self.storage.list_all_clients()
     }

--- a/easytier-web/src/client_manager/storage.rs
+++ b/easytier-web/src/client_manager/storage.rs
@@ -143,6 +143,21 @@ impl Storage {
         self.list_clients_with_auth(true)
     }
 
+    /// List authorized client sessions that belong to a single user only.
+    pub fn list_user_client_tokens(&self, user_id: UserIdInDb) -> Vec<StorageToken> {
+        self.0
+            .user_clients_map
+            .get(&user_id)
+            .map(|info_map| {
+                info_map
+                    .iter()
+                    .filter(|info| info.value().authorized)
+                    .map(|info| info.value().storage_token.clone())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
     pub fn list_all_clients(&self) -> Vec<StorageToken> {
         self.list_clients_with_auth(false)
     }

--- a/easytier-web/src/restful/mod.rs
+++ b/easytier-web/src/restful/mod.rs
@@ -14,7 +14,7 @@ use axum::response::Response;
 use axum::routing::{delete, post};
 use axum::{Extension, Json, Router, extract::State, routing::get};
 use axum_login::tower_sessions::{ExpiredDeletion, SessionManagerLayer};
-use axum_login::{AuthManagerLayerBuilder, AuthUser, AuthzBackend, login_required};
+use axum_login::{AuthManagerLayerBuilder, AuthUser, login_required};
 use axum_messages::MessagesManagerLayer;
 use easytier::common::config::{ConfigLoader, TomlConfigLoader};
 use easytier::launcher::NetworkConfig;
@@ -131,13 +131,10 @@ impl RestfulServer {
         auth_session: AuthSession,
         State(client_mgr): AppState,
     ) -> Result<Json<ListSessionJsonResp>, HttpHandleError> {
-        let perms = auth_session
-            .backend
-            .get_group_permissions(auth_session.user.as_ref().unwrap())
-            .await
-            .unwrap();
-        println!("{:?}", perms);
-        let ret = client_mgr.list_sessions().await;
+        let Some(user) = auth_session.user else {
+            return Err((StatusCode::UNAUTHORIZED, other_error("No such user").into()));
+        };
+        let ret = client_mgr.list_sessions_by_user_id(user.id()).await;
         Ok(ListSessionJsonResp(ret).into())
     }
 


### PR DESCRIPTION
## 概述 / Summary

`GET /api/v1/sessions`（`handle_list_all_sessions`）会把**所有用户**的会话返回给**任意已登录用户**。它挂在 `login_required!(Backend)` 下，但没有做任何按用户的鉴权。

改前代码（`easytier-web/src/restful/mod.rs`）：

```rust
async fn handle_list_all_sessions(
    auth_session: AuthSession,
    State(client_mgr): AppState,
) -> Result<Json<ListSessionJsonResp>, HttpHandleError> {
    let perms = auth_session
        .backend
        .get_group_permissions(auth_session.user.as_ref().unwrap())
        .await
        .unwrap();
    println!("{:?}", perms);              // 查了权限，但从未判断
    let ret = client_mgr.list_sessions().await;  // 返回所有用户的会话
    Ok(ListSessionJsonResp(ret).into())
}
```

`list_sessions()` → `Storage::list_clients()` → `list_clients_with_auth()` 遍历 `user_clients_map` 里的每个用户，返回各自的 `StorageToken { token, client_url, machine_id, user_id }`。因此低权限账户可读到他人设备的 `token` 与公网 `client_url`。由于当前 token 即用户名、并被用作设备接入凭据，拿到 token 即足以冒充他人设备接入。

`get_group_permissions` 的结果只被 `println!` 打印、从未用于任何判断 —— 看起来是一个没写完的鉴权检查。

## 修复 / Fix

将返回结果限定到调用者本人，沿用 `handle_get_summary` 已有的按用户模式（`list_machine_by_user_id(user.id())`）：

- 新增 `Storage::list_user_client_tokens(user_id)` —— 只返回该 `user_id` 下已授权的 `StorageToken`
- 新增 `ClientManager::list_sessions_by_user_id(user_id)` 包装方法
- `handle_list_all_sessions` 改为先解析当前用户（用返回 `401` 取代 `unwrap()` panic），只返回该用户自己的会话
- 移除遗留的调试 `println!` 以及不再使用的 `AuthzBackend` import

面向管理员的跨用户列举仍保留在独立的内部接口（`/api/internal/sessions` → `list_all_sessions`），该接口由 `internal_auth_middleware` 保护。

## 说明 / Notes

- `list_sessions()` 仍被 reconcile 路径与测试使用，故予以保留。
- 编译通过（`cargo check -p easytier-web`，改动 crate 零告警）。

审阅该 handler 时另外注意到几处相邻的加固点（种子默认账户 `user`/`admin` 仍可登录、验证码校验后未清除可重放、注册用户名无校验），如有需要可另开 issue/PR —— 本 PR 聚焦越权修复本身。
