### PR TITLE
Remove obsolete web console API host default

### DIFF
--- a/easytier-web/frontend/public/api_meta.js
+++ b/easytier-web/frontend/public/api_meta.js
@@ -1,3 +1,3 @@
 window.apiMeta = {
-    api_host: "https://config-server.easytier.cn"
+    api_host: ""
 }


### PR DESCRIPTION
## Summary
- clear the web console's default API host
- stop pre-filling the decommissioned `https://config-server.easytier.cn` service

## Impact
New users must explicitly enter the API host they want to use. Previously saved hosts remain available through the existing local history.

## Validation
- `corepack pnpm --dir easytier-web/frontend build`