### PR TITLE
fix(web-client): retry stalled config-server dials

### DIFF
--- a/easytier-core/src/management/full/web_client.rs
+++ b/easytier-core/src/management/full/web_client.rs
@@ -28,7 +28,18 @@ use super::{
 };
 
 const RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+// Keep retry ownership in this loop when transport or protocol handshakes stall.
+const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 const FEATURE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
+async fn connect_config_server(
+    connector: &dyn TunnelDialer,
+    timeout: std::time::Duration,
+) -> anyhow::Result<Box<dyn Tunnel>> {
+    time::timeout(timeout, connector.connect())
+        .await
+        .map_err(|_| anyhow::anyhow!("config-server connection timed out after {timeout:?}"))?
+}
 
 /// Normalized config-server endpoint and authentication token.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -168,7 +179,8 @@ where
         connector: Box<dyn TunnelDialer>,
     ) {
         loop {
-            let connection = match connector.connect().await {
+            let connection = match connect_config_server(connector.as_ref(), CONNECT_TIMEOUT).await
+            {
                 Ok(connection) => connection,
                 Err(error) => {
                     tracing::warn!(%error, "failed to connect to config server; retrying");
@@ -195,7 +207,9 @@ where
 
             if support_encryption && web_security::web_secure_tunnel_supported() {
                 drop(session);
-                let connection = match connector.connect().await {
+                let connection = match connect_config_server(connector.as_ref(), CONNECT_TIMEOUT)
+                    .await
+                {
                     Ok(connection) => connection,
                     Err(error) => {
                         connected.store(false, Ordering::Release);
@@ -368,7 +382,52 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        future::pending,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+
+    use async_trait::async_trait;
+
     use super::*;
+    use crate::tunnel::ring::create_ring_tunnel_pair;
+
+    struct StalledThenReadyDialer {
+        attempts: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl TunnelDialer for StalledThenReadyDialer {
+        async fn connect(&self) -> anyhow::Result<Box<dyn Tunnel>> {
+            if self.attempts.fetch_add(1, Ordering::Relaxed) == 0 {
+                return pending().await;
+            }
+
+            let (tunnel, _peer) = create_ring_tunnel_pair();
+            Ok(tunnel)
+        }
+
+        fn remote_url(&self) -> Url {
+            "ring://config-server".parse().unwrap()
+        }
+    }
+
+    #[tokio::test]
+    async fn stalled_connection_attempt_times_out_and_allows_redial() {
+        let connector = StalledThenReadyDialer {
+            attempts: AtomicUsize::new(0),
+        };
+
+        let error = connect_config_server(&connector, std::time::Duration::from_millis(10))
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("connection timed out"));
+
+        connect_config_server(&connector, std::time::Duration::from_secs(1))
+            .await
+            .unwrap();
+        assert_eq!(connector.attempts.load(Ordering::Relaxed), 2);
+    }
 
     #[test]
     fn endpoint_normalizes_shorthand_and_non_websocket_paths() {


### PR DESCRIPTION
## Summary

- bound every config-server dial attempt to a 20-second deadline so the WebClient retry loop always regains control
- apply the same deadline to both the initial connection and the secure-tunnel reconnect
- add a regression test where the first dial future remains pending forever and the next attempt succeeds

## Root cause

`WebClient` awaited `TunnelDialer::connect()` without an outer deadline. The native config-server adapter uses the one-shot `ManualTunnelConnector::connect()` path, which does not inherit the staged timeout budget used by the peer-manager reconnect path.

Under high latency or packet loss, a transport or protocol handshake can therefore remain pending while the underlying socket still appears established. Because the future never returns, the WebClient loop never reaches its retry branch and does not dial again. Applying the deadline at the WebClient boundary provides transport-independent recovery from a stalled dial, but does not imply that every reported TCP, UDP, and WSS disconnection has the same underlying cause.

The field evidence below specifically supports a pre-session WSS TLS/WebSocket stall in version 2.6.4 and the current code path. Raw TCP and UDP reports require separate field evidence at their shared connection and session layers.

## Field evidence (redacted)

- observed on multiple released versions and reproduced on code paths still present in the current branch
- affected processes and their data-plane activity remained healthy while the web control connection stayed offline
- one Linux sample retained an established WSS socket with almost no traffic for roughly 16 hours
- its final control-plane log reported that encryption was supported and a secure reconnect was starting; no success or failure followed, although unrelated runtime logs continued
- occurrence correlates strongly with high latency and packet loss

Related to #2104.

## Validation

- `cargo test -p easytier-core management::full::web_client::tests`
- `cargo check -p easytier-core`
- `cargo fmt --all -- --check`
- `git diff --check`
