### PR TITLE
fix: avoid Magic DNS RPC port collisions

### DIFF
--- a/easytier-web/frontend-lib/src/locales/cn.yaml
+++ b/easytier-web/frontend-lib/src/locales/cn.yaml
@@ -270,6 +270,8 @@ event:
   PortForwardAdded: 端口转发添加
   ProxyCidrsUpdated: 子网代理CIDR更新
   UdpBroadcastRelayStartResult: UDP广播中继启动结果
+  MagicDnsReady: Magic DNS 就绪
+  MagicDnsError: Magic DNS 错误
 
 web:
   login:

--- a/easytier-web/frontend-lib/src/locales/en.yaml
+++ b/easytier-web/frontend-lib/src/locales/en.yaml
@@ -270,6 +270,8 @@ event:
   PortForwardAdded: PortForwardAdded
   ProxyCidrsUpdated: ProxyCidrsUpdated
   UdpBroadcastRelayStartResult: UDP Broadcast Relay Start Result
+  MagicDnsReady: Magic DNS Ready
+  MagicDnsError: Magic DNS Error
 
 web:
   login:

--- a/easytier-web/frontend-lib/src/types/network.ts
+++ b/easytier-web/frontend-lib/src/types/network.ts
@@ -510,4 +510,7 @@ export enum EventType {
   ProxyCidrsUpdated = 'ProxyCidrsUpdated', // string[], string[]
 
   UdpBroadcastRelayStartResult = 'UdpBroadcastRelayStartResult', // { capture_backend?: string, error?: string }
+
+  MagicDnsReady = 'MagicDnsReady', // string
+  MagicDnsError = 'MagicDnsError', // string
 }

--- a/easytier/src/common/global_ctx.rs
+++ b/easytier/src/common/global_ctx.rs
@@ -71,6 +71,9 @@ pub enum GlobalCtxEvent {
         error: Option<String>,
     },
 
+    MagicDnsReady(String),
+    MagicDnsError(String),
+
     CredentialChanged,
 }
 

--- a/easytier/src/instance/cli_event_logger.rs
+++ b/easytier/src/instance/cli_event_logger.rs
@@ -243,6 +243,24 @@ fn log_event(instance_id: Uuid, event: GlobalCtxEvent) {
                 );
             }
         }
+        GlobalCtxEvent::MagicDnsReady(endpoint) => {
+            event!(
+                info,
+                category: "DNS",
+                endpoint,
+                "[{}] Magic DNS ready",
+                instance_id
+            );
+        }
+        GlobalCtxEvent::MagicDnsError(error) => {
+            event!(
+                error,
+                category: "DNS",
+                %error,
+                "[{}] Magic DNS error",
+                instance_id
+            );
+        }
         GlobalCtxEvent::CredentialChanged => {
             event!(info, "[{}] credential changed", instance_id);
         }

--- a/easytier/src/instance/dns_server/client_instance.rs
+++ b/easytier/src/instance/dns_server/client_instance.rs
@@ -1,5 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
+use anyhow::Context;
 use easytier_core::gateway::magic_dns::{
     MagicDnsRoutePublisher, MagicDnsRouteSnapshot, run_magic_dns_route_publisher,
 };
@@ -16,13 +17,14 @@ use crate::proto::{
     rpc_types::controller::BaseController,
 };
 
-use super::MAGIC_DNS_INSTANCE_ADDR;
+use super::endpoint::discover_magic_dns_endpoint;
 
 pub struct MagicDnsClientInstance {
     rpc_client: RuntimeRpcClient,
     rpc_stub: Option<Box<dyn MagicDnsServerRpc<Controller = BaseController> + Send>>,
     route_source: Arc<CorePacketPlane>,
-    tasks: JoinSet<()>,
+    tasks: JoinSet<anyhow::Result<()>>,
+    endpoint: url::Url,
 }
 
 struct RpcMagicDnsRoutePublisher {
@@ -71,7 +73,8 @@ impl MagicDnsRoutePublisher for RpcMagicDnsRoutePublisher {
 
 impl MagicDnsClientInstance {
     pub(crate) async fn new(route_source: Arc<CorePacketPlane>) -> Result<Self, anyhow::Error> {
-        let mut rpc_client = runtime_rpc_client(MAGIC_DNS_INSTANCE_ADDR.parse().unwrap());
+        let endpoint = discover_magic_dns_endpoint()?;
+        let mut rpc_client = runtime_rpc_client(endpoint.clone());
         let rpc_stub = rpc_client
             .scoped_client::<MagicDnsServerRpcClientFactory<BaseController>>("".to_string())
             .await?;
@@ -80,7 +83,12 @@ impl MagicDnsClientInstance {
             rpc_stub: Some(rpc_stub),
             route_source,
             tasks: JoinSet::new(),
+            endpoint,
         })
+    }
+
+    pub(crate) fn endpoint(&self) -> &url::Url {
+        &self.endpoint
     }
 
     async fn update_dns_task(
@@ -96,22 +104,22 @@ impl MagicDnsClientInstance {
         .await
     }
 
-    pub async fn run_and_wait(&mut self) {
+    pub async fn run_and_wait(&mut self) -> anyhow::Result<()> {
         let rpc_stub = self.rpc_stub.take().unwrap();
         let route_source = self.route_source.clone();
-        self.tasks.spawn(async move {
-            let ret = Self::update_dns_task(route_source, rpc_stub).await;
-            if let Err(e) = ret {
-                tracing::error!("MagicDnsServerInstanceData::run_and_wait: {:?}", e);
-            }
-        });
+        self.tasks
+            .spawn(Self::update_dns_task(route_source, rpc_stub));
 
         tokio::select! {
-            _ = self.tasks.join_next() => {
-                tracing::warn!("MagicDnsServerInstanceData::run_and_wait: dns record update task exited");
+            result = self.tasks.join_next() => {
+                match result {
+                    Some(Ok(result)) => result.context("Magic DNS route publisher exited"),
+                    Some(Err(error)) => Err(error).context("Magic DNS route publisher task failed"),
+                    None => anyhow::bail!("Magic DNS route publisher task was not running"),
+                }
             }
             _ = self.rpc_client.wait() => {
-                tracing::warn!("MagicDnsServerInstanceData::run_and_wait: rpc client exited");
+                anyhow::bail!("Magic DNS RPC client exited")
             }
         }
     }

--- a/easytier/src/instance/dns_server/endpoint.rs
+++ b/easytier/src/instance/dns_server/endpoint.rs
@@ -1,0 +1,186 @@
+use std::{
+    fs::{File, OpenOptions, TryLockError},
+    io::{Seek, SeekFrom, Write},
+    net::IpAddr,
+    path::{Path, PathBuf},
+};
+
+use anyhow::Context;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+
+const MAGIC_DNS_ENDPOINT_FILE: &str = "easytier-magic-dns-v1.endpoint";
+pub(super) const MAGIC_DNS_BIND_ADDR: &str = "127.0.0.1:0";
+
+pub(super) struct MagicDnsServerLease {
+    file: File,
+}
+
+impl MagicDnsServerLease {
+    pub(super) fn try_acquire() -> anyhow::Result<Option<Self>> {
+        Self::try_acquire_at(&endpoint_file_path())
+    }
+
+    fn try_acquire_at(path: &Path) -> anyhow::Result<Option<Self>> {
+        let mut options = OpenOptions::new();
+        options.create(true).truncate(false).read(true).write(true);
+        #[cfg(unix)]
+        options.mode(0o600).custom_flags(nix::libc::O_NOFOLLOW);
+
+        let file = options.open(path).with_context(|| {
+            format!(
+                "failed to open Magic DNS endpoint registry {}",
+                path.display()
+            )
+        })?;
+
+        match file.try_lock() {
+            Ok(()) => {
+                file.set_len(0).with_context(|| {
+                    format!(
+                        "failed to reset Magic DNS endpoint registry {}",
+                        path.display()
+                    )
+                })?;
+                Ok(Some(Self { file }))
+            }
+            Err(TryLockError::WouldBlock) => Ok(None),
+            Err(TryLockError::Error(error)) => Err(error).with_context(|| {
+                format!(
+                    "failed to lock Magic DNS endpoint registry {}",
+                    path.display()
+                )
+            }),
+        }
+    }
+
+    pub(super) fn publish(&mut self, endpoint: &url::Url) -> anyhow::Result<()> {
+        validate_endpoint(endpoint)?;
+        self.file.seek(SeekFrom::Start(0))?;
+        self.file.set_len(0)?;
+        self.file.write_all(endpoint.as_str().as_bytes())?;
+        self.file.sync_data()?;
+        Ok(())
+    }
+}
+
+impl Drop for MagicDnsServerLease {
+    fn drop(&mut self) {
+        let _ = self.file.set_len(0);
+        let _ = self.file.unlock();
+    }
+}
+
+pub(super) fn discover_magic_dns_endpoint() -> anyhow::Result<url::Url> {
+    discover_magic_dns_endpoint_at(&endpoint_file_path())
+}
+
+fn discover_magic_dns_endpoint_at(path: &Path) -> anyhow::Result<url::Url> {
+    let endpoint = std::fs::read_to_string(path).with_context(|| {
+        format!(
+            "failed to read Magic DNS endpoint registry {}",
+            path.display()
+        )
+    })?;
+    let endpoint = endpoint
+        .trim()
+        .parse::<url::Url>()
+        .context("Magic DNS endpoint registry does not contain a valid URL")?;
+    validate_endpoint(&endpoint)?;
+    Ok(endpoint)
+}
+
+fn validate_endpoint(endpoint: &url::Url) -> anyhow::Result<()> {
+    let is_loopback = endpoint
+        .host_str()
+        .and_then(|host| host.parse::<IpAddr>().ok())
+        .is_some_and(|ip| ip.is_loopback());
+    if endpoint.scheme() != "tcp" || !is_loopback || endpoint.port().is_none_or(|port| port == 0) {
+        anyhow::bail!(
+            "Magic DNS endpoint must be a loopback TCP URL with a non-zero port, got {endpoint}"
+        );
+    }
+    Ok(())
+}
+
+fn endpoint_file_path() -> PathBuf {
+    std::env::temp_dir().join(MAGIC_DNS_ENDPOINT_FILE)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::TcpListener;
+
+    use super::*;
+
+    #[test]
+    fn lease_is_exclusive_and_clears_stale_endpoint() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("magic-dns.endpoint");
+        std::fs::write(&path, "tcp://127.0.0.1:49813").unwrap();
+
+        let mut first = MagicDnsServerLease::try_acquire_at(&path).unwrap().unwrap();
+        assert!(std::fs::read_to_string(&path).unwrap().is_empty());
+        assert!(
+            MagicDnsServerLease::try_acquire_at(&path)
+                .unwrap()
+                .is_none()
+        );
+
+        let endpoint: url::Url = "tcp://127.0.0.1:54321".parse().unwrap();
+        first.publish(&endpoint).unwrap();
+        assert_eq!(discover_magic_dns_endpoint_at(&path).unwrap(), endpoint);
+
+        drop(first);
+        assert!(std::fs::read_to_string(&path).unwrap().is_empty());
+        assert!(
+            MagicDnsServerLease::try_acquire_at(&path)
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn discovery_rejects_non_loopback_endpoints() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("magic-dns.endpoint");
+
+        for endpoint in [
+            "tcp://192.0.2.1:54321",
+            "tcp://localhost:54321",
+            "udp://127.0.0.1:54321",
+            "tcp://127.0.0.1:0",
+            "not-a-url",
+        ] {
+            std::fs::write(&path, endpoint).unwrap();
+            assert!(discover_magic_dns_endpoint_at(&path).is_err(), "{endpoint}");
+        }
+    }
+
+    #[test]
+    fn magic_dns_bind_address_uses_an_os_assigned_port() {
+        let occupied = TcpListener::bind("127.0.0.1:0").unwrap();
+        let occupied_port = occupied.local_addr().unwrap().port();
+
+        let listener = TcpListener::bind(MAGIC_DNS_BIND_ADDR).unwrap();
+        let assigned_port = listener.local_addr().unwrap().port();
+
+        assert_ne!(assigned_port, 0);
+        assert_ne!(assigned_port, occupied_port);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn lease_does_not_follow_registry_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("target");
+        let registry = directory.path().join("magic-dns.endpoint");
+        std::fs::write(&target, "do not truncate").unwrap();
+        symlink(&target, &registry).unwrap();
+
+        assert!(MagicDnsServerLease::try_acquire_at(&registry).is_err());
+        assert_eq!(std::fs::read_to_string(target).unwrap(), "do not truncate");
+    }
+}

--- a/easytier/src/instance/dns_server/mod.rs
+++ b/easytier/src/instance/dns_server/mod.rs
@@ -2,6 +2,8 @@
 #[cfg(all(feature = "magic-dns", feature = "tun"))]
 pub(crate) mod config;
 #[cfg(all(feature = "magic-dns", feature = "tun"))]
+mod endpoint;
+#[cfg(all(feature = "magic-dns", feature = "tun"))]
 pub(crate) mod server;
 
 #[cfg(all(feature = "magic-dns", feature = "tun"))]
@@ -16,7 +18,5 @@ pub mod system_config;
 #[cfg(all(test, feature = "tun", feature = "magic-dns"))]
 mod tests;
 
-pub static MAGIC_DNS_INSTANCE_ADDR: &str = "tcp://127.0.0.1:49813";
-pub static MAGIC_DNS_INSTANCE_SOCKET_ADDR: &str = "127.0.0.1:49813";
 pub static MAGIC_DNS_FAKE_IP: &str = "100.100.100.101";
 pub use easytier_core::config::toml::DEFAULT_ET_DNS_ZONE;

--- a/easytier/src/instance/dns_server/runner.rs
+++ b/easytier/src/instance/dns_server/runner.rs
@@ -5,9 +5,50 @@ use std::{net::Ipv4Addr, sync::Arc, time::Duration};
 
 use easytier_core::instance::CorePacketPlane;
 
-use crate::common::global_ctx::ArcGlobalCtx;
+use crate::common::global_ctx::{ArcGlobalCtx, GlobalCtxEvent};
 
 use super::{client_instance::MagicDnsClientInstance, server_instance::MagicDnsServerInstance};
+
+#[derive(PartialEq, Eq)]
+enum MagicDnsState {
+    Ready(String),
+    Error(String),
+}
+
+struct MagicDnsEventReporter {
+    global_ctx: ArcGlobalCtx,
+    last_state: Option<MagicDnsState>,
+}
+
+impl MagicDnsEventReporter {
+    fn new(global_ctx: ArcGlobalCtx) -> Self {
+        Self {
+            global_ctx,
+            last_state: None,
+        }
+    }
+
+    fn report(&mut self, state: MagicDnsState) {
+        if self.last_state.as_ref() == Some(&state) {
+            return;
+        }
+
+        let event = match &state {
+            MagicDnsState::Ready(endpoint) => GlobalCtxEvent::MagicDnsReady(endpoint.clone()),
+            MagicDnsState::Error(error) => GlobalCtxEvent::MagicDnsError(error.clone()),
+        };
+        self.global_ctx.issue_event(event);
+        self.last_state = Some(state);
+    }
+
+    fn ready(&mut self, endpoint: &url::Url) {
+        self.report(MagicDnsState::Ready(endpoint.to_string()));
+    }
+
+    fn error(&mut self, error: &anyhow::Error) {
+        self.report(MagicDnsState::Error(format!("{error:#}")));
+    }
+}
 
 pub struct DnsRunner {
     client: Option<MagicDnsClientInstance>,
@@ -17,6 +58,7 @@ pub struct DnsRunner {
     tun_dev: Option<String>,
     tun_inet: Ipv4Inet,
     fake_ip: Ipv4Addr,
+    event_reporter: MagicDnsEventReporter,
 }
 
 impl DnsRunner {
@@ -27,6 +69,7 @@ impl DnsRunner {
         tun_inet: Ipv4Inet,
         fake_ip: Ipv4Addr,
     ) -> Self {
+        let event_reporter = MagicDnsEventReporter::new(global_ctx.clone());
         Self {
             client: None,
             server: None,
@@ -35,6 +78,7 @@ impl DnsRunner {
             tun_dev,
             tun_inet,
             fake_ip,
+            event_reporter,
         }
     }
 
@@ -47,7 +91,7 @@ impl DnsRunner {
 
     async fn run_once(&mut self) -> anyhow::Result<()> {
         // try server first
-        match MagicDnsServerInstance::new(
+        let server_error = match MagicDnsServerInstance::new(
             self.packet_plane.clone(),
             self.global_ctx.clone(),
             self.tun_dev.clone(),
@@ -56,21 +100,36 @@ impl DnsRunner {
         )
         .await
         {
-            Ok(server) => {
+            Ok(Some(server)) => {
+                tracing::info!(
+                    endpoint = %server.endpoint(),
+                    "DnsRunner::run_once: server started"
+                );
                 self.server = Some(server);
-                tracing::info!("DnsRunner::run_once: server started");
+                None
+            }
+            Ok(None) => {
+                tracing::debug!("DnsRunner::run_once: another Magic DNS server is active");
+                None
             }
             Err(e) => {
                 tracing::error!("DnsRunner::run_once: {:?}", e);
+                Some(e)
             }
-        }
+        };
 
         // every runner must run a client
-        let client = MagicDnsClientInstance::new(self.packet_plane.clone()).await?;
+        let client = MagicDnsClientInstance::new(self.packet_plane.clone())
+            .await
+            .map_err(|client_error| match server_error {
+                Some(server_error) => server_error.context(format!(
+                    "Magic DNS server startup failed and client fallback also failed: {client_error:#}"
+                )),
+                None => client_error.context("failed to connect to the Magic DNS server"),
+            })?;
+        self.event_reporter.ready(client.endpoint());
         self.client = Some(client);
-        self.client.as_mut().unwrap().run_and_wait().await;
-
-        Err(anyhow::anyhow!("Client instance exit"))
+        self.client.as_mut().unwrap().run_and_wait().await
     }
 
     pub async fn run(&mut self, canel_token: CancellationToken) {
@@ -86,6 +145,7 @@ impl DnsRunner {
                 ret = self.run_once() => {
                     self.clean_env().await;
                     if let Err(e) = ret {
+                        self.event_reporter.error(&e);
                         tracing::error!("DnsRunner::run: {:?}", e);
                     } else {
                         tracing::info!("DnsRunner::run: unexpected exit, server may be down");
@@ -94,5 +154,39 @@ impl DnsRunner {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::broadcast::error::TryRecvError;
+
+    use crate::common::global_ctx::{GlobalCtxEvent, tests::get_mock_global_ctx};
+
+    use super::MagicDnsEventReporter;
+
+    #[test]
+    fn event_reporter_deduplicates_unchanged_magic_dns_state() {
+        let global_ctx = get_mock_global_ctx();
+        let mut events = global_ctx.subscribe();
+        let mut reporter = MagicDnsEventReporter::new(global_ctx);
+        let error = anyhow::anyhow!("endpoint registry unavailable");
+
+        reporter.error(&error);
+        reporter.error(&error);
+        assert_eq!(
+            events.try_recv().unwrap(),
+            GlobalCtxEvent::MagicDnsError("endpoint registry unavailable".to_string())
+        );
+        assert_eq!(events.try_recv(), Err(TryRecvError::Empty));
+
+        let endpoint = "tcp://127.0.0.1:54321".parse().unwrap();
+        reporter.ready(&endpoint);
+        reporter.ready(&endpoint);
+        assert_eq!(
+            events.try_recv().unwrap(),
+            GlobalCtxEvent::MagicDnsReady("tcp://127.0.0.1:54321".to_string())
+        );
+        assert_eq!(events.try_recv(), Err(TryRecvError::Empty));
     }
 }

--- a/easytier/src/instance/dns_server/server_instance.rs
+++ b/easytier/src/instance/dns_server/server_instance.rs
@@ -7,8 +7,8 @@
 // all the clients will exit and let the easytier instance to launch a new server instance.
 
 use super::{
-    MAGIC_DNS_INSTANCE_SOCKET_ADDR,
     config::{GeneralConfigBuilder, RunConfigBuilder},
+    endpoint::{MAGIC_DNS_BIND_ADDR, MagicDnsServerLease},
     server::Server,
     system_config::{OSConfig, SystemConfig},
 };
@@ -41,6 +41,7 @@ use easytier_core::gateway::magic_dns::{
     MagicDnsRoute,
 };
 use easytier_core::instance::CorePacketPlane;
+use easytier_core::socket::SocketListener;
 use hickory_proto::rr::LowerName;
 use hickory_proto::serialize::binary::{BinDecodable, BinEncoder};
 use hickory_server::authority::{MessageRequest, MessageResponse};
@@ -330,6 +331,8 @@ impl RpcServerHook for MagicDnsServerInstanceData {
 
 pub struct MagicDnsServerInstance {
     _rpc_server: StandAloneServer<RuntimeRpcListener>,
+    _server_lease: MagicDnsServerLease,
+    endpoint: url::Url,
     pub(super) data: Arc<MagicDnsServerInstanceData>,
     packet_filter: MagicDnsResolverRegistration,
     tun_inet: Ipv4Inet,
@@ -362,10 +365,15 @@ impl MagicDnsServerInstance {
         tun_dev: Option<String>,
         tun_inet: Ipv4Inet,
         fake_ip: Ipv4Addr,
-    ) -> Result<Self, anyhow::Error> {
-        let tcp_listener = runtime_rpc_listener(MAGIC_DNS_INSTANCE_SOCKET_ADDR.parse()?);
+    ) -> Result<Option<Self>, anyhow::Error> {
+        let Some(mut server_lease) = MagicDnsServerLease::try_acquire()? else {
+            return Ok(None);
+        };
+
+        let mut tcp_listener = runtime_rpc_listener(MAGIC_DNS_BIND_ADDR.parse()?);
+        tcp_listener.listen().await?;
+        let endpoint = tcp_listener.local_url();
         let mut rpc_server = StandAloneServer::new(tcp_listener);
-        rpc_server.serve().await?;
 
         let dns_config = RunConfigBuilder::default()
             .general(GeneralConfigBuilder::default().build()?)
@@ -410,6 +418,11 @@ impl MagicDnsServerInstance {
             .await
             .context("Failed to initialize DNS zone")?;
 
+        rpc_server.serve().await?;
+        server_lease
+            .publish(&endpoint)
+            .context("Failed to publish Magic DNS RPC endpoint")?;
+
         let data_clone = data.clone();
         tokio::task::spawn_blocking(move || data_clone.do_system_config(&tld_dns_zone_clone))
             .await
@@ -422,12 +435,18 @@ impl MagicDnsServerInstance {
             .register_magic_dns_resolver(fake_ip, data.clone())
             .await;
 
-        Ok(Self {
+        Ok(Some(Self {
             _rpc_server: rpc_server,
+            _server_lease: server_lease,
+            endpoint,
             data,
             packet_filter,
             tun_inet,
-        })
+        }))
+    }
+
+    pub(crate) fn endpoint(&self) -> &url::Url {
+        &self.endpoint
     }
 
     pub async fn clean_env(&self) {

--- a/easytier/src/instance/dns_server/tests.rs
+++ b/easytier/src/instance/dns_server/tests.rs
@@ -110,6 +110,7 @@ pub async fn check_dns_record(fake_ip: &Ipv4Addr, domain: &str, expected_ip: &st
 }
 
 #[tokio::test]
+#[serial_test::serial(magic_dns)]
 async fn test_magic_dns_server_instance() {
     let tun_ip = Ipv4Inet::from_str("10.144.144.10/24").unwrap();
     let (global_ctx, core_instance, virtual_nic) = prepare_env("test1", tun_ip).await;
@@ -123,6 +124,7 @@ async fn test_magic_dns_server_instance() {
         fake_ip,
     )
     .await
+    .unwrap()
     .unwrap();
 
     let routes = [
@@ -150,6 +152,7 @@ async fn test_magic_dns_server_instance() {
 }
 
 #[tokio::test]
+#[serial_test::serial(magic_dns)]
 async fn test_magic_dns_runner() {
     // Test first runner with default DNS settings
     {
@@ -215,6 +218,7 @@ async fn test_magic_dns_runner() {
 }
 
 #[tokio::test]
+#[serial_test::serial(magic_dns)]
 async fn test_magic_dns_update_replaces_records_for_same_client() {
     let tun_ip = Ipv4Inet::from_str("100.100.100.0/24").unwrap();
     let ctx = get_mock_global_ctx();
@@ -227,6 +231,7 @@ async fn test_magic_dns_update_replaces_records_for_same_client() {
     let dns_server_inst =
         MagicDnsServerInstance::new(core_instance.packet_plane(), ctx, None, tun_ip, fake_ip)
             .await
+            .unwrap()
             .unwrap();
 
     let mut ctrl = BaseController::default();


### PR DESCRIPTION
## What changed

- Replace the fixed Magic DNS RPC listener at `127.0.0.1:49813` with an OS-assigned loopback TCP port.
- Coordinate the process-wide Magic DNS server through a locked endpoint registry so multiple EasyTier instances still share one local server.
- Validate discovered endpoints as non-zero loopback TCP URLs and reject Unix registry symlinks.
- Preserve server/client startup and route publisher errors instead of reducing them to a generic client-exit message.
- Emit deduplicated `MagicDnsReady` and `MagicDnsError` instance events, with Web UI event names in English and Chinese.

## Why

Magic DNS previously bound its internal RPC server to the hard-coded port `49813`. If another local application happened to use that port, the EasyTier network and TUN device could continue working while Magic DNS silently failed before installing its fake-IP route and system resolver configuration.

This was reproduced on macOS when another desktop application selected `127.0.0.1:49813` as one of its dynamic internal ports. The failure was difficult to diagnose because `DnsRunner` only wrote the initialization error to background tracing logs.

The endpoint registry retains the existing single-server-per-machine behavior while allowing the OS to choose an available port. A server lease owns an exclusive file lock, publishes the actual bound endpoint, and clears stale registry data when a new server is elected. Clients only accept loopback TCP endpoints from the registry.

The new instance events also make the selected endpoint or the full failure reason visible in the GUI event log.

## Tests

- `cargo test -p easytier 'instance::dns_server::endpoint::tests' --lib`
- `cargo test -p easytier 'instance::dns_server::runner::tests' --lib`
- `cargo clippy -p easytier --lib --no-deps -- -D warnings -A unsafe-op-in-unsafe-fn -A dead-code -A clippy::collapsible-if`
- `pnpm --filter easytier-frontend-lib codegen:proto`
- `pnpm --filter easytier-frontend-lib exec vue-tsc -b --pretty false`

The privileged Magic DNS integration tests were not run locally because they modify the host TUN, routes, and system resolver configuration.
