### PR TITLE
增加easytier_ffi对Windows7的兼容

### DIFF
--- a/easytier-contrib/easytier-ffi/Cargo.toml
+++ b/easytier-contrib/easytier-ffi/Cargo.toml
@@ -26,3 +26,9 @@ log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 uuid = "1.17.0"
+
+[build-dependencies]
+thunk-rs = { git = "https://github.com/easytier/thunk.git", default-features = false, features = [
+    "win7",
+] }
+

--- a/easytier-contrib/easytier-ffi/build.rs
+++ b/easytier-contrib/easytier-ffi/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+
+    if target_os == "windows" && (target_arch == "x86" || target_arch == "x86_64") {
+        thunk::thunk();
+    }
+}


### PR DESCRIPTION
1. 新增 EasyTier\easytier-contrib\easytier-ffi\build.rs
2. EasyTier\easytier-contrib\easytier-ffi\Cargo.toml 追加了 [build-dependencies] 段，添加 thunk-rs 并启用 win7 feature