### PR TITLE
fix(gui): set HOME for macOS launchd service

### DIFF
--- a/easytier-gui/src-tauri/src/lib.rs
+++ b/easytier-gui/src-tauri/src/lib.rs
@@ -1271,12 +1271,24 @@ mod service {
         }
     }
 
+    #[cfg(target_os = "macos")]
+    fn service_environment() -> Option<Vec<(String, String)>> {
+        // System LaunchDaemons run as root but launchd does not provide HOME.
+        Some(vec![("HOME".to_string(), "/var/root".to_string())])
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    fn service_environment() -> Option<Vec<(String, String)>> {
+        None
+    }
+
     pub fn install(opts: ServiceOptions) -> anyhow::Result<()> {
         let service = easytier::service_manager::Service::new(env!("CARGO_PKG_NAME").to_string())?;
         let options = easytier::service_manager::ServiceInstallOptions {
             program: super::get_exe_path().into(),
             args: opts.to_args_vec(),
             work_directory: std::env::current_dir()?,
+            environment: service_environment(),
             disable_autostart: false,
             description: Some("EasyTier Gui Service".to_string()),
             display_name: Some("EasyTier Gui Service".to_string()),
@@ -1311,6 +1323,21 @@ mod service {
     pub fn status() -> anyhow::Result<easytier::service_manager::ServiceStatus> {
         let service = easytier::service_manager::Service::new(env!("CARGO_PKG_NAME").to_string())?;
         service.status()
+    }
+
+    #[cfg(test)]
+    mod tests {
+        #[test]
+        fn service_environment_matches_platform() {
+            #[cfg(target_os = "macos")]
+            assert_eq!(
+                super::service_environment(),
+                Some(vec![("HOME".to_string(), "/var/root".to_string())])
+            );
+
+            #[cfg(not(target_os = "macos"))]
+            assert_eq!(super::service_environment(), None);
+        }
     }
 }
 

--- a/easytier/src/easytier-cli.rs
+++ b/easytier/src/easytier-cli.rs
@@ -3084,6 +3084,7 @@ async fn main() -> Result<(), Error> {
                         program: bin_path,
                         args: bin_args,
                         work_directory: work_dir,
+                        environment: None,
                         disable_autostart: install_args.disable_autostart.unwrap_or(false),
                         description: Some(install_args.description),
                         display_name: install_args.display_name,

--- a/easytier/src/service_manager/mod.rs
+++ b/easytier/src/service_manager/mod.rs
@@ -11,6 +11,7 @@ pub struct ServiceInstallOptions {
     pub program: PathBuf,
     pub args: Vec<OsString>,
     pub work_directory: PathBuf,
+    pub environment: Option<Vec<(String, String)>>,
     pub disable_autostart: bool,
     pub description: Option<String>,
     pub display_name: Option<String>,
@@ -92,7 +93,7 @@ impl Service {
             autostart: !options.disable_autostart,
             username: None,
             working_directory: Some(options.work_directory.clone()),
-            environment: None,
+            environment: options.environment.clone(),
             disable_restart_on_failure: options.disable_restart_on_failure,
         };
 


### PR DESCRIPTION
## Summary

- allow `ServiceInstallOptions` to pass environment variables to `service-manager-rs`
- set `HOME=/var/root` for the macOS GUI system LaunchDaemon
- keep CLI service installs and non-macOS GUI installs unchanged

## Root cause

The macOS GUI installs service mode as a system LaunchDaemon. The daemon launches the GUI executable with `--daemon`, which enters `core::main()` and resolves the web client machine ID from its default state directory.

System LaunchDaemons run as root, but launchd does not provide `HOME`. As a result, a GUI service configured with a config server exits with:

```text
failed to resolve machine id for web client
HOME is not set, cannot resolve machine id state directory
```

The service then keeps restarting, and the GUI cannot stay in service mode.

`service-manager-rs` already supports serializing environment variables into the launchd plist, but EasyTier always passed `environment: None`. This change exposes that existing support through `ServiceInstallOptions` and scopes `HOME=/var/root` to the macOS GUI service.

The generated plist now contains the equivalent of:

```xml
<key>EnvironmentVariables</key>
<dict>
  <key>HOME</key>
  <string>/var/root</string>
</dict>
```

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p easytier --all-targets`
- `cargo check -p easytier-gui --all-targets`
- `cargo test -p easytier-gui service_environment_matches_platform --lib`
- reproduced on macOS with v2.6.4; adding the equivalent plist environment made the LaunchDaemon remain running and restored the GUI service RPC/network listeners
