### PR TITLE
Require a full config server URL

### DIFF
--- a/easytier-core/src/management/full/web_client.rs
+++ b/easytier-core/src/management/full/web_client.rs
@@ -39,12 +39,8 @@ pub struct ConfigServerEndpoint {
 
 impl ConfigServerEndpoint {
     pub fn parse(input: &str, supports_scheme: impl FnOnce(&Url) -> bool) -> anyhow::Result<Self> {
-        let endpoint = match Url::parse(input) {
-            Ok(endpoint) => endpoint,
-            Err(_) => format!("udp://config-server.easytier.cn:22020/{input}")
-                .parse()
-                .map_err(|error| anyhow::anyhow!("failed to parse config server URL: {error}"))?,
-        };
+        let endpoint = Url::parse(input)
+            .map_err(|error| anyhow::anyhow!("failed to parse config server URL: {error}"))?;
         if !supports_scheme(&endpoint) {
             anyhow::bail!("unsupported config server scheme: {}", endpoint.scheme());
         }
@@ -371,12 +367,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn endpoint_normalizes_shorthand_and_non_websocket_paths() {
-        let endpoint = ConfigServerEndpoint::parse("team%2Ftoken", |_| true).unwrap();
+    fn endpoint_normalizes_non_websocket_paths() {
+        let endpoint =
+            ConfigServerEndpoint::parse("udp://example.com/team%2Ftoken", |_| true).unwrap();
         assert_eq!(endpoint.token(), "team/token");
-        assert_eq!(
-            endpoint.connect_url().as_str(),
-            "udp://config-server.easytier.cn:22020"
+        assert_eq!(endpoint.connect_url().as_str(), "udp://example.com");
+    }
+
+    #[test]
+    fn endpoint_rejects_token_shorthand() {
+        let error = ConfigServerEndpoint::parse("team%2Ftoken", |_| true).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("failed to parse config server URL")
         );
     }
 

--- a/easytier/locales/app.yml
+++ b/easytier/locales/app.yml
@@ -3,13 +3,11 @@ _version: 2
 core_clap:
   config_server:
     en: |+
-      config server address, allow format:
-      full url: --config-server udp://127.0.0.1:22020/admin, 'udp' can be replaced with tcp, ws, wss (when config server ws is proxied to wss)
-      only user name: --config-server admin, will use official server
+      config server address, must be a full URL:
+      --config-server udp://127.0.0.1:22020/admin, 'udp' can be replaced with tcp, ws, wss (when config server ws is proxied to wss)
     zh-CN: |+
-      配置服务器地址。允许格式：
-      完整URL：--config-server udp://127.0.0.1:22020/admin，udp可以根据配置服务器替换为 tcp，ws，wss(配置服务器ws被代理为wss时)
-      仅用户名：--config-server admin，将使用官方的服务器
+      配置服务器地址，必须使用完整 URL：
+      --config-server udp://127.0.0.1:22020/admin，udp 可以根据配置服务器替换为 tcp、ws、wss（配置服务器 ws 被代理为 wss 时）
   machine_id:
     en: |+
       the machine id to identify this machine, used for config recovery after disconnection, must be unique and fixed. by default it is loaded from persisted local state; on first start it may be migrated from system information or generated, then remains fixed.


### PR DESCRIPTION
## Summary
- require `-w/--config-server` to receive a full URL
- remove the bare username/token fallback to the decommissioned official config server
- update the English and Chinese CLI help text
- add coverage that rejects token-only input

## Root cause
Token-only values were expanded to `udp://config-server.easytier.cn:22020/<token>`, but that hosted service has been shut down.

## Impact
Users must now provide their own complete config server URL, for example `udp://127.0.0.1:22020/admin`.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p easytier-core endpoint_` 