### PR TITLE
fix(web): preserve disabled managed networks

### DIFF
--- a/easytier-web/src/client_manager/managed_config.rs
+++ b/easytier-web/src/client_manager/managed_config.rs
@@ -422,7 +422,9 @@ pub(super) fn desired_web_source_instance_ids(
 ) -> HashSet<String> {
     local_configs
         .iter()
-        .filter(|cfg| cfg.get_runtime_network_config_source() == ConfigSource::Web)
+        .filter(|cfg| {
+            !cfg.disabled && cfg.get_runtime_network_config_source() == ConfigSource::Web
+        })
         .map(|cfg| cfg.network_instance_id.clone())
         .collect()
 }
@@ -1013,6 +1015,55 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(updated.get_network_config_source(), ConfigSource::Web);
+    }
+
+    #[tokio::test]
+    async fn disabled_web_configs_are_not_auto_run() {
+        let db = crate::db::Db::memory_db().await;
+        let user_id = db.auto_create_user("web-user-disabled").await.unwrap().id;
+        let machine_id = uuid::Uuid::new_v4();
+        let enabled_id = uuid::Uuid::new_v4();
+        let disabled_id = uuid::Uuid::new_v4();
+
+        for inst_id in [enabled_id, disabled_id] {
+            assert!(
+                db.insert_or_update_web_network_config(
+                    (user_id, machine_id),
+                    inst_id,
+                    NetworkConfig::default(),
+                )
+                .await
+                .unwrap()
+            );
+        }
+        db.update_network_config_state((user_id, machine_id), disabled_id, true)
+            .await
+            .unwrap();
+        assert!(
+            db.insert_or_update_web_network_config(
+                (user_id, machine_id),
+                disabled_id,
+                NetworkConfig::default(),
+            )
+            .await
+            .unwrap()
+        );
+
+        let configs = db
+            .list_network_configs((user_id, machine_id), ListNetworkProps::All)
+            .await
+            .unwrap();
+        let desired = desired_web_source_instance_ids(&configs);
+
+        assert!(
+            configs
+                .iter()
+                .find(|cfg| cfg.network_instance_id == disabled_id.to_string())
+                .unwrap()
+                .disabled
+        );
+        assert!(desired.contains(&enabled_id.to_string()));
+        assert!(!desired.contains(&disabled_id.to_string()));
     }
 
     #[test]

--- a/easytier-web/src/client_manager/managed_config.rs
+++ b/easytier-web/src/client_manager/managed_config.rs
@@ -417,6 +417,16 @@ fn collect_web_source_instance_ids(metas: &[NetworkMeta]) -> HashSet<String> {
         .collect()
 }
 
+pub(super) fn web_source_instance_ids(
+    local_configs: &[crate::db::entity::user_running_network_configs::Model],
+) -> HashSet<String> {
+    local_configs
+        .iter()
+        .filter(|cfg| cfg.get_runtime_network_config_source() == ConfigSource::Web)
+        .map(|cfg| cfg.network_instance_id.clone())
+        .collect()
+}
+
 pub(super) fn desired_web_source_instance_ids(
     local_configs: &[crate::db::entity::user_running_network_configs::Model],
 ) -> HashSet<String> {
@@ -1053,6 +1063,7 @@ mod tests {
             .list_network_configs((user_id, machine_id), ListNetworkProps::All)
             .await
             .unwrap();
+        let all_web = web_source_instance_ids(&configs);
         let desired = desired_web_source_instance_ids(&configs);
 
         assert!(
@@ -1064,6 +1075,12 @@ mod tests {
         );
         assert!(desired.contains(&enabled_id.to_string()));
         assert!(!desired.contains(&disabled_id.to_string()));
+        assert!(all_web.contains(&enabled_id.to_string()));
+        assert!(all_web.contains(&disabled_id.to_string()));
+
+        let running = HashSet::from([disabled_id.to_string()]);
+        let running_web = running_web_source_instance_ids(&running, &all_web, None);
+        assert!(running_web.contains(&disabled_id.to_string()));
     }
 
     #[test]

--- a/easytier-web/src/client_manager/session/runtime_revision.rs
+++ b/easytier-web/src/client_manager/session/runtime_revision.rs
@@ -429,7 +429,7 @@ async fn cleanup_stale_web_source_instances(
         .list_network_configs((round.user_id, round.machine_id), ListNetworkProps::All)
         .await
     {
-        Ok(configs) => managed_config::desired_web_source_instance_ids(&configs),
+        Ok(configs) => managed_config::web_source_instance_ids(&configs),
         Err(e) => {
             tracing::error!("Failed to list all network configs, error: {:?}", e);
             return RoundStatus::Stop;

--- a/easytier-web/src/db/mod.rs
+++ b/easytier-web/src/db/mod.rs
@@ -201,7 +201,6 @@ impl Db {
             ON CONFLICT(user_id, device_id, network_instance_id) DO UPDATE SET
                 network_config = excluded.network_config,
                 source = excluded.source,
-                disabled = excluded.disabled,
                 update_time = excluded.update_time
             WHERE user_running_network_configs.source = ?
             "#,


### PR DESCRIPTION
## Summary

- preserve the local `disabled` flag when a managed web configuration is synchronized again
- exclude disabled web-managed configurations from the desired runtime instance set
- add a regression test covering disable followed by another server-side config sync

## Test

- `cargo test -p easytier-web disabled_web_configs_are_not_auto_run`
- built and tested the macOS GUI; the disabled network stayed stopped across configuration sync cycles