### PR TITLE
feat(web): add credential input to network config form

### DIFF
--- a/easytier-web/frontend-lib/src/components/Config.vue
+++ b/easytier-web/frontend-lib/src/components/Config.vue
@@ -29,6 +29,26 @@ const curNetwork = defineModel('curNetwork', {
 
 const { t } = useI18n()
 
+// Credential mode: once a credential is filled, configure secure_mode with the
+// credential as local_private_key; the backend (api_input) normalizes it and
+// derives the public key. Password must stay empty in credential mode.
+const credential = computed({
+  get: () => curNetwork.value.secure_mode?.local_private_key ?? '',
+  set: (v: string) => {
+    const val = v.trim()
+    if (val) {
+      curNetwork.value.secure_mode = { enabled: true, local_private_key: val, local_public_key: undefined }
+      curNetwork.value.network_secret = ''
+    } else {
+      curNetwork.value.secure_mode = undefined
+    }
+  },
+})
+// Password and credential are mutually exclusive: typing a password clears credential mode.
+watch(() => curNetwork.value.network_secret, (v) => {
+  if (v) curNetwork.value.secure_mode = undefined
+})
+
 const protos: { [proto: string]: number } = {
   tcp: 11010,
   udp: 11010,
@@ -237,6 +257,17 @@ const instanceRecvBpsLimitInput = computed<string>({
                   <label for="network_secret">{{ t('network_secret') }}</label>
                   <Password id="network_secret" v-model="curNetwork.network_secret"
                     aria-describedby="network_secret-help" toggleMask :feedback="false" fluid />
+                </div>
+              </div>
+
+              <div class="flex flex-row gap-x-9 flex-wrap">
+                <div class="flex flex-col gap-2 basis-5/12 grow">
+                  <div class="flex items-center">
+                    <label for="credential">{{ t('credential') }}</label>
+                    <span class="pi pi-question-circle ml-2 self-center" v-tooltip="t('credential_help')"></span>
+                  </div>
+                  <InputText id="credential" v-model="credential" aria-describedby="credential-help"
+                    :placeholder="t('credential_placeholder')" />
                 </div>
               </div>
 

--- a/easytier-web/frontend-lib/src/locales/cn.yaml
+++ b/easytier-web/frontend-lib/src/locales/cn.yaml
@@ -15,6 +15,9 @@ virtual_ipv4: 虚拟IPv4地址
 virtual_ipv4_dhcp: DHCP
 network_name: 网络名称
 network_secret: 网络密码
+credential: 凭据
+credential_help: 凭据模式：填服务器签发的凭据，密码留空（自动启用安全模式，仅按网络名入网）
+credential_placeholder: 服务器签发的凭据（如 sxs3K94/...）
 public_server_url: 公共服务器地址
 peer_urls: 对等节点地址
 proxy_cidrs: 子网代理CIDR

--- a/easytier-web/frontend-lib/src/locales/en.yaml
+++ b/easytier-web/frontend-lib/src/locales/en.yaml
@@ -15,6 +15,9 @@ virtual_ipv4: Virtual IPv4
 virtual_ipv4_dhcp: DHCP
 network_name: Network Name
 network_secret: Network Secret
+credential: Credential
+credential_help: "Credential mode: paste the server-issued credential and leave the password empty (secure mode is enabled automatically; join by network name only)"
+credential_placeholder: Server-issued credential (e.g. sxs3K94/...)
 public_server_url: Public Server URL
 peer_urls: Peer URLs
 proxy_cidrs: Subnet Proxy CIDRs


### PR DESCRIPTION
## What

Add a **Credential** input to the network configuration form (basic settings) so credential-peer nodes can join the network via the GUI, without touching the CLI.

## Why

- `easytier-gui` (and the web frontend-lib) has no place to enter the server-issued credential (the `--credential` value). Users who only hold a credential (e.g. temporary guest access issued by an admin) cannot join through the UI; the CLI is the only way (related: #2357).
- The backend already supports this path: `InstanceConfigPatch`/`api_input` turns an empty `network_secret` + `secure_mode.local_private_key` into a credential identity, and `normalize_secure_mode_config` derives the X25519 public key automatically when it is absent.

## How

- `Config.vue`: a new `credential` input is bound to `secure_mode.local_private_key` via a computed:
  - filling it enables secure mode (`enabled: true`, `local_private_key: <credential>`, public key left unset for the backend to derive) and clears the password — credential mode joins by network name only, matching the server-side credential system;
  - typing a password clears the credential (the two are mutually exclusive).
- i18n: `cn` / `en` entries for the label, placeholder and help text.

## Verification

- `vue-tsc --noEmit` passes
- `vite build` passes (after `pnpm codegen:proto`)

## Notes

- CLI users are unaffected; this only adds a new input to the form.
- The credential is stored in the same `secure_mode.local_private_key` field that the CLI `--credential` flag produces, so saved/exported TOML configs are identical in both paths.
