### PR TITLE
fix(Windows): 移除 wait_interface_show 的 10 秒硬超时，避免开机无网络时 TUN 接口未就绪导致实例停止

### DIFF
--- a/easytier/src/common/ifcfg/windows.rs
+++ b/easytier/src/common/ifcfg/windows.rs
@@ -242,19 +242,13 @@ impl IfConfiguerTrait for WindowsIfConfiger {
     }
 
     async fn wait_interface_show(&self, name: &str) -> Result<(), Error> {
-        Ok(
-            tokio::time::timeout(std::time::Duration::from_secs(10), async move {
-                loop {
-                    if let Some(idx) = Self::get_interface_index(name) {
-                        tracing::info!(?name, ?idx, "Interface found");
-                        break;
-                    }
-                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                }
-                Ok::<(), Error>(())
-            })
-            .await??,
-        )
+        loop {
+            if let Some(idx) = Self::get_interface_index(name) {
+                tracing::info!(?name, ?idx, "Interface found");
+                return Ok(());
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
     }
 
     async fn set_mtu(&self, name: &str, mtu: u32) -> Result<(), Error> {


### PR DESCRIPTION
在 Windows 开机后约一分钟内启动隧道时，若设备没有网络连接，wait_interface_show 的 10 秒超时会被触发，返回 Timeout error: deadline has elapsed 错误，导致整个实例停止运行，且无法在网络恢复时自动重连。

移除该硬超时，改为无限循环等待接口出现。外层 tokio::select! 的 cancel token 机制负责在实例停止时正确取消等待，不会导致进程无法退出。