### PR TITLE
feat(listener): multiplex server UDP protocols

### DIFF
--- a/easytier-core/src/connectivity/direct/mod.rs
+++ b/easytier-core/src/connectivity/direct/mod.rs
@@ -1095,11 +1095,13 @@ where
                 .as_ref(),
         )
         .await;
+        let mut seen_listeners = HashSet::new();
         response.listeners = self
             .host
             .mapped_listeners()
             .into_iter()
             .chain(self.running_listeners.local_listener_urls())
+            .filter(|url| seen_listeners.insert(url.clone()))
             .map(Into::into)
             .collect();
         Ok(response)

--- a/easytier-core/src/connectivity/manual/mod.rs
+++ b/easytier-core/src/connectivity/manual/mod.rs
@@ -1062,6 +1062,14 @@ mod tests {
 
     use super::*;
 
+    #[test]
+    fn multiplexed_udp_protocols_share_manual_default_port() {
+        for scheme in ["udp", "wg", "quic"] {
+            let url = format!("{scheme}://peer.example").parse().unwrap();
+            assert_eq!(manual_default_port(&url), 11010);
+        }
+    }
+
     fn reserve_pending_connector(
         state: &Arc<ManualConnectorState>,
         url: &Url,

--- a/easytier-core/src/connectivity/protocol/mod.rs
+++ b/easytier-core/src/connectivity/protocol/mod.rs
@@ -80,7 +80,7 @@ pub trait ClientProtocolUpgrader<TcpSocket>: Send + Sync + 'static {
 
 #[async_trait]
 pub trait ServerTunnelAcceptor: Send + 'static {
-    async fn accept(&mut self) -> anyhow::Result<Box<dyn Tunnel>>;
+    async fn accept(&mut self) -> anyhow::Result<Option<Box<dyn Tunnel>>>;
 }
 
 pub enum ServerProtocolUpgrade {

--- a/easytier-core/src/connectivity/protocol/mod.rs
+++ b/easytier-core/src/connectivity/protocol/mod.rs
@@ -43,9 +43,9 @@ pub(crate) const fn protocol_uses_udp(scheme: &str) -> bool {
 /// into EasyTier's protocol-specific listener set.
 pub const fn protocol_port_offset(scheme: &str) -> Option<u16> {
     match scheme.as_bytes() {
-        b"tcp" | b"udp" => Some(0),
-        b"wg" | b"ws" => Some(1),
-        b"quic" | b"wss" => Some(2),
+        b"tcp" | b"udp" | b"wg" | b"quic" => Some(0),
+        b"ws" => Some(1),
+        b"wss" => Some(2),
         b"faketcp" => Some(3),
         _ => None,
     }
@@ -469,8 +469,8 @@ mod tests {
         let cases = [
             ("tcp", 0, 11010),
             ("udp", 0, 11010),
-            ("wg", 1, 11011),
-            ("quic", 2, 11012),
+            ("wg", 0, 11010),
+            ("quic", 0, 11010),
             ("ws", 1, 80),
             ("wss", 2, 443),
             ("faketcp", 3, 11013),

--- a/easytier-core/src/instance/tests.rs
+++ b/easytier-core/src/instance/tests.rs
@@ -137,7 +137,7 @@ fn core_plans_transport_and_external_listener_capabilities() {
 fn same_udp_endpoint_combines_protocol_routes() {
     let config = ListenerRuntimeConfig::new(
         [
-            "udp://127.0.0.1:11010?accept=udp",
+            "udp://127.0.0.1:11010/?accept=udp",
             "wg://127.0.0.1",
             "quic://127.0.0.1:11010",
         ]

--- a/easytier-core/src/instance/tests.rs
+++ b/easytier-core/src/instance/tests.rs
@@ -133,6 +133,48 @@ fn core_plans_transport_and_external_listener_capabilities() {
     assert_eq!(plan.external[0].1.socket_mark, Some(7));
 }
 
+#[test]
+fn same_udp_endpoint_combines_protocol_routes() {
+    let config = ListenerRuntimeConfig::new(
+        [
+            "udp://127.0.0.1:11010?accept=udp",
+            "wg://127.0.0.1",
+            "quic://127.0.0.1:11010",
+        ]
+        .into_iter()
+        .map(str::parse)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap(),
+        false,
+        SocketContext::default(),
+    );
+
+    let plan = prepare_listener_plan::<(), ()>(
+        Some(&config),
+        uuid::Uuid::new_v4(),
+        Some(&TestServerProtocol),
+        None,
+    )
+    .unwrap();
+    let udp = plan
+        .transports
+        .iter()
+        .filter(|transport| matches!(transport, TransportListenerConfig::Udp { .. }))
+        .collect::<Vec<_>>();
+
+    assert_eq!(udp.len(), 1);
+    assert!(matches!(
+        udp[0],
+        TransportListenerConfig::Udp {
+            url,
+            routes,
+            must_succeed: true,
+            ..
+        } if url.as_str() == "udp://127.0.0.1:11010"
+            && routes.iter().eq(UdpSessionAcceptKind::ALL)
+    ));
+}
+
 fn planned_udp_listener(
     listener: &str,
     server_protocol: Option<&dyn ServerProtocolUpgrader<()>>,

--- a/easytier-core/src/instance/tests.rs
+++ b/easytier-core/src/instance/tests.rs
@@ -8,7 +8,7 @@ use crate::{
     listener::transport::TransportListenerConfig,
     socket::{
         SocketContext, SocketListener,
-        udp::{UdpSessionAcceptKind, UdpSessionProtocol},
+        udp::{UdpSessionAcceptKind, UdpSessionProtocol, UdpSessionRouteSet},
     },
 };
 
@@ -114,19 +114,100 @@ fn core_plans_transport_and_external_listener_capabilities() {
     assert!(matches!(
         &plan.transports[4],
         TransportListenerConfig::Udp {
-            accept_kind: UdpSessionAcceptKind::Classified(UdpSessionProtocol::WireGuard),
+            routes,
             ..
-        }
+        } if *routes == UdpSessionRouteSet::singleton(
+            UdpSessionAcceptKind::Classified(UdpSessionProtocol::WireGuard)
+        )
     ));
     assert!(matches!(
         &plan.transports[5],
         TransportListenerConfig::Udp {
-            accept_kind: UdpSessionAcceptKind::Classified(UdpSessionProtocol::Quic),
+            routes,
             ..
-        }
+        } if *routes == UdpSessionRouteSet::singleton(
+            UdpSessionAcceptKind::Classified(UdpSessionProtocol::Quic)
+        )
     ));
     assert_eq!(plan.external[0].0.url.scheme(), "faketcp");
     assert_eq!(plan.external[0].1.socket_mark, Some(7));
+}
+
+fn planned_udp_listener(
+    listener: &str,
+    server_protocol: Option<&dyn ServerProtocolUpgrader<()>>,
+) -> anyhow::Result<(Url, UdpSessionRouteSet)> {
+    let config = ListenerRuntimeConfig::new(
+        vec![listener.parse().unwrap()],
+        false,
+        SocketContext::default(),
+    );
+    let plan = prepare_listener_plan::<(), ()>(
+        Some(&config),
+        uuid::Uuid::new_v4(),
+        server_protocol,
+        None,
+    )?;
+    plan.transports
+        .into_iter()
+        .find_map(|transport| match transport {
+            TransportListenerConfig::Udp { url, routes, .. } => Some((url, routes)),
+            _ => None,
+        })
+        .ok_or_else(|| anyhow::anyhow!("planned UDP listener is missing"))
+}
+
+#[test]
+fn udp_listener_accept_selects_routes_and_sanitizes_url() {
+    let all_routes = UdpSessionRouteSet::new([
+        UdpSessionAcceptKind::EasyTierMux,
+        UdpSessionAcceptKind::Classified(UdpSessionProtocol::WireGuard),
+        UdpSessionAcceptKind::Classified(UdpSessionProtocol::Quic),
+    ]);
+    let (_, default_routes) =
+        planned_udp_listener("udp://127.0.0.1:11010", Some(&TestServerProtocol)).unwrap();
+    let (_, explicit_all_routes) = planned_udp_listener(
+        "udp://127.0.0.1:11010?accept=all",
+        Some(&TestServerProtocol),
+    )
+    .unwrap();
+    assert_eq!(default_routes, all_routes);
+    assert_eq!(explicit_all_routes, all_routes);
+
+    let (url, selected_routes) = planned_udp_listener(
+        "udp://127.0.0.1:11010/device?accept=wg+udp&keep=value",
+        Some(&TestServerProtocol),
+    )
+    .unwrap();
+    assert_eq!(url.as_str(), "udp://127.0.0.1:11010/device?keep=value");
+    assert_eq!(
+        selected_routes.iter().collect::<Vec<_>>(),
+        vec![
+            UdpSessionAcceptKind::EasyTierMux,
+            UdpSessionAcceptKind::Classified(UdpSessionProtocol::WireGuard),
+        ]
+    );
+}
+
+#[test]
+fn udp_listener_accept_rejects_invalid_or_unavailable_routes() {
+    for listener in [
+        "udp://127.0.0.1:11010?accept=",
+        "udp://127.0.0.1:11010?accept=udp++wg",
+        "udp://127.0.0.1:11010?accept=udp+udp",
+        "udp://127.0.0.1:11010?accept=all+wg",
+        "udp://127.0.0.1:11010?accept=unknown",
+        "udp://127.0.0.1:11010?accept=udp&accept=wg",
+    ] {
+        assert!(
+            planned_udp_listener(listener, Some(&TestServerProtocol)).is_err(),
+            "{listener} should fail"
+        );
+    }
+    assert!(planned_udp_listener("udp://127.0.0.1:11010?accept=wg", None).is_err());
+    assert!(
+        planned_udp_listener("wg://127.0.0.1:11011?accept=wg", Some(&TestServerProtocol)).is_err()
+    );
 }
 
 #[test]

--- a/easytier-core/src/listener/mod.rs
+++ b/easytier-core/src/listener/mod.rs
@@ -382,10 +382,10 @@ async fn run_listener<Accepted, H>(
         let _registration = registered_listener.registration;
 
         loop {
-            let listener_url = listener.local_url();
             let accepted = match listener.accept().await {
                 Ok(accepted) => accepted,
                 Err(error) => {
+                    let listener_url = listener.local_url();
                     events.emit(CoreEvent::ListenerAcceptFailed {
                         url: listener_url.clone(),
                         error: format!("{error:?}"),
@@ -395,6 +395,7 @@ async fn run_listener<Accepted, H>(
                     break;
                 }
             };
+            let listener_url = listener.accepted_url(&accepted);
 
             events.emit(CoreEvent::ListenerSocketAccepted {
                 url: listener_url.clone(),
@@ -468,35 +469,38 @@ where
         events: Arc<dyn CoreEventSink>,
         registry: Arc<RunningListenerRegistry>,
     ) -> Self {
-        let url = listener.local_url();
-        let registry = registry.register(url.clone());
-        events.emit(CoreEvent::ListenerAdded {
-            url: url.clone(),
-            connection_counter: listener.connection_counter(),
-        });
+        let connection_counter = listener.connection_counter();
+        let aliases = listener
+            .advertised_urls()
+            .into_iter()
+            .map(|url| {
+                let registration = registry.register(url.clone());
+                events.emit(CoreEvent::ListenerAdded {
+                    url,
+                    connection_counter: connection_counter.clone(),
+                });
+                registration
+            })
+            .collect();
         Self {
             listener,
-            registration: ListenerRegistration {
-                url,
-                events,
-                registry: Some(registry),
-            },
+            registration: ListenerRegistration { events, aliases },
         }
     }
 }
 
 struct ListenerRegistration {
-    url: Url,
     events: Arc<dyn CoreEventSink>,
-    registry: Option<RunningListenerRegistration>,
+    aliases: Vec<RunningListenerRegistration>,
 }
 
 impl Drop for ListenerRegistration {
     fn drop(&mut self) {
-        drop(self.registry.take());
-        self.events.emit(CoreEvent::ListenerRemoved {
-            url: self.url.clone(),
-        });
+        for alias in self.aliases.drain(..) {
+            let url = alias.url.clone();
+            drop(alias);
+            self.events.emit(CoreEvent::ListenerRemoved { url });
+        }
     }
 }
 
@@ -619,6 +623,63 @@ mod tests {
         assert_eq!(registry.running_listeners(), vec![url.clone()]);
         drop(second);
         assert!(registry.running_listeners().is_empty());
+    }
+
+    #[test]
+    fn registered_listener_publishes_and_removes_every_alias() {
+        #[derive(Debug)]
+        struct AliasListener;
+
+        #[async_trait]
+        impl SocketListener for AliasListener {
+            type Accepted = usize;
+
+            async fn listen(&mut self) -> anyhow::Result<()> {
+                Ok(())
+            }
+
+            async fn accept(&mut self) -> anyhow::Result<Self::Accepted> {
+                std::future::pending().await
+            }
+
+            fn local_url(&self) -> Url {
+                "udp://127.0.0.1:11010".parse().unwrap()
+            }
+
+            fn advertised_urls(&self) -> Vec<Url> {
+                ["udp", "wg", "quic"]
+                    .map(|scheme| format!("{scheme}://127.0.0.1:11010").parse().unwrap())
+                    .to_vec()
+            }
+        }
+
+        let registry = Arc::new(RunningListenerRegistry::default());
+        let events = Arc::new(Events::default());
+        let listener =
+            RegisteredListener::new(Box::new(AliasListener), events.clone(), registry.clone());
+        assert_eq!(
+            registry.running_listeners(),
+            ["udp", "wg", "quic"]
+                .map(|scheme| format!("{scheme}://127.0.0.1:11010").parse().unwrap())
+        );
+
+        drop(listener);
+        assert!(registry.running_listeners().is_empty());
+        let events = events.events.lock().unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, CoreEvent::ListenerAdded { .. }))
+                .count(),
+            3
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, CoreEvent::ListenerRemoved { .. }))
+                .count(),
+            3
+        );
     }
 
     #[tokio::test]

--- a/easytier-core/src/listener/plan.rs
+++ b/easytier-core/src/listener/plan.rs
@@ -16,7 +16,7 @@ use crate::{
     socket::{
         SocketContext,
         tcp::{TcpBindOptions, TcpListenOptions},
-        udp::{UdpBindOptions, UdpSessionAcceptKind, UdpSessionListenRequest},
+        udp::{UdpBindOptions, UdpSessionAcceptKind, UdpSessionListenRequest, UdpSessionRouteSet},
     },
 };
 
@@ -183,26 +183,14 @@ where
                 });
             }
             ListenerKind::UdpSession => {
-                let accept_kind = match protocol_transport(listener.url.scheme()) {
-                    Some(ProtocolTransport::Udp(UdpSessionMode::EasyTierMux)) => {
-                        UdpSessionAcceptKind::EasyTierMux
-                    }
-                    Some(ProtocolTransport::Udp(UdpSessionMode::Classified(protocol))) => {
-                        UdpSessionAcceptKind::Classified(protocol)
-                    }
-                    _ => anyhow::bail!(
-                        "listener scheme {} cannot produce a core UDP session",
-                        listener.url.scheme()
-                    ),
-                };
-                let request = unresolved_udp_session_listen_request(
-                    &listener.url,
-                    config.socket_context.clone(),
-                );
+                let mut url = listener.url;
+                let routes = udp_listener_routes(&mut url, server_protocol)?;
+                let request =
+                    unresolved_udp_session_listen_request(&url, config.socket_context.clone());
                 transports.push(TransportListenerConfig::Udp {
-                    url: listener.url,
+                    url,
                     request,
-                    accept_kind,
+                    routes,
                     must_succeed,
                 });
             }
@@ -216,6 +204,101 @@ where
         external,
         failures: plan.failures,
     })
+}
+
+fn udp_listener_routes<TcpSocket: 'static>(
+    url: &mut Url,
+    server_protocol: Option<&dyn ServerProtocolUpgrader<TcpSocket>>,
+) -> anyhow::Result<UdpSessionRouteSet> {
+    let configured_url = url.clone();
+    let accept = take_listener_accept(url)?;
+    if url.scheme() != "udp" {
+        if accept.is_some() {
+            anyhow::bail!("accept is only valid on udp listeners, not {configured_url}");
+        }
+        let route = match protocol_transport(url.scheme()) {
+            Some(ProtocolTransport::Udp(UdpSessionMode::EasyTierMux)) => {
+                UdpSessionAcceptKind::EasyTierMux
+            }
+            Some(ProtocolTransport::Udp(UdpSessionMode::Classified(protocol))) => {
+                UdpSessionAcceptKind::Classified(protocol)
+            }
+            _ => anyhow::bail!(
+                "listener scheme {} cannot produce a core UDP session",
+                url.scheme()
+            ),
+        };
+        return Ok(UdpSessionRouteSet::singleton(route));
+    }
+
+    let supported = UdpSessionAcceptKind::ALL
+        .into_iter()
+        .filter(|route| udp_route_supported(*route, server_protocol))
+        .collect::<Vec<_>>();
+
+    let Some(accept) = accept else {
+        return Ok(UdpSessionRouteSet::new(supported));
+    };
+    let accept = accept.to_ascii_lowercase();
+    if accept == "all" {
+        return Ok(UdpSessionRouteSet::new(supported));
+    }
+
+    let mut selected = Vec::new();
+    let mut tokens = BTreeSet::new();
+    for token in accept.split(['+', ' ']) {
+        if token.is_empty() {
+            anyhow::bail!("udp listener {configured_url} has an empty accept token");
+        }
+        if token == "all" {
+            anyhow::bail!(
+                "udp listener {configured_url} cannot combine all with another accept token"
+            );
+        }
+        if !tokens.insert(token.to_owned()) {
+            anyhow::bail!("udp listener {configured_url} repeats accept protocol {token}");
+        }
+        let Some(route) = UdpSessionAcceptKind::ALL
+            .into_iter()
+            .find(|route| route.scheme() == token)
+        else {
+            anyhow::bail!("udp listener {configured_url} has unknown accept protocol {token}");
+        };
+        if !udp_route_supported(route, server_protocol) {
+            anyhow::bail!(
+                "udp listener {configured_url} explicitly accepts unsupported protocol {token}"
+            );
+        }
+        selected.push(route);
+    }
+    Ok(UdpSessionRouteSet::new(selected))
+}
+
+fn udp_route_supported<TcpSocket: 'static>(
+    route: UdpSessionAcceptKind,
+    server_protocol: Option<&dyn ServerProtocolUpgrader<TcpSocket>>,
+) -> bool {
+    route == UdpSessionAcceptKind::EasyTierMux
+        || server_protocol.is_some_and(|protocol| protocol.supports_scheme(route.scheme()))
+}
+
+fn take_listener_accept(url: &mut Url) -> anyhow::Result<Option<String>> {
+    let mut accept = None;
+    let mut retained = Vec::new();
+    for (key, value) in url.query_pairs() {
+        if key == "accept" {
+            if accept.replace(value.into_owned()).is_some() {
+                anyhow::bail!("listener {url} contains more than one accept parameter");
+            }
+        } else {
+            retained.push((key.into_owned(), value.into_owned()));
+        }
+    }
+    url.set_query(None);
+    if !retained.is_empty() {
+        url.query_pairs_mut().extend_pairs(retained);
+    }
+    Ok(accept)
 }
 
 fn validate_listener_protocols(

--- a/easytier-core/src/listener/plan.rs
+++ b/easytier-core/src/listener/plan.rs
@@ -185,6 +185,22 @@ where
             ListenerKind::UdpSession => {
                 let mut url = listener.url;
                 let routes = udp_listener_routes(&mut url, server_protocol)?;
+                normalize_udp_listener_url(&mut url)?;
+                let existing = transports.iter_mut().find_map(|transport| match transport {
+                    TransportListenerConfig::Udp {
+                        url: existing_url,
+                        routes: existing_routes,
+                        must_succeed: existing_must_succeed,
+                        ..
+                    } if existing_url == &url => Some((existing_routes, existing_must_succeed)),
+                    _ => None,
+                });
+                if let Some((existing_routes, existing_must_succeed)) = existing {
+                    *existing_routes =
+                        UdpSessionRouteSet::new(existing_routes.iter().chain(routes.iter()));
+                    *existing_must_succeed |= must_succeed;
+                    continue;
+                }
                 let request =
                     unresolved_udp_session_listen_request(&url, config.socket_context.clone());
                 transports.push(TransportListenerConfig::Udp {
@@ -272,6 +288,18 @@ fn udp_listener_routes<TcpSocket: 'static>(
         selected.push(route);
     }
     Ok(UdpSessionRouteSet::new(selected))
+}
+
+fn normalize_udp_listener_url(url: &mut Url) -> anyhow::Result<()> {
+    if url.port().is_none() {
+        let default_port = listener_default_port(url.scheme())
+            .ok_or_else(|| anyhow::anyhow!("listener has no default port: {url}"))?;
+        url.set_port(Some(default_port))
+            .map_err(|_| anyhow::anyhow!("listener cannot use a port: {url}"))?;
+    }
+    url.set_scheme("udp")
+        .map_err(|_| anyhow::anyhow!("failed to normalize UDP listener URL: {url}"))?;
+    Ok(())
 }
 
 fn udp_route_supported<TcpSocket: 'static>(

--- a/easytier-core/src/listener/plan.rs
+++ b/easytier-core/src/listener/plan.rs
@@ -297,6 +297,10 @@ fn normalize_udp_listener_url(url: &mut Url) -> anyhow::Result<()> {
         url.set_port(Some(default_port))
             .map_err(|_| anyhow::anyhow!("listener cannot use a port: {url}"))?;
     }
+    match listener_url_bind_device(url) {
+        Some(bind_device) => url.set_path(&format!("/{bind_device}")),
+        None => url.set_path(""),
+    }
     url.set_scheme("udp")
         .map_err(|_| anyhow::anyhow!("failed to normalize UDP listener URL: {url}"))?;
     Ok(())
@@ -582,5 +586,16 @@ mod tests {
         let url = "udp://0.0.0.0:11010/eth%2Btest".parse().unwrap();
 
         assert_eq!(listener_url_bind_device(&url), Some("eth+test".to_owned()));
+    }
+
+    #[test]
+    fn udp_listener_normalization_uses_effective_bind_device() {
+        let mut encoded = "wg://0.0.0.0/eth%2Btest".parse().unwrap();
+        let mut plain = "quic://0.0.0.0:11010/eth+test".parse().unwrap();
+
+        normalize_udp_listener_url(&mut encoded).unwrap();
+        normalize_udp_listener_url(&mut plain).unwrap();
+
+        assert_eq!(encoded, plain);
     }
 }

--- a/easytier-core/src/listener/transport.rs
+++ b/easytier-core/src/listener/transport.rs
@@ -22,8 +22,9 @@ use crate::{
         IpVersion, ListenerConnectionCounter, SocketContext, SocketListener,
         tcp::{TcpListenOptions, TcpSocketListener, VirtualTcpListener, VirtualTcpListenerFactory},
         udp::{
-            UdpSession, UdpSessionAcceptKind, UdpSessionListenRequest, UdpSessionSocket,
-            UdpSessionSocketListener, VirtualUdpSocketFactory,
+            RoutedUdpSession, UdpSession, UdpSessionAcceptKind, UdpSessionListenRequest,
+            UdpSessionRouteSet, UdpSessionSocket, UdpSessionSocketListener,
+            VirtualUdpSocketFactory,
         },
     },
     tunnel::{Tunnel, ring::RingTunnelRegistry},
@@ -104,10 +105,12 @@ where
     async fn handle_upgrade(&self, upgrade: ServerProtocolUpgrade) -> anyhow::Result<()> {
         match upgrade {
             ServerProtocolUpgrade::Tunnel(tunnel) => self.handle_tunnel(tunnel).await,
-            ServerProtocolUpgrade::Acceptor(mut acceptor) => loop {
-                let tunnel = acceptor.accept().await?;
-                let _ = self.handle_tunnel(tunnel).await;
-            },
+            ServerProtocolUpgrade::Acceptor(mut acceptor) => {
+                while let Some(tunnel) = acceptor.accept().await? {
+                    let _ = self.handle_tunnel(tunnel).await;
+                }
+                Ok(())
+            }
         }
     }
 }
@@ -184,7 +187,7 @@ pub(crate) enum TransportListenerConfig {
     Udp {
         url: Url,
         request: UdpSessionListenRequest,
-        accept_kind: UdpSessionAcceptKind,
+        routes: UdpSessionRouteSet,
         must_succeed: bool,
     },
 }
@@ -211,9 +214,11 @@ impl TransportListenerConfig {
                 self,
                 Self::Udp {
                     url,
-                    accept_kind: UdpSessionAcceptKind::EasyTierMux,
+                    routes,
                     ..
                 } if url.scheme() == "udp"
+                    && routes.len() == 1
+                    && routes.contains(UdpSessionAcceptKind::EasyTierMux)
             )
     }
 }
@@ -408,7 +413,7 @@ where
 {
     url: Url,
     request: UdpSessionListenRequest,
-    accept_kind: UdpSessionAcceptKind,
+    routes: UdpSessionRouteSet,
     host: Arc<H>,
     dns: Arc<dyn DnsResolver>,
     inner: Option<UdpSessionSocketListener<H>>,
@@ -423,19 +428,19 @@ where
     fn new(
         url: Url,
         request: UdpSessionListenRequest,
-        accept_kind: UdpSessionAcceptKind,
+        routes: UdpSessionRouteSet,
         host: Arc<H>,
         dns: Arc<dyn DnsResolver>,
     ) -> Self {
-        let protocol_admission = matches!(
-            accept_kind,
-            UdpSessionAcceptKind::Classified(crate::socket::udp::UdpSessionProtocol::Quic)
-        )
-        .then(ServerProtocolAdmissionController::quic);
+        let protocol_admission = routes
+            .contains(UdpSessionAcceptKind::Classified(
+                crate::socket::udp::UdpSessionProtocol::Quic,
+            ))
+            .then(ServerProtocolAdmissionController::quic);
         Self {
             url,
             request,
-            accept_kind,
+            routes,
             host,
             dns,
             inner: None,
@@ -459,7 +464,7 @@ where
         formatter
             .debug_struct("UdpTransportListener")
             .field("url", &self.url)
-            .field("accept_kind", &self.accept_kind)
+            .field("routes", &self.routes)
             .field("listening", &self.inner.is_some())
             .finish()
     }
@@ -492,10 +497,10 @@ where
             };
             request.bind.only_v6 = local_addr.is_ipv6();
         }
-        let mut inner = UdpSessionSocketListener::new_with_request(
+        let mut inner = UdpSessionSocketListener::new_with_routes(
             self.url.clone(),
             request,
-            self.accept_kind,
+            self.routes,
             self.host.clone(),
         );
         inner.listen().await?;
@@ -505,9 +510,12 @@ where
 
     async fn accept(&mut self) -> anyhow::Result<Self::Accepted> {
         loop {
-            let session = self.inner()?.accept().await?;
-            let admission = match &self.protocol_admission {
-                Some(controller) => match controller.try_admit() {
+            let RoutedUdpSession { session, route } = self.inner()?.accept_routed_session().await?;
+            let admission = match (&self.protocol_admission, route) {
+                (
+                    Some(controller),
+                    UdpSessionAcceptKind::Classified(crate::socket::udp::UdpSessionProtocol::Quic),
+                ) => match controller.try_admit() {
                     Some(admission) => Some(admission),
                     None => {
                         tracing::debug!(
@@ -517,11 +525,11 @@ where
                         continue;
                     }
                 },
-                None => None,
+                _ => None,
             };
             return Ok(AcceptedTransport::Udp {
                 session,
-                local_url: self.local_url(),
+                local_url: udp_route_url(&self.local_url(), route),
                 admission,
             });
         }
@@ -534,12 +542,32 @@ where
             .unwrap_or_else(|| self.url.clone())
     }
 
+    fn advertised_urls(&self) -> Vec<Url> {
+        let local_url = self.local_url();
+        self.routes
+            .iter()
+            .map(|route| udp_route_url(&local_url, route))
+            .collect()
+    }
+
+    fn accepted_url(&self, accepted: &Self::Accepted) -> Url {
+        accepted.local_url().clone()
+    }
+
     fn connection_counter(&self) -> Arc<dyn ListenerConnectionCounter> {
         self.inner
             .as_ref()
             .map(SocketListener::connection_counter)
             .unwrap_or_else(|| Arc::new(EmptyTransportConnectionCounter))
     }
+}
+
+fn udp_route_url(physical_url: &Url, route: UdpSessionAcceptKind) -> Url {
+    let mut logical_url = physical_url.clone();
+    logical_url
+        .set_scheme(route.scheme())
+        .expect("UDP route schemes must be valid URL schemes");
+    logical_url
 }
 
 #[derive(Debug)]
@@ -647,7 +675,7 @@ where
                 TransportListenerConfig::Udp {
                     url,
                     request,
-                    accept_kind,
+                    routes,
                     ..
                 } => {
                     let host = host.clone();
@@ -657,7 +685,7 @@ where
                             Box::new(UdpTransportListener::new(
                                 url.clone(),
                                 request.clone(),
-                                accept_kind,
+                                routes,
                                 host.clone(),
                                 dns.clone(),
                             ))
@@ -987,10 +1015,8 @@ mod tests {
 
     #[async_trait]
     impl ServerTunnelAcceptor for QueueTunnelAcceptor {
-        async fn accept(&mut self) -> anyhow::Result<Box<dyn crate::tunnel::Tunnel>> {
-            self.tunnels
-                .pop_front()
-                .ok_or_else(|| anyhow::anyhow!("server tunnel acceptor finished"))
+        async fn accept(&mut self) -> anyhow::Result<Option<Box<dyn crate::tunnel::Tunnel>>> {
+            Ok(self.tunnels.pop_front())
         }
     }
 
@@ -1220,7 +1246,9 @@ mod tests {
                 &"wg://listener.example".parse()?,
                 SocketContext::default().with_socket_mark(Some(7)),
             ),
-            UdpSessionAcceptKind::Classified(UdpSessionProtocol::WireGuard),
+            UdpSessionRouteSet::singleton(UdpSessionAcceptKind::Classified(
+                UdpSessionProtocol::WireGuard,
+            )),
             host.clone(),
             Arc::new(MockDns),
         );
@@ -1250,13 +1278,113 @@ mod tests {
                 &udp_v6_url,
                 SocketContext::default(),
             ),
-            UdpSessionAcceptKind::EasyTierMux,
+            UdpSessionRouteSet::singleton(UdpSessionAcceptKind::EasyTierMux),
             host.clone(),
             Arc::new(MockDns),
         );
         udp_v6.listen().await?;
         assert_eq!(host.udp_bind_options(1).context.ip_version, IpVersion::V6);
         assert!(host.udp_bind_options(1).only_v6);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn umbrella_udp_listener_binds_once_and_routes_all_protocols() -> anyhow::Result<()> {
+        let host = Arc::new(MockHost::new());
+        let routes = UdpSessionRouteSet::new([
+            UdpSessionAcceptKind::EasyTierMux,
+            UdpSessionAcceptKind::Classified(UdpSessionProtocol::WireGuard),
+            UdpSessionAcceptKind::Classified(UdpSessionProtocol::Quic),
+        ]);
+        let mut listener = UdpTransportListener::<MockHost, MockTcpSocket>::new(
+            "udp://127.0.0.1:0".parse()?,
+            UdpSessionListenRequest::new(UdpBindOptions::port_bound_listener(
+                "127.0.0.1:0".parse()?,
+            )),
+            routes,
+            host.clone(),
+            Arc::new(MockDns),
+        );
+        listener.listen().await?;
+
+        assert_eq!(host.udp_bind_options.lock().unwrap().len(), 1);
+        assert_eq!(
+            listener
+                .advertised_urls()
+                .into_iter()
+                .map(|url| url.to_string())
+                .collect::<Vec<_>>(),
+            vec![
+                "udp://127.0.0.1:22000",
+                "wg://127.0.0.1:22000",
+                "quic://127.0.0.1:22000",
+            ]
+        );
+
+        let socket = host.udp_socket(0);
+        socket.receive_from(wireguard_packet(), "127.0.0.1:32001".parse()?);
+        let wireguard =
+            crate::foundation::time::timeout(Duration::from_secs(1), listener.accept()).await??;
+        assert_eq!(wireguard.local_url().scheme(), "wg");
+
+        socket.receive_from(
+            new_syn_packet(1, 2).into_bytes().to_vec(),
+            "127.0.0.1:32002".parse()?,
+        );
+        let udp =
+            crate::foundation::time::timeout(Duration::from_secs(1), listener.accept()).await??;
+        assert_eq!(udp.local_url().scheme(), "udp");
+
+        socket.receive_from(quic_initial_packet(3), "127.0.0.1:32003".parse()?);
+        let quic =
+            crate::foundation::time::timeout(Duration::from_secs(1), listener.accept()).await??;
+        assert_eq!(quic.local_url().scheme(), "quic");
+        assert!(matches!(
+            quic,
+            AcceptedTransport::Udp {
+                admission: Some(_),
+                ..
+            }
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn umbrella_udp_listener_accepts_only_selected_routes() -> anyhow::Result<()> {
+        let host = Arc::new(MockHost::new());
+        let routes = UdpSessionRouteSet::singleton(UdpSessionAcceptKind::Classified(
+            UdpSessionProtocol::WireGuard,
+        ));
+        let mut listener = UdpTransportListener::<MockHost, MockTcpSocket>::new(
+            "udp://127.0.0.1:0".parse()?,
+            UdpSessionListenRequest::new(UdpBindOptions::port_bound_listener(
+                "127.0.0.1:0".parse()?,
+            )),
+            routes,
+            host.clone(),
+            Arc::new(MockDns),
+        );
+        listener.listen().await?;
+        assert_eq!(
+            listener.advertised_urls(),
+            vec!["wg://127.0.0.1:22000".parse()?]
+        );
+
+        let socket = host.udp_socket(0);
+        socket.receive_from(
+            new_syn_packet(1, 2).into_bytes().to_vec(),
+            "127.0.0.1:32001".parse()?,
+        );
+        assert!(
+            crate::foundation::time::timeout(Duration::from_millis(50), listener.accept())
+                .await
+                .is_err()
+        );
+
+        socket.receive_from(wireguard_packet(), "127.0.0.1:32002".parse()?);
+        let accepted =
+            crate::foundation::time::timeout(Duration::from_secs(1), listener.accept()).await??;
+        assert_eq!(accepted.local_url().scheme(), "wg");
         Ok(())
     }
 
@@ -1330,7 +1458,9 @@ mod tests {
             UdpSessionListenRequest::new(UdpBindOptions::port_bound_listener(
                 "127.0.0.1:0".parse()?,
             )),
-            UdpSessionAcceptKind::Classified(UdpSessionProtocol::Quic),
+            UdpSessionRouteSet::singleton(UdpSessionAcceptKind::Classified(
+                UdpSessionProtocol::Quic,
+            )),
             host.clone(),
             Arc::new(MockDns),
         );
@@ -1380,7 +1510,7 @@ mod tests {
         let handler = ProtocolAcceptedTransportHandler::new(&tunnel_handler, protocol.clone());
 
         let (stream, _remote) = tokio::io::duplex(64);
-        let tcp_result = handler
+        handler
             .handle_accepted_socket(AcceptedTransport::Tcp {
                 socket: MockTcpSocket {
                     stream,
@@ -1390,9 +1520,7 @@ mod tests {
                 local_url: "tcp://127.0.0.1:21000".parse().unwrap(),
                 upgrade_permit: None,
             })
-            .await
-            .unwrap_err();
-        assert_eq!(tcp_result.to_string(), "server tunnel acceptor finished");
+            .await?;
         assert_eq!(protocol.tcp_calls.load(Ordering::Relaxed), 1);
         assert_eq!(tunnel_handler.calls.load(Ordering::Relaxed), 2);
 
@@ -1496,7 +1624,7 @@ mod tests {
                     request: UdpSessionListenRequest::new(UdpBindOptions::port_bound_listener(
                         "127.0.0.1:0".parse().unwrap(),
                     )),
-                    accept_kind: UdpSessionAcceptKind::EasyTierMux,
+                    routes: UdpSessionRouteSet::singleton(UdpSessionAcceptKind::EasyTierMux),
                     must_succeed: true,
                 },
                 TransportListenerConfig::Udp {
@@ -1504,7 +1632,9 @@ mod tests {
                     request: UdpSessionListenRequest::new(UdpBindOptions::port_bound_listener(
                         "127.0.0.1:0".parse().unwrap(),
                     )),
-                    accept_kind: UdpSessionAcceptKind::Classified(UdpSessionProtocol::WireGuard),
+                    routes: UdpSessionRouteSet::singleton(UdpSessionAcceptKind::Classified(
+                        UdpSessionProtocol::WireGuard,
+                    )),
                     must_succeed: true,
                 },
             ],

--- a/easytier-core/src/listener/transport.rs
+++ b/easytier-core/src/listener/transport.rs
@@ -1253,7 +1253,7 @@ mod tests {
             Arc::new(MockDns),
         );
         udp.listen().await?;
-        assert_eq!(host.udp_socket(0).local_addr()?.port(), 11011);
+        assert_eq!(host.udp_socket(0).local_addr()?.port(), 11010);
         assert_eq!(host.udp_bind_options(0).context.ip_version, IpVersion::V4);
         assert!(!host.udp_bind_options(0).only_v6);
 

--- a/easytier-core/src/socket/mod.rs
+++ b/easytier-core/src/socket/mod.rs
@@ -40,6 +40,14 @@ pub trait SocketListener: Debug + Send {
 
     fn local_url(&self) -> Url;
 
+    fn advertised_urls(&self) -> Vec<Url> {
+        vec![self.local_url()]
+    }
+
+    fn accepted_url(&self, _accepted: &Self::Accepted) -> Url {
+        self.local_url()
+    }
+
     fn connection_counter(&self) -> Arc<dyn ListenerConnectionCounter> {
         Arc::new(EmptyConnectionCounter)
     }

--- a/easytier-core/src/socket/udp/layer.rs
+++ b/easytier-core/src/socket/udp/layer.rs
@@ -16,6 +16,7 @@ use crate::packet::{ZCPacket, new_hole_punch_packet};
 
 use super::{
     UDP_SESSION_CONNECT_TIMEOUT, UDP_SESSION_QUEUE_CAPACITY, UDP_SESSION_RESEND_INTERVAL,
+    listener::{UdpSessionAcceptKind, UdpSessionRouteSet},
     packet::{
         EasyTierUdpPacketKind, UdpDatagramClassification, UdpSessionPacketKind,
         classify_session_udp_datagram, classify_udp_datagram,
@@ -28,9 +29,10 @@ use super::{
         UdpConnectControl, UdpSession, UdpSessionClose, UdpSessionCodec, UdpSessionConnectError,
         UdpSessionConnectRequest, UdpSessionConnector, UdpSessionDatagram, UdpSessionEnqueuePolicy,
         UdpSessionKey, UdpSessionKind, UdpSessionLayerControl, UdpSessionProtocol,
-        UdpSessionRegistry, close_all_classified_udp_sessions, close_all_udp_sessions,
-        close_classified_udp_session, close_udp_session, create_udp_session_rings,
-        dispatch_payload_to_session, udp_session_registry_entry,
+        UdpSessionRegistry, UdpTupleOwnerLease, UdpTupleOwners, close_all_classified_udp_sessions,
+        close_all_udp_sessions, close_classified_udp_session, close_udp_session,
+        create_udp_session_rings, dispatch_payload_to_session, udp_session_registry_entry,
+        udp_session_registry_entry_with_owner,
     },
     virtual_socket::{
         MAX_UDP_SESSION_DATAGRAM_SIZE, NoopUdpSessionStunResponder, PreferredIpv6Source,
@@ -55,16 +57,19 @@ pub struct UdpSessionLayer<S, R = NoopUdpSessionStunResponder> {
     recv_task: JoinHandle<()>,
 }
 
-pub(super) fn create_classified_udp_session_accepts() -> Arc<ClassifiedUdpSessionAccepts> {
+pub(super) fn create_classified_udp_session_accepts(
+    routes: UdpSessionRouteSet,
+) -> Arc<ClassifiedUdpSessionAccepts> {
     let accepts = Arc::new(DashMap::new());
     for protocol in [UdpSessionProtocol::WireGuard, UdpSessionProtocol::Quic] {
         let (accepted, accepted_rx) = mpsc::channel(UDP_SESSION_QUEUE_CAPACITY);
+        let accept_enabled = routes.contains(UdpSessionAcceptKind::Classified(protocol));
         accepts.insert(
             protocol,
             Arc::new(ClassifiedUdpSessionAccept {
                 accepted,
                 accepted_rx: TokioMutex::new(accepted_rx),
-                accept_enabled: std::sync::atomic::AtomicBool::new(false),
+                accept_enabled: std::sync::atomic::AtomicBool::new(accept_enabled),
             }),
         );
     }
@@ -86,9 +91,22 @@ where
     R: UdpSessionStunResponder<S>,
 {
     pub fn new_with_stun_responder(socket: Arc<S>, stun_responder: Arc<R>) -> Self {
+        Self::new_with_stun_responder_and_routes(
+            socket,
+            stun_responder,
+            UdpSessionRouteSet::singleton(UdpSessionAcceptKind::EasyTierMux),
+        )
+    }
+
+    pub(crate) fn new_with_stun_responder_and_routes(
+        socket: Arc<S>,
+        stun_responder: Arc<R>,
+        routes: UdpSessionRouteSet,
+    ) -> Self {
         let sessions = Arc::new(DashMap::new());
         let classified_sessions = Arc::new(DashMap::new());
-        let classified_accepts = create_classified_udp_session_accepts();
+        let tuple_owners = Arc::new(DashMap::new());
+        let classified_accepts = create_classified_udp_session_accepts(routes);
         let pending_connects = Arc::new(DashMap::new());
         let (mux_accepted_tx, mux_accepted_rx) = mpsc::channel(UDP_SESSION_QUEUE_CAPACITY);
         let (control_tx, control_rx) = mpsc::channel(UDP_SESSION_QUEUE_CAPACITY);
@@ -97,12 +115,14 @@ where
             socket.clone(),
             sessions.clone(),
             classified_sessions.clone(),
+            tuple_owners,
             classified_accepts.clone(),
             pending_connects.clone(),
             mux_accepted_tx,
             control_tx,
             stun_responder.clone(),
             session_shutdown_tx.clone(),
+            routes.contains(UdpSessionAcceptKind::EasyTierMux),
         ));
 
         Self {
@@ -435,12 +455,14 @@ pub(super) async fn udp_session_layer_recv_task<S, R>(
     socket: Arc<S>,
     sessions: Arc<UdpSessionRegistry>,
     classified_sessions: Arc<ClassifiedUdpSessionRegistry>,
+    tuple_owners: Arc<UdpTupleOwners>,
     classified_accepts: Arc<ClassifiedUdpSessionAccepts>,
     pending_connects: Arc<PendingUdpSessionConnects>,
     mux_accepted: mpsc::Sender<UdpSession>,
     control: mpsc::Sender<UdpSessionLayerControl>,
     stun_responder: Arc<R>,
     session_shutdown_tx: watch::Sender<bool>,
+    mux_accept_enabled: bool,
 ) where
     S: VirtualUdpSocket,
     R: UdpSessionStunResponder<S>,
@@ -471,12 +493,18 @@ pub(super) async fn udp_session_layer_recv_task<S, R>(
             continue;
         }
         let quic_key = ClassifiedUdpSessionKey::new(UdpSessionProtocol::Quic, remote_addr);
-        if classified_sessions.contains_key(&quic_key) {
-            dispatch_existing_classified_udp_datagram(
-                &classified_sessions,
-                quic_key,
-                UdpSessionDatagram::new(payload, recv_meta),
+        if let Some(entry) = classified_sessions.get(&quic_key) {
+            let datagram = UdpSessionDatagram::new(payload, recv_meta);
+            let dispatched = dispatch_payload_to_session(
+                &entry.incoming,
+                datagram,
+                UdpSessionEnqueuePolicy::Reliable,
             );
+            drop(entry);
+            if !dispatched {
+                close_classified_udp_session(&classified_sessions, quic_key);
+                tracing::debug!(?quic_key, "classified udp session data queue closed");
+            }
             continue;
         }
         match classify_udp_datagram(payload) {
@@ -503,6 +531,7 @@ pub(super) async fn udp_session_layer_recv_task<S, R>(
                 dispatch_session_udp_datagram(
                     socket.clone(),
                     &classified_sessions,
+                    &tuple_owners,
                     &classified_accepts,
                     session_shutdown_tx.subscribe(),
                     remote_addr,
@@ -518,6 +547,7 @@ pub(super) async fn udp_session_layer_recv_task<S, R>(
                 let unconsumed = dispatch_easy_tier_udp_datagram(
                     &socket,
                     &sessions,
+                    &tuple_owners,
                     &pending_connects,
                     &mux_accepted,
                     &control,
@@ -528,6 +558,7 @@ pub(super) async fn udp_session_layer_recv_task<S, R>(
                     packet,
                     recv_meta,
                     &session_shutdown_tx,
+                    mux_accept_enabled,
                 );
                 if let Some(packet) = unconsumed {
                     let datagram = BytesMut::from(packet.into_bytes());
@@ -535,6 +566,7 @@ pub(super) async fn udp_session_layer_recv_task<S, R>(
                     dispatch_session_udp_datagram(
                         socket.clone(),
                         &classified_sessions,
+                        &tuple_owners,
                         &classified_accepts,
                         session_shutdown_tx.subscribe(),
                         remote_addr,
@@ -547,28 +579,11 @@ pub(super) async fn udp_session_layer_recv_task<S, R>(
     }
 }
 
-fn dispatch_existing_classified_udp_datagram(
-    classified_sessions: &Arc<ClassifiedUdpSessionRegistry>,
-    key: ClassifiedUdpSessionKey,
-    datagram: UdpSessionDatagram,
-) {
-    let Some(entry) = classified_sessions.get(&key) else {
-        return;
-    };
-
-    let dispatched =
-        dispatch_payload_to_session(&entry.incoming, datagram, UdpSessionEnqueuePolicy::Reliable);
-    drop(entry);
-    if !dispatched {
-        close_classified_udp_session(classified_sessions, key);
-        tracing::debug!(?key, "classified udp session data queue closed");
-    }
-}
-
 #[allow(clippy::too_many_arguments)]
 fn dispatch_easy_tier_udp_datagram<S>(
     socket: &Arc<S>,
     sessions: &Arc<UdpSessionRegistry>,
+    tuple_owners: &Arc<UdpTupleOwners>,
     pending_connects: &Arc<PendingUdpSessionConnects>,
     mux_accepted: &mpsc::Sender<UdpSession>,
     control: &mpsc::Sender<UdpSessionLayerControl>,
@@ -579,6 +594,7 @@ fn dispatch_easy_tier_udp_datagram<S>(
     packet: ZCPacket,
     recv_meta: UdpSocketRecvMeta,
     session_shutdown: &watch::Sender<bool>,
+    mux_accept_enabled: bool,
 ) -> Option<ZCPacket>
 where
     S: VirtualUdpSocket,
@@ -587,15 +603,17 @@ where
         EasyTierUdpPacketKind::Data => {
             return dispatch_data_packet(sessions, remote_addr, conn_id, packet, recv_meta).err();
         }
-        EasyTierUdpPacketKind::Syn => handle_new_easy_tier_mux_connect(
+        EasyTierUdpPacketKind::Syn if mux_accept_enabled => handle_new_easy_tier_mux_connect(
             socket.clone(),
             sessions.clone(),
+            tuple_owners.clone(),
             mux_accepted.clone(),
             remote_addr,
             conn_id,
             &packet,
             session_shutdown.subscribe(),
         ),
+        EasyTierUdpPacketKind::Syn => false,
         EasyTierUdpPacketKind::Sack => {
             dispatch_sack_packet(sessions, pending_connects, remote_addr, conn_id, &packet)
         }
@@ -647,9 +665,11 @@ pub(super) fn dispatch_data_packet(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn dispatch_session_udp_datagram<S>(
     socket: Arc<S>,
     classified_sessions: &Arc<ClassifiedUdpSessionRegistry>,
+    tuple_owners: &Arc<UdpTupleOwners>,
     classified_accepts: &Arc<ClassifiedUdpSessionAccepts>,
     session_shutdown: watch::Receiver<bool>,
     remote_addr: SocketAddr,
@@ -662,6 +682,7 @@ fn dispatch_session_udp_datagram<S>(
         UdpSessionPacketKind::Classified(protocol) => dispatch_classified_udp_datagram(
             socket,
             classified_sessions,
+            tuple_owners,
             classified_accepts,
             protocol,
             session_shutdown,
@@ -674,9 +695,11 @@ fn dispatch_session_udp_datagram<S>(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn dispatch_classified_udp_datagram<S>(
     socket: Arc<S>,
     classified_sessions: &Arc<ClassifiedUdpSessionRegistry>,
+    tuple_owners: &Arc<UdpTupleOwners>,
     classified_accepts: &Arc<ClassifiedUdpSessionAccepts>,
     protocol: UdpSessionProtocol,
     session_shutdown: watch::Receiver<bool>,
@@ -730,10 +753,20 @@ fn dispatch_classified_udp_datagram<S>(
             return;
         }
     };
+    let Some(tuple_owner) =
+        UdpTupleOwnerLease::try_acquire(tuple_owners.clone(), remote_addr, protocol.session_kind())
+    else {
+        tracing::trace!(
+            ?protocol,
+            ?remote_addr,
+            "udp tuple is owned by another protocol"
+        );
+        return;
+    };
     let rings = create_udp_session_rings();
     match classified_sessions.entry(key) {
         dashmap::mapref::entry::Entry::Vacant(entry) => {
-            entry.insert(udp_session_registry_entry(&rings));
+            entry.insert(udp_session_registry_entry_with_owner(&rings, tuple_owner));
         }
         dashmap::mapref::entry::Entry::Occupied(entry) => {
             let entry = entry.get().clone();
@@ -773,9 +806,11 @@ fn dispatch_classified_udp_datagram<S>(
     accept_permit.send(session);
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn handle_new_easy_tier_mux_connect<S>(
     socket: Arc<S>,
     sessions: Arc<UdpSessionRegistry>,
+    tuple_owners: Arc<UdpTupleOwners>,
     mux_accepted: mpsc::Sender<UdpSession>,
     remote_addr: SocketAddr,
     conn_id: u32,
@@ -824,8 +859,21 @@ where
             return true;
         }
     };
+    let Some(tuple_owner) =
+        UdpTupleOwnerLease::try_acquire(tuple_owners, remote_addr, UdpSessionKind::EasyTierMux)
+    else {
+        tracing::trace!(
+            ?remote_addr,
+            ?conn_id,
+            "udp tuple is owned by another protocol"
+        );
+        return false;
+    };
     let rings = create_udp_session_rings();
-    sessions.insert(key, udp_session_registry_entry(&rings));
+    sessions.insert(
+        key,
+        udp_session_registry_entry_with_owner(&rings, tuple_owner),
+    );
     let close = UdpSessionClose::easy_tier(key, rings.close_tx.clone(), sessions.clone());
     let session = UdpSession::new(
         socket.clone(),

--- a/easytier-core/src/socket/udp/listener.rs
+++ b/easytier-core/src/socket/udp/listener.rs
@@ -15,10 +15,71 @@ use super::{
     UdpSessionStunResponder, VirtualUdpSocket, VirtualUdpSocketFactory,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum UdpSessionAcceptKind {
     EasyTierMux,
     Classified(UdpSessionProtocol),
+}
+
+impl UdpSessionAcceptKind {
+    pub(crate) const ALL: [Self; 3] = [
+        Self::EasyTierMux,
+        Self::Classified(UdpSessionProtocol::WireGuard),
+        Self::Classified(UdpSessionProtocol::Quic),
+    ];
+
+    pub(crate) const fn scheme(self) -> &'static str {
+        match self {
+            Self::EasyTierMux => "udp",
+            Self::Classified(UdpSessionProtocol::WireGuard) => "wg",
+            Self::Classified(UdpSessionProtocol::Quic) => "quic",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct UdpSessionRouteSet(u8);
+
+impl UdpSessionRouteSet {
+    pub(crate) fn new(routes: impl IntoIterator<Item = UdpSessionAcceptKind>) -> Self {
+        Self(
+            routes
+                .into_iter()
+                .fold(0, |bits, route| bits | route_bit(route)),
+        )
+    }
+
+    pub(crate) fn singleton(route: UdpSessionAcceptKind) -> Self {
+        Self(route_bit(route))
+    }
+
+    pub(crate) fn contains(self, route: UdpSessionAcceptKind) -> bool {
+        self.0 & route_bit(route) != 0
+    }
+
+    pub(crate) fn iter(self) -> impl Iterator<Item = UdpSessionAcceptKind> {
+        UdpSessionAcceptKind::ALL
+            .into_iter()
+            .filter(move |route| self.contains(*route))
+    }
+
+    pub(crate) fn len(self) -> usize {
+        self.0.count_ones() as usize
+    }
+}
+
+const fn route_bit(route: UdpSessionAcceptKind) -> u8 {
+    match route {
+        UdpSessionAcceptKind::EasyTierMux => 1 << 0,
+        UdpSessionAcceptKind::Classified(UdpSessionProtocol::WireGuard) => 1 << 1,
+        UdpSessionAcceptKind::Classified(UdpSessionProtocol::Quic) => 1 << 2,
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct RoutedUdpSession {
+    pub(crate) session: UdpSession,
+    pub(crate) route: UdpSessionAcceptKind,
 }
 
 pub async fn accept_udp_session<S, R>(
@@ -45,7 +106,7 @@ where
 {
     url: Url,
     request: UdpSessionListenRequest,
-    accept_kind: UdpSessionAcceptKind,
+    routes: UdpSessionRouteSet,
     factory: Arc<F>,
     socket: Option<Arc<F::Socket>>,
     layer: Option<Arc<Layer<F>>>,
@@ -69,10 +130,24 @@ where
         accept_kind: UdpSessionAcceptKind,
         factory: Arc<F>,
     ) -> Self {
+        Self::new_with_routes(
+            url,
+            request,
+            UdpSessionRouteSet::singleton(accept_kind),
+            factory,
+        )
+    }
+
+    pub(crate) fn new_with_routes(
+        url: Url,
+        request: UdpSessionListenRequest,
+        routes: UdpSessionRouteSet,
+        factory: Arc<F>,
+    ) -> Self {
         Self {
             url,
             request,
-            accept_kind,
+            routes,
             factory,
             socket: None,
             layer: None,
@@ -87,10 +162,27 @@ where
     }
 
     pub async fn accept_session(&self) -> anyhow::Result<UdpSession> {
+        if self.routes.len() != 1 {
+            anyhow::bail!("accept_session requires exactly one UDP session route");
+        }
+        Ok(self.accept_routed_session().await?.session)
+    }
+
+    pub(crate) async fn accept_routed_session(&self) -> anyhow::Result<RoutedUdpSession> {
         let layer = self.layer()?;
-        let mut session = accept_udp_session(&layer, self.accept_kind).await?;
+        let easy_tier = UdpSessionAcceptKind::EasyTierMux;
+        let wireguard = UdpSessionAcceptKind::Classified(UdpSessionProtocol::WireGuard);
+        let quic = UdpSessionAcceptKind::Classified(UdpSessionProtocol::Quic);
+        let (mut session, route) = tokio::select! {
+            result = accept_udp_session(&layer, easy_tier),
+                if self.routes.contains(easy_tier) => (result?, easy_tier),
+            result = accept_udp_session(&layer, wireguard),
+                if self.routes.contains(wireguard) => (result?, wireguard),
+            result = accept_udp_session(&layer, quic),
+                if self.routes.contains(quic) => (result?, quic),
+        };
         session.keep_layer_alive(layer);
-        Ok(session)
+        Ok(RoutedUdpSession { session, route })
     }
 }
 
@@ -102,7 +194,7 @@ where
         f.debug_struct("UdpSessionSocketListener")
             .field("url", &self.url)
             .field("request", &self.request)
-            .field("accept_kind", &self.accept_kind)
+            .field("routes", &self.routes)
             .field("listening", &self.socket.is_some())
             .finish()
     }
@@ -126,13 +218,11 @@ where
             .set_port(Some(local_addr.port()))
             .map_err(|_| anyhow::anyhow!("failed to update udp listener port for {}", self.url))?;
 
-        let layer = Arc::new(UdpSessionLayer::new_with_stun_responder(
+        let layer = Arc::new(UdpSessionLayer::new_with_stun_responder_and_routes(
             socket.clone(),
             self.factory.clone(),
+            self.routes,
         ));
-        if let UdpSessionAcceptKind::Classified(protocol) = self.accept_kind {
-            layer.enable_classified_accept(protocol)?;
-        }
 
         *self.layer_ref.lock().unwrap() = Some(Arc::downgrade(&layer));
         self.socket = Some(socket);

--- a/easytier-core/src/socket/udp/mod.rs
+++ b/easytier-core/src/socket/udp/mod.rs
@@ -12,6 +12,7 @@ const UDP_SESSION_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::fr
 const UDP_SESSION_QUEUE_CAPACITY: usize = 128;
 
 pub use layer::{UdpSessionDialer, UdpSessionLayer};
+pub(crate) use listener::{RoutedUdpSession, UdpSessionRouteSet};
 pub use listener::{UdpSessionAcceptKind, UdpSessionSocketListener, accept_udp_session};
 pub use packet::{
     UdpSessionPacketError, extract_dst_addr_from_v4_hole_punch_packet,

--- a/easytier-core/src/socket/udp/session.rs
+++ b/easytier-core/src/socket/udp/session.rs
@@ -22,7 +22,9 @@ use crate::{
 use super::{
     MAX_UDP_SESSION_DATAGRAM_SIZE, UDP_SESSION_QUEUE_CAPACITY,
     packet::{new_data_packet, udp_session_payload_len},
-    virtual_socket::{PreferredIpv6Source, UdpBindOptions, UdpSocketRecvMeta, VirtualUdpSocket},
+    virtual_socket::{
+        PreferredIpv6Source, UdpBindOptions, UdpSocketRecvMeta, UdpSocketSendMeta, VirtualUdpSocket,
+    },
 };
 
 #[derive(Debug)]
@@ -107,6 +109,11 @@ pub trait UdpSessionSocket: Send + Sync + 'static {
     fn peer_addr(&self) -> std::io::Result<SocketAddr>;
 
     async fn send(&self, data: &[u8]) -> std::io::Result<usize>;
+
+    async fn send_with_meta(&self, data: &[u8], meta: UdpSocketSendMeta) -> std::io::Result<usize> {
+        let _ = meta;
+        self.send(data).await
+    }
 
     async fn recv(&self, buf: &mut [u8]) -> std::io::Result<usize>;
 
@@ -201,6 +208,69 @@ pub(super) type ClassifiedUdpSessionRegistry =
 pub(super) type ClassifiedUdpSessionAccepts =
     DashMap<UdpSessionProtocol, Arc<ClassifiedUdpSessionAccept>>;
 pub(super) type PendingUdpSessionConnects = DashMap<u32, PendingUdpSessionConnect>;
+pub(super) type UdpTupleOwners = DashMap<SocketAddr, UdpTupleOwner>;
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct UdpTupleOwner {
+    kind: UdpSessionKind,
+    sessions: usize,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct UdpTupleOwnerLease {
+    _inner: Arc<UdpTupleOwnerLeaseInner>,
+}
+
+#[derive(Debug)]
+struct UdpTupleOwnerLeaseInner {
+    owners: Arc<UdpTupleOwners>,
+    peer_addr: SocketAddr,
+    kind: UdpSessionKind,
+}
+
+impl UdpTupleOwnerLease {
+    pub(super) fn try_acquire(
+        owners: Arc<UdpTupleOwners>,
+        peer_addr: SocketAddr,
+        kind: UdpSessionKind,
+    ) -> Option<Self> {
+        match owners.entry(peer_addr) {
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                entry.insert(UdpTupleOwner { kind, sessions: 1 });
+            }
+            dashmap::mapref::entry::Entry::Occupied(mut entry) => {
+                if entry.get().kind != kind {
+                    return None;
+                }
+                entry.get_mut().sessions += 1;
+            }
+        }
+        Some(Self {
+            _inner: Arc::new(UdpTupleOwnerLeaseInner {
+                owners,
+                peer_addr,
+                kind,
+            }),
+        })
+    }
+}
+
+impl Drop for UdpTupleOwnerLeaseInner {
+    fn drop(&mut self) {
+        let dashmap::mapref::entry::Entry::Occupied(mut entry) = self.owners.entry(self.peer_addr)
+        else {
+            return;
+        };
+        if entry.get().kind != self.kind {
+            return;
+        }
+        if entry.get().sessions == 1 {
+            entry.remove();
+        } else {
+            entry.get_mut().sessions -= 1;
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(super) struct ClassifiedUdpSessionKey {
@@ -228,6 +298,7 @@ pub(super) struct ClassifiedUdpSessionAccept {
 pub(super) struct UdpSessionRegistryEntry {
     pub(super) incoming: Arc<StdMutex<RingSocketSender<UdpSessionDatagram>>>,
     pub(super) close: watch::Sender<bool>,
+    _tuple_owner: Option<UdpTupleOwnerLease>,
 }
 
 #[derive(Debug, Clone)]
@@ -278,6 +349,7 @@ pub struct UdpSession {
 pub(crate) enum UdpSessionOutbound {
     Datagram {
         payload: BytesMut,
+        meta: UdpSocketSendMeta,
         completion: oneshot::Sender<io::Result<usize>>,
     },
     TunnelPacket(ZCPacket),
@@ -397,10 +469,10 @@ impl UdpSessionClose {
             #[cfg(test)]
             UdpSessionCloseTarget::SignalOnly => {}
             UdpSessionCloseTarget::EasyTier { key, sessions } => {
-                close_udp_session(sessions, *key);
+                close_udp_session_if_current(sessions, *key, &self.close);
             }
             UdpSessionCloseTarget::Classified { key, sessions } => {
-                close_classified_udp_session(sessions, *key);
+                close_classified_udp_session_if_current(sessions, *key, &self.close);
             }
         }
         let _ = self.close.send(true);
@@ -494,6 +566,12 @@ impl UdpSession {
         self._cleanup.layer_guard = Some(Box::new(layer_guard));
     }
 
+    pub fn close(&self) {
+        if let Some(close) = &self._cleanup.session_close {
+            close.close();
+        }
+    }
+
     pub(crate) fn into_tunnel_parts(self) -> UdpSessionTunnelParts {
         let Self {
             local_addr,
@@ -544,6 +622,11 @@ impl UdpSessionSocket for UdpSession {
     }
 
     async fn send(&self, data: &[u8]) -> std::io::Result<usize> {
+        self.send_with_meta(data, UdpSocketSendMeta::default())
+            .await
+    }
+
+    async fn send_with_meta(&self, data: &[u8], meta: UdpSocketSendMeta) -> std::io::Result<usize> {
         self.codec.validate_payload(data)?;
         let mut closed = self.closed.clone();
         if *closed.borrow() {
@@ -552,6 +635,7 @@ impl UdpSessionSocket for UdpSession {
         let (completion, sent) = oneshot::channel();
         let outbound = UdpSessionOutbound::Datagram {
             payload: BytesMut::from(data),
+            meta,
             completion,
         };
         tokio::select! {
@@ -631,6 +715,18 @@ pub(super) fn udp_session_registry_entry(rings: &UdpSessionRingParts) -> UdpSess
     UdpSessionRegistryEntry {
         incoming: rings.session_recv_tx.clone(),
         close: rings.close_tx.clone(),
+        _tuple_owner: None,
+    }
+}
+
+pub(super) fn udp_session_registry_entry_with_owner(
+    rings: &UdpSessionRingParts,
+    tuple_owner: UdpTupleOwnerLease,
+) -> UdpSessionRegistryEntry {
+    UdpSessionRegistryEntry {
+        incoming: rings.session_recv_tx.clone(),
+        close: rings.close_tx.clone(),
+        _tuple_owner: Some(tuple_owner),
     }
 }
 
@@ -645,6 +741,30 @@ pub(super) fn close_classified_udp_session(
     key: ClassifiedUdpSessionKey,
 ) {
     if let Some((_, entry)) = classified_sessions.remove(&key) {
+        let _ = entry.close.send(true);
+    }
+}
+
+fn close_udp_session_if_current(
+    sessions: &UdpSessionRegistry,
+    key: UdpSessionKey,
+    expected_close: &watch::Sender<bool>,
+) {
+    if let Some((_, entry)) =
+        sessions.remove_if(&key, |_, entry| entry.close.same_channel(expected_close))
+    {
+        let _ = entry.close.send(true);
+    }
+}
+
+fn close_classified_udp_session_if_current(
+    classified_sessions: &ClassifiedUdpSessionRegistry,
+    key: ClassifiedUdpSessionKey,
+    expected_close: &watch::Sender<bool>,
+) {
+    if let Some((_, entry)) =
+        classified_sessions.remove_if(&key, |_, entry| entry.close.same_channel(expected_close))
+    {
         let _ = entry.close.send(true);
     }
 }
@@ -713,9 +833,10 @@ async fn forward_udp_session_to_socket<S>(
                 break;
             }
         };
-        let (datagram, completion) = match outbound {
+        let (datagram, meta, completion) = match outbound {
             UdpSessionOutbound::Datagram {
                 payload,
+                meta,
                 completion,
             } => {
                 let payload_len = payload.len();
@@ -733,7 +854,7 @@ async fn forward_udp_session_to_socket<S>(
                         break;
                     }
                 };
-                (datagram, Some((completion, payload_len)))
+                (datagram, meta, Some((completion, payload_len)))
             }
             UdpSessionOutbound::TunnelPacket(packet) => {
                 let datagram = match codec.encode_tunnel_packet(packet) {
@@ -744,10 +865,15 @@ async fn forward_udp_session_to_socket<S>(
                         break;
                     }
                 };
-                (datagram, None)
+                (datagram, UdpSocketSendMeta::default(), None)
             }
         };
-        match socket.send_to(&datagram, peer_addr).await {
+        let result = if meta == UdpSocketSendMeta::default() {
+            socket.send_to(&datagram, peer_addr).await
+        } else {
+            socket.send_to_with_meta(&datagram, peer_addr, meta).await
+        };
+        match result {
             Ok(_) => {
                 if let Some((completion, payload_len)) = completion {
                     let _ = completion.send(Ok(payload_len));

--- a/easytier-core/src/socket/udp/tests.rs
+++ b/easytier-core/src/socket/udp/tests.rs
@@ -453,6 +453,7 @@ struct AutoSackVirtualUdpSocket {
     local_addr: SocketAddr,
     incoming: Mutex<VecDeque<(Vec<u8>, SocketAddr)>>,
     sent: Mutex<Vec<(Vec<u8>, SocketAddr)>>,
+    send_meta_attempts: Mutex<Vec<UdpSocketSendMeta>>,
     incoming_notify: tokio::sync::Notify,
 }
 
@@ -462,12 +463,17 @@ impl AutoSackVirtualUdpSocket {
             local_addr,
             incoming: Mutex::new(VecDeque::new()),
             sent: Mutex::new(Vec::new()),
+            send_meta_attempts: Mutex::new(Vec::new()),
             incoming_notify: tokio::sync::Notify::new(),
         }
     }
 
     fn sent(&self) -> Vec<(Vec<u8>, SocketAddr)> {
         self.sent.lock().unwrap().clone()
+    }
+
+    fn send_meta_attempts(&self) -> Vec<UdpSocketSendMeta> {
+        self.send_meta_attempts.lock().unwrap().clone()
     }
 }
 
@@ -492,6 +498,16 @@ impl VirtualUdpSocket for AutoSackVirtualUdpSocket {
             }
         }
         Ok(data.len())
+    }
+
+    async fn send_to_with_meta(
+        &self,
+        data: &[u8],
+        addr: SocketAddr,
+        meta: UdpSocketSendMeta,
+    ) -> io::Result<usize> {
+        self.send_meta_attempts.lock().unwrap().push(meta);
+        self.send_to(data, addr).await
     }
 
     async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
@@ -562,6 +578,34 @@ where
     )
 }
 
+fn create_test_classified_session<S>(
+    socket: Arc<S>,
+    key: ClassifiedUdpSessionKey,
+    sessions: Arc<ClassifiedUdpSessionRegistry>,
+) -> (UdpSession, watch::Sender<bool>)
+where
+    S: VirtualUdpSocket,
+{
+    let local_addr = socket.local_addr().unwrap();
+    let rings = create_udp_session_rings();
+    sessions.insert(key, udp_session_registry_entry(&rings));
+    let close = UdpSessionClose::classified(key, rings.close_tx.clone(), sessions);
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    (
+        UdpSession::new(
+            socket,
+            local_addr,
+            key.peer_addr,
+            key.protocol.session_kind(),
+            UdpSessionCodec::Identity,
+            rings,
+            close,
+            shutdown_rx,
+        ),
+        shutdown_tx,
+    )
+}
+
 async fn wait_for_sent<F>(mut sent: F, min_len: usize) -> Vec<(Vec<u8>, SocketAddr)>
 where
     F: FnMut() -> Vec<(Vec<u8>, SocketAddr)>,
@@ -596,6 +640,80 @@ fn wireguard_packet_with_easy_tier_data_header(payload: &[u8]) -> Vec<u8> {
     packet
 }
 
+fn quic_initial_packet(dcid: u8) -> Vec<u8> {
+    let mut packet = vec![0; 1200];
+    packet[0] = 0xc0;
+    packet[4] = 1;
+    packet[5] = 1;
+    packet[6] = dcid;
+    packet[7] = 0;
+    packet[8] = 0;
+    packet[9] = 1;
+    packet
+}
+
+#[tokio::test]
+async fn udp_layer_remote_tuple_is_owned_by_one_protocol_at_a_time() {
+    let local_addr = SocketAddr::from(([127, 0, 0, 1], 12000));
+    let peer_addr = SocketAddr::from(([127, 0, 0, 1], 12001));
+    let socket = Arc::new(AutoSackVirtualUdpSocket::new(local_addr));
+    let routes = UdpSessionRouteSet::new([
+        UdpSessionAcceptKind::EasyTierMux,
+        UdpSessionAcceptKind::Classified(UdpSessionProtocol::WireGuard),
+        UdpSessionAcceptKind::Classified(UdpSessionProtocol::Quic),
+    ]);
+    let layer = Arc::new(UdpSessionLayer::new_with_stun_responder_and_routes(
+        socket.clone(),
+        Arc::new(NoopUdpSessionStunResponder),
+        routes,
+    ));
+
+    socket
+        .incoming
+        .lock()
+        .unwrap()
+        .push_back((wireguard_transport_packet(b"owner"), peer_addr));
+    socket.incoming_notify.notify_one();
+    let wireguard = tokio::time::timeout(
+        Duration::from_secs(1),
+        layer.accept_classified_session(UdpSessionProtocol::WireGuard),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    socket
+        .incoming
+        .lock()
+        .unwrap()
+        .push_back((quic_initial_packet(1), peer_addr));
+    socket.incoming_notify.notify_one();
+    assert!(
+        tokio::time::timeout(
+            Duration::from_millis(100),
+            layer.accept_classified_session(UdpSessionProtocol::Quic)
+        )
+        .await
+        .is_err()
+    );
+
+    drop(wireguard);
+    socket
+        .incoming
+        .lock()
+        .unwrap()
+        .push_back((quic_initial_packet(2), peer_addr));
+    socket.incoming_notify.notify_one();
+    let quic = tokio::time::timeout(
+        Duration::from_secs(1),
+        layer.accept_classified_session(UdpSessionProtocol::Quic),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(quic.kind(), UdpSessionKind::Quic);
+}
+
 #[tokio::test]
 async fn wireguard_udp_session_sends_to_peer_addr() {
     let local_addr = SocketAddr::from(([127, 0, 0, 1], 12000));
@@ -612,6 +730,27 @@ async fn wireguard_udp_session_sends_to_peer_addr() {
 
     let sent = wait_for_sent(|| socket.sent(), 1).await;
     assert_eq!(sent, vec![(b"hello".to_vec(), peer_addr)]);
+    assert!(socket.send_meta_attempts().is_empty());
+}
+
+#[tokio::test]
+async fn quic_udp_session_forwards_send_source_ip() {
+    let local_addr = SocketAddr::from(([0, 0, 0, 0], 12000));
+    let peer_addr = SocketAddr::from(([192, 0, 2, 2], 12001));
+    let source_ip = Ipv4Addr::new(192, 0, 2, 1).into();
+    let socket = Arc::new(MockVirtualUdpSocket::new(local_addr, Vec::new()));
+    let session =
+        UdpSession::identity_standalone(socket.clone(), peer_addr, UdpSessionKind::Quic).unwrap();
+    let meta = UdpSocketSendMeta {
+        src_ip: Some(source_ip),
+        src_ifindex: None,
+    };
+
+    assert_eq!(session.send_with_meta(b"hello", meta).await.unwrap(), 5);
+    assert_eq!(
+        socket.send_attempts(),
+        vec![(b"hello".to_vec(), peer_addr, meta)]
+    );
 }
 
 #[tokio::test]
@@ -1138,6 +1277,32 @@ async fn easy_tier_mux_udp_session_send_failure_closes_session() {
 }
 
 #[tokio::test]
+async fn stale_classified_session_cleanup_does_not_close_replacement() {
+    let local_addr = SocketAddr::from(([127, 0, 0, 1], 12000));
+    let peer_addr = SocketAddr::from(([127, 0, 0, 1], 12001));
+    let key = ClassifiedUdpSessionKey::new(UdpSessionProtocol::Quic, peer_addr);
+    let socket = Arc::new(MockVirtualUdpSocket::new(local_addr, Vec::new()));
+    let sessions = Arc::new(DashMap::new());
+    let (old_session, _old_shutdown_tx) =
+        create_test_classified_session(socket.clone(), key, sessions.clone());
+
+    old_session.close();
+    assert!(!sessions.contains_key(&key));
+
+    let (replacement, _replacement_shutdown_tx) =
+        create_test_classified_session(socket, key, sessions.clone());
+    drop(old_session);
+
+    assert!(sessions.contains_key(&key));
+    let mut buf = [0; 1];
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), replacement.recv(&mut buf))
+            .await
+            .is_err()
+    );
+}
+
+#[tokio::test]
 async fn easy_tier_mux_udp_session_receives_only_peer_data_payloads() {
     let local_addr = SocketAddr::from(([127, 0, 0, 1], 12000));
     let peer_addr = SocketAddr::from(([127, 0, 0, 1], 12001));
@@ -1285,7 +1450,9 @@ async fn udp_session_recv_loop_error_closes_registered_sessions() {
     );
     let pending_connects = Arc::new(DashMap::new());
     let classified_sessions = Arc::new(DashMap::new());
-    let classified_accepts = create_classified_udp_session_accepts();
+    let tuple_owners = Arc::new(DashMap::new());
+    let routes = UdpSessionRouteSet::singleton(UdpSessionAcceptKind::EasyTierMux);
+    let classified_accepts = create_classified_udp_session_accepts(routes);
     let (mux_accepted_tx, _mux_accepted_rx) = mpsc::channel(UDP_SESSION_QUEUE_CAPACITY);
     let (control_tx, _control_rx) = mpsc::channel(UDP_SESSION_QUEUE_CAPACITY);
 
@@ -1293,12 +1460,14 @@ async fn udp_session_recv_loop_error_closes_registered_sessions() {
         socket,
         sessions.clone(),
         classified_sessions.clone(),
+        tuple_owners,
         classified_accepts,
         pending_connects.clone(),
         mux_accepted_tx,
         control_tx,
         Arc::new(NoopUdpSessionStunResponder),
         session_shutdown_tx,
+        true,
     )
     .await;
 
@@ -1340,6 +1509,7 @@ async fn udp_session_layer_accepts_syn_and_sends_sack() {
     handle_new_easy_tier_mux_connect(
         socket.clone(),
         sessions.clone(),
+        Arc::new(DashMap::new()),
         mux_accepted_tx,
         peer_addr,
         conn_id,
@@ -1383,6 +1553,7 @@ async fn duplicate_syn_sack_send_failure_closes_existing_session() {
     handle_new_easy_tier_mux_connect(
         socket,
         sessions.clone(),
+        Arc::new(DashMap::new()),
         mux_accepted_tx,
         peer_addr,
         conn_id,
@@ -1420,6 +1591,7 @@ async fn full_accept_queue_does_not_block_udp_session_recv_loop() {
     handle_new_easy_tier_mux_connect(
         socket.clone(),
         sessions.clone(),
+        Arc::new(DashMap::new()),
         mux_accepted_tx,
         peer_addr,
         conn_id,
@@ -1607,7 +1779,9 @@ async fn udp_session_recv_loop_does_not_wait_for_stun_responder() {
     );
     let pending_connects = Arc::new(DashMap::new());
     let classified_sessions = Arc::new(DashMap::new());
-    let classified_accepts = create_classified_udp_session_accepts();
+    let tuple_owners = Arc::new(DashMap::new());
+    let routes = UdpSessionRouteSet::singleton(UdpSessionAcceptKind::EasyTierMux);
+    let classified_accepts = create_classified_udp_session_accepts(routes);
     let (mux_accepted_tx, _mux_accepted_rx) = mpsc::channel(UDP_SESSION_QUEUE_CAPACITY);
     let (control_tx, _control_rx) = mpsc::channel(UDP_SESSION_QUEUE_CAPACITY);
     let stun_responder = Arc::new(BlockingUdpSessionStunResponder::default());
@@ -1616,12 +1790,14 @@ async fn udp_session_recv_loop_does_not_wait_for_stun_responder() {
         socket,
         sessions,
         classified_sessions,
+        tuple_owners,
         classified_accepts,
         pending_connects,
         mux_accepted_tx,
         control_tx,
         stun_responder.clone(),
         session_shutdown_tx,
+        true,
     ));
 
     tokio::time::timeout(Duration::from_secs(1), stun_responder.started.notified())

--- a/easytier/src/core.rs
+++ b/easytier/src/core.rs
@@ -1718,6 +1718,17 @@ mod tests {
                 .all(|listener| !listener.starts_with("wg://") && !listener.starts_with("quic://"))
         );
 
+        #[cfg(feature = "wireguard")]
+        assert_eq!(
+            Cli::parse_listeners(false, vec!["wg".to_string()]).unwrap(),
+            vec!["wg://0.0.0.0:11010"]
+        );
+        #[cfg(feature = "quic")]
+        assert_eq!(
+            Cli::parse_listeners(false, vec!["quic".to_string()]).unwrap(),
+            vec!["quic://0.0.0.0:11010"]
+        );
+
         let cli = Cli::try_parse_from([
             "easytier-core",
             "--listeners",

--- a/easytier/src/core.rs
+++ b/easytier/src/core.rs
@@ -788,9 +788,16 @@ struct RpcPortalOptions {
 }
 
 impl Cli {
+    fn generated_listener_schemes() -> impl Iterator<Item = &'static IpScheme> {
+        IpScheme::VARIANTS.iter().filter(|scheme| {
+            let scheme: &'static str = (**scheme).into();
+            !matches!(scheme, "wg" | "quic")
+        })
+    }
+
     fn gen_listeners(addr: SocketAddr) -> impl Iterator<Item = String> {
         let dynamic = addr.port() == 0;
-        IpScheme::VARIANTS.iter().map(move |proto| {
+        Self::generated_listener_schemes().map(move |proto| {
             let mut addr = addr;
             if !dynamic {
                 addr.set_port(addr.port() + proto.port_offset());
@@ -1686,16 +1693,41 @@ mod tests {
         for (input, output) in cases {
             assert_eq!(
                 Cli::parse_listeners(false, vec![input.to_string()]).unwrap(),
-                IpScheme::VARIANTS.iter().map(output).collect::<Vec<_>>()
+                Cli::generated_listener_schemes()
+                    .map(output)
+                    .collect::<Vec<_>>()
             );
         }
 
         let input = cases.iter().map(|(i, _)| i.to_string()).collect::<Vec<_>>();
         let output = cases
             .iter()
-            .flat_map(|(_, o)| IpScheme::VARIANTS.iter().map(o))
+            .flat_map(|(_, o)| Cli::generated_listener_schemes().map(o))
             .collect::<Vec<_>>();
         assert_eq!(Cli::parse_listeners(false, input).unwrap(), output);
+
+        let generated = Cli::parse_listeners(false, vec!["11010".to_string()]).unwrap();
+        assert!(
+            generated
+                .iter()
+                .any(|listener| listener == "udp://0.0.0.0:11010")
+        );
+        assert!(
+            generated
+                .iter()
+                .all(|listener| !listener.starts_with("wg://") && !listener.starts_with("quic://"))
+        );
+
+        let cli = Cli::try_parse_from([
+            "easytier-core",
+            "--listeners",
+            "udp://0.0.0.0:11010?accept=udp+wg",
+        ])
+        .unwrap();
+        assert_eq!(
+            cli.network_options.listeners,
+            vec!["udp://0.0.0.0:11010?accept=udp+wg"]
+        );
 
         let cases: [(IpSchemeMap, IpSchemeMap); _] = [
             (

--- a/easytier/src/instance/cli_event_logger.rs
+++ b/easytier/src/instance/cli_event_logger.rs
@@ -95,7 +95,7 @@ fn log_event(instance_id: Uuid, event: GlobalCtxEvent) {
             event!(
                 info,
                 %listener,
-                "[{}] new listener added",
+                "[{}] listener endpoint available",
                 instance_id
             );
         }

--- a/easytier/src/tunnel/protocol.rs
+++ b/easytier/src/tunnel/protocol.rs
@@ -448,7 +448,7 @@ mod tests {
             else {
                 panic!("QUIC must keep accepting connections from its UDP session");
             };
-            let tunnel = accepted.accept().await.unwrap();
+            let tunnel = accepted.accept().await.unwrap().unwrap();
             crate::tunnel::common::tests::_tunnel_echo_server(tunnel, false).await;
         });
 

--- a/easytier/src/tunnel/quic.rs
+++ b/easytier/src/tunnel/quic.rs
@@ -20,13 +20,21 @@ use quinn::{
     AsyncUdpSocket, ClientConfig, Connecting, Connection, Endpoint, EndpointConfig, Incoming,
     ServerConfig, TransportConfig, congestion::BbrConfig, default_runtime,
 };
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use std::{
+    net::SocketAddr,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
 use tokio::{
     sync::{
-        OwnedSemaphorePermit, Semaphore,
+        Notify, OwnedSemaphorePermit, Semaphore,
         mpsc::{Receiver, Sender, channel},
     },
     task::JoinSet,
+    time::Instant,
 };
 use tokio_util::task::AbortOnDropHandle;
 
@@ -313,10 +321,12 @@ pub fn endpoint_config() -> EndpointConfig {
 //endregion
 
 const QUIC_ACCEPT_COMPLETION_TIMEOUT: Duration = Duration::from_secs(10);
+const QUIC_ESTABLISHMENT_TIMEOUT: Duration = Duration::from_secs(30);
 
 struct ConnWrapper {
     conn: Connection,
     _endpoint: Endpoint,
+    _activity: Option<QuicActiveConnection>,
 }
 
 impl Drop for ConnWrapper {
@@ -353,6 +363,7 @@ pub(crate) async fn upgrade_connected(
     let connection = Arc::new(ConnWrapper {
         conn: connection,
         _endpoint: endpoint,
+        _activity: None,
     });
     let info = TunnelInfo {
         tunnel_type: "quic".to_owned(),
@@ -374,7 +385,38 @@ struct PendingQuicSessionTunnel {
     endpoint: Endpoint,
     local_url: url::Url,
     remote_addr: SocketAddr,
+    activity: Arc<QuicConnectionActivity>,
     _handshake_permit: OwnedSemaphorePermit,
+}
+
+#[derive(Debug, Default)]
+struct QuicConnectionActivity {
+    active: AtomicUsize,
+    changed: Notify,
+}
+
+impl QuicConnectionActivity {
+    fn active(&self) -> usize {
+        self.active.load(Ordering::Acquire)
+    }
+}
+
+struct QuicActiveConnection {
+    activity: Arc<QuicConnectionActivity>,
+}
+
+impl QuicActiveConnection {
+    fn new(activity: Arc<QuicConnectionActivity>) -> Self {
+        activity.active.fetch_add(1, Ordering::AcqRel);
+        Self { activity }
+    }
+}
+
+impl Drop for QuicActiveConnection {
+    fn drop(&mut self) {
+        self.activity.active.fetch_sub(1, Ordering::AcqRel);
+        self.activity.changed.notify_one();
+    }
 }
 
 async fn finish_quic_session_tunnel(
@@ -385,6 +427,7 @@ async fn finish_quic_session_tunnel(
         endpoint,
         local_url,
         remote_addr,
+        activity,
         _handshake_permit,
     } = pending;
     let connection = tokio::time::timeout(QUIC_ACCEPT_COMPLETION_TIMEOUT, connecting)
@@ -399,6 +442,7 @@ async fn finish_quic_session_tunnel(
     let connection = Arc::new(ConnWrapper {
         conn: connection,
         _endpoint: endpoint,
+        _activity: Some(QuicActiveConnection::new(activity)),
     });
     let remote_url = super::build_url_from_socket_addr(&remote_addr.to_string(), "quic");
     let info = TunnelInfo {
@@ -414,38 +458,64 @@ async fn finish_quic_session_tunnel(
     )))
 }
 
+struct QuicAcceptedSessionLease {
+    session: Arc<UdpSession>,
+    _active_session: OwnedSemaphorePermit,
+}
+
+impl Drop for QuicAcceptedSessionLease {
+    fn drop(&mut self) {
+        self.session.close();
+    }
+}
+
 async fn run_quic_accepted_session(
     endpoint: Endpoint,
     local_url: url::Url,
     handshakes: Arc<Semaphore>,
     completed: Sender<Result<Box<dyn Tunnel>, TunnelError>>,
+    lease: QuicAcceptedSessionLease,
+    establishment_timeout: Duration,
 ) {
+    let activity = Arc::new(QuicConnectionActivity::default());
+    let establishment_deadline = Instant::now() + establishment_timeout;
     let mut complete_tasks = JoinSet::new();
     let mut pending_incoming: Option<Incoming> = None;
+    let mut ever_connected = false;
+
     loop {
+        let no_handshake = pending_incoming.is_none() && complete_tasks.is_empty();
+        if ever_connected && no_handshake && activity.active() == 0 {
+            break;
+        }
+
         tokio::select! {
-            Some(result) = complete_tasks.join_next(), if !complete_tasks.is_empty() => {
-                let result = match result {
-                    Ok(result) => result,
+            biased;
+
+            result = complete_tasks.join_next(), if !complete_tasks.is_empty() => {
+                let result = match result.expect("nonempty QUIC task set must yield a result") {
+                    Ok(Ok(tunnel)) => {
+                        ever_connected = true;
+                        Ok(tunnel)
+                    }
+                    Ok(Err(error)) => Err(error),
                     Err(error) => Err(TunnelError::InternalError(
-                        format!("quic accept task failed: {error}"),
+                        format!("quic accept task failed: {error}")
                     )),
                 };
                 if completed.send(result).await.is_err() {
                     break;
                 }
             }
-            incoming = endpoint.accept(), if pending_incoming.is_none() => {
-                match incoming {
-                    Some(incoming) => pending_incoming = Some(incoming),
-                    None => break,
-                }
+            _ = tokio::time::sleep_until(establishment_deadline), if !ever_connected => {
+                break;
             }
+            _ = activity.changed.notified() => {}
             permit = handshakes.clone().acquire_owned(), if pending_incoming.is_some() => {
                 let Ok(handshake_permit) = permit else {
                     break;
                 };
-                let incoming = pending_incoming.take().unwrap();
+                let incoming = pending_incoming.take().expect("pending QUIC Incoming must exist");
                 let remote_addr = incoming.remote_address();
                 match incoming.accept() {
                     Ok(connecting) => {
@@ -455,26 +525,36 @@ async fn run_quic_accepted_session(
                                 endpoint: endpoint.clone(),
                                 local_url: local_url.clone(),
                                 remote_addr,
+                                activity: activity.clone(),
                                 _handshake_permit: handshake_permit,
                             },
                         ));
                     }
                     Err(error) => {
                         drop(handshake_permit);
-                        if completed
-                            .send(Err(anyhow::Error::new(error)
+                        let result = Err(
+                            anyhow::Error::new(error)
                                 .context("quic accept connection failed")
-                                .into()))
-                            .await
-                            .is_err()
-                        {
+                                .into(),
+                        );
+                        if completed.send(result).await.is_err() {
                             break;
                         }
                     }
                 }
             }
+            incoming = endpoint.accept(), if pending_incoming.is_none() => {
+                match incoming {
+                    Some(incoming) => pending_incoming = Some(incoming),
+                    None => break,
+                }
+            }
         }
     }
+
+    endpoint.close(0u32.into(), b"accepted session retired");
+    complete_tasks.abort_all();
+    drop(lease);
 }
 
 pub(crate) struct QuicAcceptedSession {
@@ -488,20 +568,27 @@ impl QuicAcceptedSession {
         local_url: url::Url,
         admission: ServerProtocolAdmission,
     ) -> Result<Self, TunnelError> {
-        let (active_session, handshake_slots) = admission.into_parts();
-        Self::new_with_admission_parts(session, local_url, active_session, handshake_slots)
+        Self::new_with_establishment_timeout(
+            session,
+            local_url,
+            admission,
+            QUIC_ESTABLISHMENT_TIMEOUT,
+        )
     }
 
-    fn new_with_admission_parts(
+    fn new_with_establishment_timeout(
         session: UdpSession,
         local_url: url::Url,
-        active_session: OwnedSemaphorePermit,
-        handshakes: Arc<Semaphore>,
+        admission: ServerProtocolAdmission,
+        establishment_timeout: Duration,
     ) -> Result<Self, TunnelError> {
-        let socket = Arc::new(QuicUdpSessionSocket::from_accepted(
-            session,
-            active_session,
-        )?);
+        let (active_session, handshakes) = admission.into_parts();
+        let session = Arc::new(session);
+        let lease = QuicAcceptedSessionLease {
+            session: session.clone(),
+            _active_session: active_session,
+        };
+        let socket = Arc::new(QuicUdpSessionSocket::from_accepted(session)?);
         let runtime = default_runtime().ok_or(TunnelError::InternalError(
             "no async runtime found".to_owned(),
         ))?;
@@ -517,6 +604,8 @@ impl QuicAcceptedSession {
             local_url,
             handshakes,
             completed_tx,
+            lease,
+            establishment_timeout,
         )));
         Ok(Self {
             completed,
@@ -524,22 +613,22 @@ impl QuicAcceptedSession {
         })
     }
 
-    pub(crate) async fn accept(&mut self) -> Result<Box<dyn Tunnel>, TunnelError> {
+    pub(crate) async fn accept(&mut self) -> Result<Option<Box<dyn Tunnel>>, TunnelError> {
         while let Some(result) = self.completed.recv().await {
             match result {
-                Ok(tunnel) => return Ok(tunnel),
+                Ok(tunnel) => return Ok(Some(tunnel)),
                 Err(error) => {
                     tracing::warn!(?error, "QUIC session connection failed");
                 }
             }
         }
-        Err(TunnelError::Shutdown)
+        Ok(None)
     }
 }
 
 #[async_trait::async_trait]
 impl ServerTunnelAcceptor for QuicAcceptedSession {
-    async fn accept(&mut self) -> anyhow::Result<Box<dyn Tunnel>> {
+    async fn accept(&mut self) -> anyhow::Result<Option<Box<dyn Tunnel>>> {
         Ok(QuicAcceptedSession::accept(self).await?)
     }
 }
@@ -557,7 +646,7 @@ mod tests {
         socket::SocketListener,
         socket::udp::{
             UdpBindOptions, UdpSessionAcceptKind, UdpSessionListenRequest, UdpSessionProtocol,
-            VirtualUdpSocket,
+            UdpSessionSocket, VirtualUdpSocket,
         },
     };
     use futures::{SinkExt, StreamExt};
@@ -568,6 +657,68 @@ mod tests {
     };
 
     use super::*;
+
+    fn synthetic_quic_initial(dcid: u8) -> Vec<u8> {
+        let mut packet = vec![0; 1200];
+        packet[0] = 0xc0;
+        packet[4] = 1;
+        packet[5] = 1;
+        packet[6] = dcid;
+        packet[7] = 0;
+        packet[8] = 0;
+        packet[9] = 1;
+        packet
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unestablished_quic_session_retires_and_releases_admission() {
+        tokio::time::timeout(Duration::from_secs(3), async {
+            let bind_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+            let mut listener = new_runtime_udp_session_listener(
+                format!("quic://{bind_addr}").parse().unwrap(),
+                UdpSessionListenRequest::new(
+                    UdpBindOptions::port_bound_listener(bind_addr).with_only_v6(false),
+                ),
+                UdpSessionAcceptKind::Classified(UdpSessionProtocol::Quic),
+                NetNS::new(None),
+            );
+            listener.listen().await.unwrap();
+            let remote_addr = listener.bound_socket().unwrap().local_addr().unwrap();
+            let local_url = listener.local_url();
+            let client = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+            let client_addr = client.local_addr().unwrap();
+
+            client
+                .send_to(&synthetic_quic_initial(1), remote_addr)
+                .await
+                .unwrap();
+            let session = listener.accept().await.unwrap();
+            let admission = ServerProtocolAdmissionController::new(1, 1);
+            let permit = admission.try_admit().unwrap();
+            let mut accepted = QuicAcceptedSession::new_with_establishment_timeout(
+                session,
+                local_url,
+                permit,
+                Duration::from_millis(100),
+            )
+            .unwrap();
+
+            assert!(accepted.accept().await.unwrap().is_none());
+            assert!(admission.try_admit().is_some());
+
+            client
+                .send_to(&synthetic_quic_initial(2), remote_addr)
+                .await
+                .unwrap();
+            let fresh = tokio::time::timeout(Duration::from_secs(1), listener.accept())
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(fresh.peer_addr().unwrap(), client_addr);
+        })
+        .await
+        .unwrap();
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn accepted_udp_session_supports_multiple_quic_connections() {
@@ -606,16 +757,22 @@ mod tests {
                 let admission = ServerProtocolAdmissionController::new(1, 2)
                     .try_admit()
                     .unwrap();
-                let mut accepted = QuicAcceptedSession::new(session, local_url, admission).unwrap();
-                let first = accepted.accept().await.unwrap();
-                let second = accepted.accept().await.unwrap();
+                let mut accepted = QuicAcceptedSession::new_with_establishment_timeout(
+                    session,
+                    local_url,
+                    admission,
+                    Duration::from_secs(2),
+                )
+                .unwrap();
+                let first = accepted.accept().await.unwrap().unwrap();
+                let second = accepted.accept().await.unwrap().unwrap();
                 assert!(
                     tokio::time::timeout(Duration::from_millis(50), listener.accept())
                         .await
                         .is_err(),
                     "both QUIC connections must use the first accepted UDP session"
                 );
-                (first, second)
+                (first, second, accepted)
             });
 
             let first_connection = endpoint
@@ -640,7 +797,7 @@ mod tests {
                 .send(ZCPacket::new_with_payload(b"second QUIC connection ready"))
                 .await
                 .unwrap();
-            let (first_server, second_server) = server_task.await.unwrap();
+            let (first_server, second_server, accepted) = server_task.await.unwrap();
 
             drop(first_send);
             drop(first_read);
@@ -666,6 +823,14 @@ mod tests {
             echo_task.await.unwrap();
             second_connection.close(0u32.into(), b"second connection done");
             endpoint.close(0u32.into(), b"test done");
+            let mut accepted = accepted;
+            assert!(
+                tokio::time::timeout(Duration::from_secs(1), accepted.accept())
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .is_none()
+            );
         })
         .await
         .unwrap();

--- a/easytier/src/tunnel/quic.rs
+++ b/easytier/src/tunnel/quic.rs
@@ -16,6 +16,7 @@ use easytier_core::{
         wrapper::TunnelWrapper,
     },
 };
+use futures::FutureExt as _;
 use quinn::{
     AsyncUdpSocket, ClientConfig, Connecting, Connection, Endpoint, EndpointConfig, Incoming,
     ServerConfig, TransportConfig, congestion::BbrConfig, default_runtime,
@@ -469,6 +470,10 @@ impl Drop for QuicAcceptedSessionLease {
     }
 }
 
+fn try_accept_ready(endpoint: &Endpoint) -> Option<Incoming> {
+    endpoint.accept().now_or_never().flatten()
+}
+
 async fn run_quic_accepted_session(
     endpoint: Endpoint,
     local_url: url::Url,
@@ -486,7 +491,11 @@ async fn run_quic_accepted_session(
     loop {
         let no_handshake = pending_incoming.is_none() && complete_tasks.is_empty();
         if ever_connected && no_handshake && activity.active() == 0 {
-            break;
+            // A connection drop can become visible alongside a queued replacement Initial.
+            let Some(incoming) = try_accept_ready(&endpoint) else {
+                break;
+            };
+            pending_incoming = Some(incoming);
         }
 
         tokio::select! {
@@ -715,6 +724,65 @@ mod tests {
                 .unwrap()
                 .unwrap();
             assert_eq!(fresh.peer_addr().unwrap(), client_addr);
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ready_quic_initial_is_taken_before_idle_retirement() {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            let bind_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+            let mut listener = new_runtime_udp_session_listener(
+                format!("quic://{bind_addr}").parse().unwrap(),
+                UdpSessionListenRequest::new(
+                    UdpBindOptions::port_bound_listener(bind_addr).with_only_v6(false),
+                ),
+                UdpSessionAcceptKind::Classified(UdpSessionProtocol::Quic),
+                NetNS::new(None),
+            );
+            listener.listen().await.unwrap();
+            let remote_addr = listener.bound_socket().unwrap().local_addr().unwrap();
+
+            let connected = connect_udp(
+                native_host_runtime(),
+                remote_addr,
+                Vec::new(),
+                UdpBindOptions::direct_connect(),
+                UdpSessionMode::Classified(UdpSessionProtocol::Quic),
+            )
+            .await
+            .unwrap();
+            let socket = Arc::new(QuicUdpSessionSocket::new(connected).unwrap());
+            let runtime = default_runtime().unwrap();
+            let mut client_endpoint =
+                Endpoint::new_with_abstract_socket(endpoint_config(), None, socket, runtime)
+                    .unwrap();
+            client_endpoint.set_default_client_config(client_config());
+            let connecting = client_endpoint.connect(remote_addr, "localhost").unwrap();
+            let connect_task = tokio::spawn(connecting);
+
+            let session = Arc::new(listener.accept().await.unwrap());
+            let socket = Arc::new(QuicUdpSessionSocket::from_accepted(session).unwrap());
+            let runtime = default_runtime().unwrap();
+            let endpoint = Endpoint::new_with_abstract_socket(
+                endpoint_config(),
+                Some(server_config()),
+                socket,
+                runtime,
+            )
+            .unwrap();
+
+            loop {
+                if let Some(incoming) = try_accept_ready(&endpoint) {
+                    drop(incoming);
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+            endpoint.close(0u32.into(), b"server test done");
+            client_endpoint.close(0u32.into(), b"client test done");
+            connect_task.abort();
         })
         .await
         .unwrap();

--- a/easytier/src/tunnel/quic.rs
+++ b/easytier/src/tunnel/quic.rs
@@ -644,7 +644,14 @@ impl ServerTunnelAcceptor for QuicAcceptedSession {
 
 #[cfg(test)]
 mod tests {
-    use std::{net::SocketAddr, sync::Arc, time::Duration};
+    use std::{
+        io::{self, IoSliceMut},
+        net::SocketAddr,
+        pin::Pin,
+        sync::{Arc, Mutex},
+        task::{Context, Poll},
+        time::Duration,
+    };
 
     use easytier_core::{
         connectivity::{
@@ -655,10 +662,14 @@ mod tests {
         socket::SocketListener,
         socket::udp::{
             UdpBindOptions, UdpSessionAcceptKind, UdpSessionListenRequest, UdpSessionProtocol,
-            UdpSessionSocket, VirtualUdpSocket,
+            UdpSessionSocket, VirtualUdpSocket, parse_quic_initial_dcid,
         },
     };
     use futures::{SinkExt, StreamExt};
+    use quinn::{
+        UdpPoller,
+        udp::{RecvMeta, Transmit},
+    };
 
     use crate::{
         common::netns::NetNS, host_runtime::native_host_runtime,
@@ -677,6 +688,86 @@ mod tests {
         packet[8] = 0;
         packet[9] = 1;
         packet
+    }
+
+    #[derive(Debug)]
+    struct ReplacementInitialObserver {
+        inner: Arc<QuicUdpSessionSocket>,
+        first_dcid: Mutex<Option<Vec<u8>>>,
+        replacement_initial: Notify,
+    }
+
+    impl ReplacementInitialObserver {
+        fn new(inner: Arc<QuicUdpSessionSocket>) -> Self {
+            Self {
+                inner,
+                first_dcid: Mutex::new(None),
+                replacement_initial: Notify::new(),
+            }
+        }
+
+        fn observe(&self, datagram: &[u8]) {
+            let Some(dcid) = parse_quic_initial_dcid(datagram) else {
+                return;
+            };
+            let mut first_dcid = self.first_dcid.lock().unwrap();
+            match first_dcid.as_ref() {
+                None => *first_dcid = Some(dcid),
+                Some(first_dcid) if first_dcid != &dcid => {
+                    self.replacement_initial.notify_one();
+                }
+                Some(_) => {}
+            }
+        }
+
+        fn saw_first_initial(&self) -> bool {
+            self.first_dcid.lock().unwrap().is_some()
+        }
+
+        async fn replacement_initial_seen(&self) {
+            self.replacement_initial.notified().await;
+        }
+    }
+
+    impl AsyncUdpSocket for ReplacementInitialObserver {
+        fn create_io_poller(self: Arc<Self>) -> Pin<Box<dyn UdpPoller>> {
+            self.inner.clone().create_io_poller()
+        }
+
+        fn try_send(&self, transmit: &Transmit<'_>) -> io::Result<()> {
+            self.inner.try_send(transmit)
+        }
+
+        fn poll_recv(
+            &self,
+            context: &mut Context<'_>,
+            buffers: &mut [IoSliceMut<'_>],
+            meta: &mut [RecvMeta],
+        ) -> Poll<io::Result<usize>> {
+            let result = self.inner.poll_recv(context, buffers, meta);
+            if let Poll::Ready(Ok(received)) = &result {
+                for (buffer, meta) in buffers.iter().zip(meta.iter()).take(*received) {
+                    self.observe(&buffer[..meta.len]);
+                }
+            }
+            result
+        }
+
+        fn local_addr(&self) -> io::Result<SocketAddr> {
+            self.inner.local_addr()
+        }
+
+        fn max_transmit_segments(&self) -> usize {
+            self.inner.max_transmit_segments()
+        }
+
+        fn max_receive_segments(&self) -> usize {
+            self.inner.max_receive_segments()
+        }
+
+        fn may_fragment(&self) -> bool {
+            self.inner.may_fragment()
+        }
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -730,7 +821,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn ready_quic_initial_is_taken_before_idle_retirement() {
+    async fn queued_replacement_initial_is_accepted_before_idle_retirement() {
         tokio::time::timeout(Duration::from_secs(5), async {
             let bind_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
             let mut listener = new_runtime_udp_session_listener(
@@ -743,6 +834,7 @@ mod tests {
             );
             listener.listen().await.unwrap();
             let remote_addr = listener.bound_socket().unwrap().local_addr().unwrap();
+            let local_url = listener.local_url();
 
             let connected = connect_udp(
                 native_host_runtime(),
@@ -759,30 +851,103 @@ mod tests {
                 Endpoint::new_with_abstract_socket(endpoint_config(), None, socket, runtime)
                     .unwrap();
             client_endpoint.set_default_client_config(client_config());
-            let connecting = client_endpoint.connect(remote_addr, "localhost").unwrap();
-            let connect_task = tokio::spawn(connecting);
+
+            let first_connecting = client_endpoint.connect(remote_addr, "localhost").unwrap();
+            let first_client = tokio::spawn(async move {
+                let connection = first_connecting.await.unwrap();
+                let (write, read) = connection.open_bi().await.unwrap();
+                let mut write = FramedWriter::new(write);
+                write
+                    .send(ZCPacket::new_with_payload(b"first QUIC connection"))
+                    .await
+                    .unwrap();
+                (connection, (write, read))
+            });
 
             let session = Arc::new(listener.accept().await.unwrap());
-            let socket = Arc::new(QuicUdpSessionSocket::from_accepted(session).unwrap());
+            let socket = Arc::new(QuicUdpSessionSocket::from_accepted(session.clone()).unwrap());
+            let observer = Arc::new(ReplacementInitialObserver::new(socket));
             let runtime = default_runtime().unwrap();
             let endpoint = Endpoint::new_with_abstract_socket(
                 endpoint_config(),
                 Some(server_config()),
-                socket,
+                observer.clone(),
                 runtime,
             )
             .unwrap();
+            let endpoint_sync = endpoint.clone();
+            let admission = ServerProtocolAdmissionController::new(1, 2)
+                .try_admit()
+                .unwrap();
+            let (active_session, handshakes) = admission.into_parts();
+            let lease = QuicAcceptedSessionLease {
+                session,
+                _active_session: active_session,
+            };
+            let (completed_tx, mut completed) = channel(2);
+            let runner = run_quic_accepted_session(
+                endpoint,
+                local_url,
+                handshakes,
+                completed_tx,
+                lease,
+                Duration::from_secs(2),
+            );
+            tokio::pin!(runner);
 
-            loop {
-                if let Some(incoming) = try_accept_ready(&endpoint) {
-                    drop(incoming);
-                    break;
+            let first_server = tokio::select! {
+                () = &mut runner => panic!("accepted QUIC session retired before first tunnel"),
+                result = completed.recv() => result
+                    .expect("accepted QUIC session must report first tunnel")
+                    .expect("first QUIC tunnel must complete"),
+            };
+            let (first_connection, first_streams) = first_client.await.unwrap();
+            assert!(observer.saw_first_initial());
+
+            let second_connecting = client_endpoint.connect(remote_addr, "localhost").unwrap();
+            let second_client = tokio::spawn(async move {
+                let connection = second_connecting.await.unwrap();
+                let (write, read) = connection.open_bi().await.unwrap();
+                let mut write = FramedWriter::new(write);
+                write
+                    .send(ZCPacket::new_with_payload(b"replacement QUIC connection"))
+                    .await
+                    .unwrap();
+                (connection, (write, read))
+            });
+            tokio::time::timeout(Duration::from_secs(1), observer.replacement_initial_seen())
+                .await
+                .expect("replacement QUIC Initial must reach the accepted session");
+            // The endpoint driver holds its state lock while polling the socket and
+            // queuing Incoming values. Acquiring it here waits for that poll to finish.
+            let _ = endpoint_sync.stats();
+
+            // The runner remains unpolled while Quinn queues the replacement Initial.
+            // Dropping the final active tunnel now makes both select branches ready.
+            drop(first_server);
+
+            let second_server = tokio::select! {
+                () = &mut runner => {
+                    panic!("accepted QUIC session retired with a replacement Initial queued")
                 }
-                tokio::task::yield_now().await;
-            }
-            endpoint.close(0u32.into(), b"server test done");
+                result = completed.recv() => result
+                    .expect("accepted QUIC session must report replacement tunnel")
+                    .expect("replacement QUIC tunnel must complete"),
+            };
+            let (second_connection, second_streams) = second_client.await.unwrap();
+            assert!(
+                tokio::time::timeout(Duration::from_millis(50), listener.accept())
+                    .await
+                    .is_err(),
+                "replacement QUIC connection must use the first accepted UDP session"
+            );
+
+            drop(second_server);
+            drop(first_streams);
+            drop(second_streams);
+            first_connection.close(0u32.into(), b"first connection done");
+            second_connection.close(0u32.into(), b"second connection done");
             client_endpoint.close(0u32.into(), b"client test done");
-            connect_task.abort();
         })
         .await
         .unwrap();

--- a/easytier/src/tunnel/quic/session_socket.rs
+++ b/easytier/src/tunnel/quic/session_socket.rs
@@ -9,7 +9,7 @@ use std::{
 
 use easytier_core::{
     connectivity::transport::ConnectedUdpSession,
-    socket::udp::{UdpSession, UdpSessionSocket},
+    socket::udp::{UdpSession, UdpSessionSocket, UdpSocketSendMeta},
 };
 use quinn::{
     AsyncUdpSocket, UdpPoller,
@@ -20,7 +20,37 @@ use tokio_util::task::AbortOnDropHandle;
 
 const DATAGRAM_QUEUE_CAPACITY: usize = 1024;
 
-type SendBatch = Vec<Vec<u8>>;
+struct SendBatch {
+    datagrams: Vec<Vec<u8>>,
+    meta: UdpSocketSendMeta,
+}
+
+impl SendBatch {
+    fn from_transmit(transmit: &Transmit<'_>) -> io::Result<Self> {
+        let datagrams = match transmit.segment_size {
+            Some(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "QUIC segment size cannot be zero",
+                ));
+            }
+            Some(segment_size) => transmit
+                .contents
+                .chunks(segment_size)
+                .map(<[u8]>::to_vec)
+                .collect(),
+            None => vec![transmit.contents.to_vec()],
+        };
+        Ok(Self {
+            datagrams,
+            meta: UdpSocketSendMeta {
+                src_ip: transmit.src_ip,
+                src_ifindex: None,
+            },
+        })
+    }
+}
+
 type WritableFuture = Pin<Box<dyn Future<Output = io::Result<()>> + Send>>;
 
 struct ReceivedDatagram {
@@ -55,11 +85,8 @@ impl QuicUdpSessionSocket {
         Self::from_session(Arc::new(session), session_guard)
     }
 
-    pub(crate) fn from_accepted<T>(session: UdpSession, session_guard: T) -> io::Result<Self>
-    where
-        T: Send + Sync + 'static,
-    {
-        Self::from_session(Arc::new(session), Box::new(session_guard))
+    pub(crate) fn from_accepted(session: Arc<UdpSession>) -> io::Result<Self> {
+        Self::from_session(session, Box::new(()))
     }
 
     fn from_session(
@@ -97,8 +124,8 @@ impl QuicUdpSessionSocket {
         let send_session = session.clone();
         let send_task = AbortOnDropHandle::new(tokio::spawn(async move {
             while let Some(batch) = outgoing_rx.recv().await {
-                for datagram in batch {
-                    match send_session.send(&datagram).await {
+                for datagram in batch.datagrams {
+                    match send_session.send_with_meta(&datagram, batch.meta).await {
                         Ok(length) if length == datagram.len() => {}
                         Ok(_) => {
                             let _ = recv_errors
@@ -145,20 +172,7 @@ impl QuicUdpSessionSocket {
             ));
         }
 
-        let batch = match transmit.segment_size {
-            Some(0) => {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    "QUIC segment size cannot be zero",
-                ));
-            }
-            Some(segment_size) => transmit
-                .contents
-                .chunks(segment_size)
-                .map(<[u8]>::to_vec)
-                .collect(),
-            None => vec![transmit.contents.to_vec()],
-        };
+        let batch = SendBatch::from_transmit(transmit)?;
         self.outgoing.try_send(batch).map_err(map_try_send_error)
     }
 }
@@ -275,5 +289,31 @@ impl AsyncUdpSocket for QuicUdpSessionSocket {
 
     fn may_fragment(&self) -> bool {
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use quinn::udp::Transmit;
+
+    use super::SendBatch;
+
+    #[test]
+    fn send_batch_preserves_quinn_source_ip() {
+        let peer_addr = "192.0.2.2:22023".parse().unwrap();
+        let source_ip = "192.0.2.1".parse().unwrap();
+        let transmit = Transmit {
+            destination: peer_addr,
+            ecn: None,
+            contents: b"quic",
+            segment_size: None,
+            src_ip: Some(source_ip),
+        };
+
+        let batch = SendBatch::from_transmit(&transmit).unwrap();
+
+        assert_eq!(batch.datagrams, vec![b"quic".to_vec()]);
+        assert_eq!(batch.meta.src_ip, Some(source_ip));
+        assert_eq!(batch.meta.src_ifindex, None);
     }
 }

--- a/easytier/src/tunnel/quic/session_socket.rs
+++ b/easytier/src/tunnel/quic/session_socket.rs
@@ -44,11 +44,21 @@ impl SendBatch {
         Ok(Self {
             datagrams,
             meta: UdpSocketSendMeta {
-                src_ip: transmit.src_ip,
+                src_ip: selectable_source_ip(transmit.src_ip),
                 src_ifindex: None,
             },
         })
     }
+}
+
+fn selectable_source_ip(src_ip: Option<std::net::IpAddr>) -> Option<std::net::IpAddr> {
+    // OHOS cannot select an IPv6 source for UDP sends, so retain the OS-selected source.
+    #[cfg(target_env = "ohos")]
+    if matches!(src_ip, Some(std::net::IpAddr::V6(_))) {
+        return None;
+    }
+
+    src_ip
 }
 
 type WritableFuture = Pin<Box<dyn Future<Output = io::Result<()>> + Send>>;
@@ -315,5 +325,27 @@ mod tests {
         assert_eq!(batch.datagrams, vec![b"quic".to_vec()]);
         assert_eq!(batch.meta.src_ip, Some(source_ip));
         assert_eq!(batch.meta.src_ifindex, None);
+    }
+
+    #[test]
+    fn send_batch_uses_platform_supported_ipv6_source_selection() {
+        let peer_addr = "[2001:db8::2]:22023".parse().unwrap();
+        let source_ip = "2001:db8::1".parse().unwrap();
+        let transmit = Transmit {
+            destination: peer_addr,
+            ecn: None,
+            contents: b"quic",
+            segment_size: None,
+            src_ip: Some(source_ip),
+        };
+
+        let batch = SendBatch::from_transmit(&transmit).unwrap();
+        let expected_source_ip = if cfg!(target_env = "ohos") {
+            None
+        } else {
+            Some(source_ip)
+        };
+
+        assert_eq!(batch.meta.src_ip, expected_source_ip);
     }
 }


### PR DESCRIPTION
## Summary

- let EasyTier UDP, WireGuard, and QUIC listeners that resolve to the same physical endpoint share one UDP socket
- normalize listener endpoints before planning, merge their protocol routes and required-listener state, and publish every protocol alias
- classify each remote tuple into one protocol at a time so active sessions cannot be displaced by cross-protocol traffic
- allow one accepted QUIC UDP session to host multiple Quinn connections while keeping admission, retirement, and source-address metadata correct
- retain OS-selected IPv6 sources for QUIC on OHOS, whose UDP backend cannot honor explicit IPv6 source selection

## Design

UDP listener planning now converts protocol-specific URLs to a canonical physical `udp://` endpoint. Equivalent endpoints are coalesced into one transport config with a route set. A raw UDP listener accepts every supported route by default, and `accept=` can restrict it to an explicit `udp`, `wg`, `quic`, or combined route set.

The shared receive loop classifies new datagrams, gives an active remote tuple to exactly one protocol, and releases ownership only after the last session of that protocol closes. EasyTier multiplexed sessions retain their existing framing; WireGuard and QUIC receive classified peer-scoped sessions from the same socket.

The QUIC adapter forwards received destination-IP metadata to Quinn and applies Quinn's selected source address on replies. Accepted sessions are reference-counted across connections, stale cleanup cannot remove replacements, and an already queued Initial is drained before idle retirement. On OHOS only, explicit IPv6 source metadata is omitted at the send boundary because that platform reports it as unsupported; IPv4 and all other platforms keep exact source selection.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --features full --all -- -D warnings`
- `cargo hack check --package easytier --each-feature --exclude-features macos-ne --verbose` (40 feature combinations)
- `cargo metadata --format-version 1 --locked`
- `cargo test -p easytier --features full tunnel::quic::session_socket::tests -- --nocapture` (2 passed)
- `cargo check --package easytier --target aarch64-unknown-linux-ohos --no-default-features --features quic` (274 crates, 0 errors)
- CI-equivalent nextest `three_node` matrix (183 passed)
- CI-equivalent nextest `subnet_proxy_three_node_test` matrix (256 passed)
- CI-equivalent non-`three_node` matrix (1000 passed; the unchanged external-DNS `common::dns::tests::test_socket_addrs` assertion failed because the local container resolved one address instead of its hard-coded two)

## Compatibility

- existing `udp://` listeners continue to accept EasyTier UDP traffic and, when supported, classified WireGuard and QUIC traffic
- protocol-specific listener URLs remain advertised even when their physical socket is shared
- invalid or unsupported explicit route selections fail during listener planning instead of being silently ignored
