### PR TITLE
fix(tunnel): prevent WebSocket MapErr panic after send failure

### DIFF
--- a/easytier/src/tunnel/websocket.rs
+++ b/easytier/src/tunnel/websocket.rs
@@ -10,10 +10,12 @@ use easytier_core::{
     tunnel::{IpVersion, Tunnel, TunnelError, wrapper::TunnelWrapper},
 };
 use forwarded_header_value::ForwardedHeaderValue;
-use futures::{SinkExt, StreamExt};
+use futures::{Sink, StreamExt};
 use std::{
     net::{IpAddr, SocketAddr},
+    pin::Pin,
     sync::{Arc, LazyLock},
+    task::{Context, Poll},
     time::Duration,
 };
 use tokio::{net::TcpListener, time::timeout};
@@ -59,8 +61,46 @@ fn is_wss(url: &url::Url) -> Result<bool, TunnelError> {
     }
 }
 
-async fn sink_from_zc_packet<E>(packet: ZCPacket) -> Result<Message, E> {
-    Ok(Message::binary(packet.tunnel_payload_bytes().freeze()))
+struct WebSocketPacketSink<S> {
+    inner: S,
+}
+
+impl<S> WebSocketPacketSink<S> {
+    fn new(inner: S) -> Self {
+        Self { inner }
+    }
+}
+
+impl<S, E> Sink<ZCPacket> for WebSocketPacketSink<S>
+where
+    S: Sink<Message, Error = E> + Unpin,
+    E: std::fmt::Display,
+{
+    type Error = TunnelError;
+
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.inner)
+            .poll_ready(cx)
+            .map(|result| result.map_err(websocket_error))
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, packet: ZCPacket) -> Result<(), Self::Error> {
+        Pin::new(&mut self.inner)
+            .start_send(Message::binary(packet.tunnel_payload_bytes().freeze()))
+            .map_err(websocket_error)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.inner)
+            .poll_flush(cx)
+            .map(|result| result.map_err(websocket_error))
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.inner)
+            .poll_close(cx)
+            .map(|result| result.map_err(websocket_error))
+    }
 }
 
 async fn map_from_ws_message(
@@ -231,9 +271,7 @@ where
     };
     Ok(Box::new(TunnelWrapper::new(
         read.filter_map(map_from_ws_message),
-        write
-            .sink_map_err(websocket_error)
-            .with(sink_from_zc_packet::<TunnelError>),
+        WebSocketPacketSink::new(write),
         Some(info),
     )))
 }
@@ -365,9 +403,7 @@ where
     let (write, read) = client.split();
     Ok(Box::new(TunnelWrapper::new(
         read.filter_map(map_from_ws_message),
-        write
-            .sink_map_err(websocket_error)
-            .with(sink_from_zc_packet::<TunnelError>),
+        WebSocketPacketSink::new(write),
         Some(info),
     )))
 }
@@ -376,10 +412,65 @@ where
 pub mod tests {
     use super::*;
     use easytier_core::socket::SocketListener;
+    use futures::SinkExt;
+    use std::io;
     use tokio::{
         io::{AsyncReadExt, AsyncWriteExt},
         net::TcpSocket,
     };
+
+    struct FailingWebSocketSink {
+        close_called: bool,
+    }
+
+    impl Sink<Message> for FailingWebSocketSink {
+        type Error = io::Error;
+
+        fn poll_ready(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn start_send(self: Pin<&mut Self>, _item: Message) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "send failed",
+            )))
+        }
+
+        fn poll_close(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            self.close_called = true;
+            Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "close failed",
+            )))
+        }
+    }
+
+    #[tokio::test]
+    async fn packet_sink_maps_send_and_close_errors_independently() {
+        let mut sink = WebSocketPacketSink::new(FailingWebSocketSink {
+            close_called: false,
+        });
+
+        sink.send(ZCPacket::new_with_payload(b"packet"))
+            .await
+            .expect_err("send should fail");
+        sink.close().await.expect_err("close should fail");
+        assert!(sink.inner.close_called);
+    }
 
     #[tokio::test]
     async fn ws_forwarded() {


### PR DESCRIPTION
## 问题背景

当 WebSocket 连接在切网、对端断开或底层 Socket 异常时，发送阶段可能先返回一次错误。`MpscTunnel` 在停止转发后仍会执行 best-effort `close()`，如果关闭阶段再次返回错误，程序会触发：

```text
futures-util: polled MapErr after completion
```

这不是普通错误日志，而是一次真实的 panic。

## 根因

WebSocket 写端此前使用以下组合：

```rust
write
    .sink_map_err(websocket_error)
    .with(sink_from_zc_packet::<TunnelError>)
```

`futures-util::SinkMapErr` 将错误映射函数保存为 `Option<F>`，且 `F` 的约束是 `FnOnce`。

第一次发送或刷新错误会消费该映射函数：

```text
Some(websocket_error) -> None
```

随后 `MpscTunnel` 调用 `close()`。如果底层 WebSocket 因连接已经损坏而再次返回错误，`SinkMapErr` 会尝试再次取出映射函数，从而触发 `polled MapErr after completion` panic。

只有“发送错误后，关闭也返回错误”这一连续错误条件才会触发，因此普通断开不一定能复现。

## 修复方案

新增轻量的 `WebSocketPacketSink<S>`，直接实现：

- `poll_ready`
- `start_send`
- `poll_flush`
- `poll_close`

每次底层操作返回错误时，均独立调用 `websocket_error()` 转换为 `TunnelError`，不再保存或消费 `FnOnce` 映射函数。

同时在 `start_send()` 中直接将 `ZCPacket` 转换为 WebSocket binary `Message`，替代原有的 `.with()` 适配。

服务端和客户端两个 WebSocket 写端构造点均使用该适配器。

## 为什么不修改 MpscTunnel

此前的临时方案是在发送失败后跳过 `sink.close()`。虽然可以避开 panic，但会改变所有 Tunnel 的通用关闭语义，并可能跳过底层协议或会话需要的清理过程。

本次修复保持 `MpscTunnel` 与上游一致：

- 转发失败后仍执行 best-effort `close()`。
- 关闭最多等待 5 秒。
- 关闭错误保持可见，不伪装为成功。
- 任务结束后仍由 Drop 释放 WebSocket、TLS/TCP 及相关资源。

因此修复范围仅限 WebSocket 错误适配层，不影响其他 Tunnel。

## 回归测试

新增失败 Sink，模拟以下顺序：

1. `poll_ready()` 成功。
2. `start_send()` 成功。
3. `poll_flush()` 返回发送错误。
4. 随后的 `poll_close()` 确实被调用，并再次返回错误。

测试确认：

- 发送错误正常转换为 `TunnelError`。
- 关闭错误正常转换为 `TunnelError`。
- 不再发生 panic。
- 发送失败后仍然执行底层关闭流程。

## 验证结果

- `cargo test -p easytier tunnel::websocket::tests -- --nocapture`
  - 2 passed
- `cargo test -p easytier-core tunnel:: -- --nocapture`
  - 36 passed
- `cargo check -p easytier --all-targets`
  - passed
- HarmonyOS arm64 release OHRS HAR 构建成功
- ArkTS signed debug HAP 构建成功
- 下游实际运行验证通过

## 影响范围

- 不修改公开 API。
- 不修改 `MpscTunnel` 行为。
- 不影响非 WebSocket Tunnel。
- 同时覆盖 WebSocket 客户端与服务端。
- 保留原有关闭和 Drop 清理语义。