### PR TITLE
feat(mobile): auto pause/resume VPN on WiFi connect/disconnect

### DIFF
--- a/easytier-gui/src-tauri/capabilities/migrated.json
+++ b/easytier-gui/src-tauri/capabilities/migrated.json
@@ -40,6 +40,7 @@
     "vpnservice:allow-prepare-vpn",
     "vpnservice:allow-start-vpn",
     "vpnservice:allow-stop-vpn",
+    "vpnservice:allow-set-auto-stop-on-wifi",
     "vpnservice:allow-registerListener",
     "os:default",
     "os:allow-os-type",

--- a/easytier-web/frontend-lib/src/components/Config.vue
+++ b/easytier-web/frontend-lib/src/components/Config.vue
@@ -196,6 +196,34 @@ const instanceRecvBpsLimitInput = computed<string>({
     }
   },
 })
+
+const AUTO_STOP_ON_WIFI_KEY = 'easytier.auto_stop_vpn_on_wifi'
+
+const isAndroidApp = computed(() => {
+  const internals = (window as any).__TAURI_INTERNALS__
+  return !!internals?.invoke && /android/i.test(navigator.userAgent)
+})
+
+const autoStopOnWifi = ref(false)
+
+async function applyAutoStopOnWifi() {
+  const internals = (window as any).__TAURI_INTERNALS__
+  if (!internals?.invoke) return
+  try {
+    localStorage.setItem(AUTO_STOP_ON_WIFI_KEY, autoStopOnWifi.value ? '1' : '0')
+    await internals.invoke('plugin:vpnservice|set_auto_stop_on_wifi', { enabled: autoStopOnWifi.value })
+  } catch (e) {
+    console.error('set auto stop on wifi failed', e)
+  }
+}
+
+onMounted(() => {
+  if (isAndroidApp.value) {
+    const saved = localStorage.getItem(AUTO_STOP_ON_WIFI_KEY)
+    autoStopOnWifi.value = saved === '1'
+    applyAutoStopOnWifi()
+  }
+})
 </script>
 
 <template>
@@ -272,6 +300,17 @@ const instanceRecvBpsLimitInput = computed<string>({
                       <span class="pi pi-question-circle ml-2 self-center" v-tooltip="t(flag.help)"></span>
                     </div>
 
+                  </div>
+                </div>
+              </div>
+
+              <div v-if="isAndroidApp" class="flex flex-row gap-x-9 flex-wrap">
+                <div class="flex flex-col gap-2 grow">
+                  <div class="flex items-center">
+                    <Checkbox v-model="autoStopOnWifi" input-id="vpn_auto_stop_on_wifi" :binary="true"
+                      @change="applyAutoStopOnWifi" />
+                    <label for="vpn_auto_stop_on_wifi" class="ml-2">{{ t('vpn_auto_stop_on_wifi') }}</label>
+                    <span class="pi pi-question-circle ml-2 self-center" v-tooltip="t('vpn_auto_stop_on_wifi_help')"></span>
                   </div>
                 </div>
               </div>

--- a/easytier-web/frontend-lib/src/locales/cn.yaml
+++ b/easytier-web/frontend-lib/src/locales/cn.yaml
@@ -23,6 +23,8 @@ vpn_portal_listen_port: 监听端口
 vpn_portal_client_network: 客户端子网
 dev_name: TUN接口名称
 advanced_settings: 高级设置
+vpn_auto_stop_on_wifi: 连接WiFi自动暂停VPN，断开自动恢复
+vpn_auto_stop_on_wifi_help: 开启后，连接WiFi时自动暂停VPN服务，断开WiFi后自动恢复连接
 basic_settings: 基础设置
 listener_urls: 监听地址
 rpc_port: RPC端口

--- a/easytier-web/frontend-lib/src/locales/en.yaml
+++ b/easytier-web/frontend-lib/src/locales/en.yaml
@@ -23,6 +23,8 @@ vpn_portal_listen_port: VPN Portal Listen Port
 vpn_portal_client_network: Client Sub Network
 dev_name: TUN interface name
 advanced_settings: Advanced Settings
+vpn_auto_stop_on_wifi: Auto pause VPN on WiFi, resume on disconnect
+vpn_auto_stop_on_wifi_help: When enabled, the VPN pauses automatically while WiFi is connected and resumes when WiFi disconnects
 basic_settings: Basic Settings
 listener_urls: Listener URLs
 rpc_port: RPC Port

--- a/tauri-plugin-vpnservice/android/src/main/java/VpnServicePlugin.kt
+++ b/tauri-plugin-vpnservice/android/src/main/java/VpnServicePlugin.kt
@@ -1,8 +1,16 @@
 package com.plugin.vpnservice
 
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
 import android.net.VpnService
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import androidx.activity.result.ActivityResult
 import app.tauri.annotation.Command
 import app.tauri.annotation.ActivityCallback
@@ -27,9 +35,144 @@ class StartVpnArgs {
     var mtu: Int? = null
 }
 
+@InvokeArg
+class SetAutoStopOnWifiArgs {
+    var enabled: Boolean = false
+}
+
 @TauriPlugin
 class VpnServicePlugin(private val activity: Activity) : Plugin(activity) {
     private val implementation = Example()
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var connectivityManager: ConnectivityManager? = null
+
+    // Last successful VPN start args, used to resume the VPN when WiFi goes away.
+    private var lastStartArgs: Bundle? = null
+    // True when the VPN was paused by the WiFi auto-pause feature and should be resumed later.
+    private var pausedByWifi = false
+    private var pendingRestartRunnable: Runnable? = null
+
+    private val wifiNetworkCallback = object : ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network) {
+            println("vpn: wifi available, pause vpn if running")
+            cancelPendingRestart()
+            stopVpnIfRunning(byWifi = true)
+        }
+
+        override fun onLost(network: Network) {
+            println("vpn: wifi lost, schedule vpn resume")
+            scheduleVpnRestart()
+        }
+    }
+
+    private fun isWifiConnected(): Boolean {
+        val cm = connectivityManager ?: return false
+        for (network in cm.allNetworks) {
+            val capabilities = cm.getNetworkCapabilities(network) ?: continue
+            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private fun stopVpnIfRunning(byWifi: Boolean) {
+        if (TauriVpnService.self == null) {
+            return
+        }
+        activity.runOnUiThread {
+            println("vpn: pause vpn (byWifi=$byWifi)")
+            pausedByWifi = byWifi
+            if (byWifi) {
+                cancelPendingRestart()
+            }
+            TauriVpnService.self?.onRevoke()
+            activity.stopService(Intent(activity, TauriVpnService::class.java))
+        }
+    }
+
+    // Covers the case where WiFi is already connected when the feature is enabled:
+    // registerNetworkCallback only fires 'onAvailable' on future connect events.
+    private fun stopIfWifiConnected() {
+        val cm = connectivityManager ?: return
+        for (network in cm.allNetworks) {
+            val capabilities = cm.getNetworkCapabilities(network) ?: continue
+            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
+                stopVpnIfRunning(byWifi = true)
+                return
+            }
+        }
+    }
+
+    // Resume the VPN a short time after WiFi is lost, only if it was paused by this
+    // feature, the feature is still enabled and WiFi is really gone (not just roaming
+    // to another AP).
+    private fun scheduleVpnRestart() {
+        if (lastStartArgs == null || !pausedByWifi) {
+            return
+        }
+        cancelPendingRestart()
+        val runnable = Runnable {
+            pendingRestartRunnable = null
+            // feature disabled while waiting
+            if (connectivityManager == null) return@Runnable
+            if (!pausedByWifi || lastStartArgs == null) return@Runnable
+            // WiFi came back - keep it paused
+            if (isWifiConnected()) return@Runnable
+            println("vpn: wifi lost, resume vpn")
+            pausedByWifi = false
+            startVpnService(lastStartArgs!!)
+        }
+        pendingRestartRunnable = runnable
+        mainHandler.postDelayed(runnable, 3000)
+    }
+
+    private fun cancelPendingRestart() {
+        pendingRestartRunnable?.let { mainHandler.removeCallbacks(it) }
+        pendingRestartRunnable = null
+    }
+
+    private fun startVpnService(args: Bundle) {
+        TauriVpnService.self?.onRevoke()
+        val intent = Intent(activity, TauriVpnService::class.java)
+        intent.putExtras(args)
+        activity.startService(intent)
+    }
+
+    private fun storeStartArgs(args: StartVpnArgs): Bundle {
+        val bundle = Bundle()
+        bundle.putString(TauriVpnService.IPV4_ADDR, args.ipv4Addr)
+        bundle.putStringArray(TauriVpnService.ROUTES, args.routes)
+        bundle.putString(TauriVpnService.DNS, args.dns)
+        bundle.putStringArray(TauriVpnService.DISALLOWED_APPLICATIONS, args.disallowedApplications)
+        args.mtu?.let { bundle.putInt(TauriVpnService.MTU, it) }
+        return bundle
+    }
+
+    private fun registerWifiCallback() {
+        if (connectivityManager != null) {
+            return
+        }
+        val cm = activity.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val request = NetworkRequest.Builder()
+            .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+            .build()
+        connectivityManager = cm
+        try {
+            cm.registerNetworkCallback(request, wifiNetworkCallback, Handler(Looper.getMainLooper()))
+            println("vpn: wifi auto-pause callback registered")
+            stopIfWifiConnected()
+        } catch (e: Exception) {
+            connectivityManager = null
+            println("vpn: failed to register wifi auto-pause callback: $e")
+        }
+    }
+
+    private fun unregisterWifiCallback() {
+        cancelPendingRestart()
+        connectivityManager?.unregisterNetworkCallback(wifiNetworkCallback)
+        connectivityManager = null
+    }
 
     override fun load(webView: WebView) {
         println("load vpn service plugin")
@@ -76,21 +219,14 @@ class VpnServicePlugin(private val activity: Activity) : Plugin(activity) {
         activity.runOnUiThread {
             println("start vpn in plugin, args: $args")
 
-            TauriVpnService.self?.onRevoke()
-
             val it = VpnService.prepare(activity)
             val ret = JSObject()
             if (it != null) {
                 ret.put("errorMsg", "need_prepare")
             } else {
-                val intent = Intent(activity, TauriVpnService::class.java)
-                intent.putExtra(TauriVpnService.IPV4_ADDR, args.ipv4Addr)
-                intent.putExtra(TauriVpnService.ROUTES, args.routes)
-                intent.putExtra(TauriVpnService.DNS, args.dns)
-                intent.putExtra(TauriVpnService.DISALLOWED_APPLICATIONS, args.disallowedApplications)
-                intent.putExtra(TauriVpnService.MTU, args.mtu)
-
-                activity.startService(intent)
+                lastStartArgs = storeStartArgs(args)
+                pausedByWifi = false
+                startVpnService(lastStartArgs!!)
             }
             invoke.resolve(ret)
         }
@@ -100,6 +236,8 @@ class VpnServicePlugin(private val activity: Activity) : Plugin(activity) {
     fun stopVpn(invoke: Invoke) {
         activity.runOnUiThread {
             println("stop vpn in plugin")
+            cancelPendingRestart()
+            pausedByWifi = false
             TauriVpnService.self?.onRevoke()
             activity.stopService(Intent(activity, TauriVpnService::class.java))
             println("stop vpn in plugin end")
@@ -115,5 +253,17 @@ class VpnServicePlugin(private val activity: Activity) : Plugin(activity) {
         ret.put("routes", TauriVpnService.routes)
         ret.put("dns", TauriVpnService.dns)
         invoke.resolve(ret)
+    }
+
+    @Command
+    fun setAutoStopOnWifi(invoke: Invoke) {
+        val args = invoke.parseArgs(SetAutoStopOnWifiArgs::class.java)
+        println("vpn: set auto pause on wifi " + args.enabled)
+        if (args.enabled) {
+            registerWifiCallback()
+        } else {
+            unregisterWifiCallback()
+        }
+        invoke.resolve(JSObject())
     }
 }

--- a/tauri-plugin-vpnservice/build.rs
+++ b/tauri-plugin-vpnservice/build.rs
@@ -4,6 +4,7 @@ const COMMANDS: &[&str] = &[
     "start_vpn",
     "stop_vpn",
     "get_vpn_status",
+    "set_auto_stop_on_wifi",
     "registerListener",
 ];
 

--- a/tauri-plugin-vpnservice/guest-js/index.ts
+++ b/tauri-plugin-vpnservice/guest-js/index.ts
@@ -45,3 +45,9 @@ export async function stop_vpn(): Promise<InvokeResponse | null> {
 export async function get_vpn_status(): Promise<VpnStatusResponse | null> {
   return await invoke<VpnStatusResponse>('plugin:vpnservice|get_vpn_status', {})
 }
+
+export async function set_auto_stop_on_wifi(enabled: boolean): Promise<void> {
+  return await invoke<void>('plugin:vpnservice|set_auto_stop_on_wifi', {
+    enabled,
+  })
+}

--- a/tauri-plugin-vpnservice/permissions/autogenerated/commands/set_auto_stop_on_wifi.toml
+++ b/tauri-plugin-vpnservice/permissions/autogenerated/commands/set_auto_stop_on_wifi.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-set-auto-stop-on-wifi"
+description = "Enables the set_auto_stop_on_wifi command without any pre-configured scope."
+commands.allow = ["set_auto_stop_on_wifi"]
+
+[[permission]]
+identifier = "deny-set-auto-stop-on-wifi"
+description = "Denies the set_auto_stop_on_wifi command without any pre-configured scope."
+commands.deny = ["set_auto_stop_on_wifi"]

--- a/tauri-plugin-vpnservice/permissions/autogenerated/reference.md
+++ b/tauri-plugin-vpnservice/permissions/autogenerated/reference.md
@@ -149,6 +149,32 @@ Denies the register_listener command without any pre-configured scope.
 <tr>
 <td>
 
+`vpnservice:allow-set-auto-stop-on-wifi`
+
+</td>
+<td>
+
+Enables the set_auto_stop_on_wifi command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`vpnservice:deny-set-auto-stop-on-wifi`
+
+</td>
+<td>
+
+Denies the set_auto_stop_on_wifi command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 `vpnservice:allow-start-vpn`
 
 </td>

--- a/tauri-plugin-vpnservice/permissions/schemas/schema.json
+++ b/tauri-plugin-vpnservice/permissions/schemas/schema.json
@@ -355,6 +355,18 @@
           "markdownDescription": "Denies the register_listener command without any pre-configured scope."
         },
         {
+          "description": "Enables the set_auto_stop_on_wifi command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-set-auto-stop-on-wifi",
+          "markdownDescription": "Enables the set_auto_stop_on_wifi command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_auto_stop_on_wifi command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-set-auto-stop-on-wifi",
+          "markdownDescription": "Denies the set_auto_stop_on_wifi command without any pre-configured scope."
+        },
+        {
           "description": "Enables the start_vpn command without any pre-configured scope.",
           "type": "string",
           "const": "allow-start-vpn",


### PR DESCRIPTION
Add an opt-in setting (Android only) that pauses the VPN service when the device connects to WiFi and automatically resumes it when WiFi disconnects (e.g. for networks that block VPN traffic).

- vpnservice plugin: new set_auto_stop_on_wifi command registers a ConnectivityManager network callback for TRANSPORT_WIFI, remembers the last VPN start args and resumes the service ~3s after WiFi is lost. Only VPNs paused by the feature are resumed; manual stops stay stopped.
- build.rs: register the new plugin command and grant vpnservice:allow-set-auto-stop-on-wifi in the migrated capabilities.
- web frontend: Android-only toggle in advanced settings, persisted in localStorage, wired through the tauri invoke; cn/en i18n texts.
- guest-js: export set_auto_stop_on_wifi().