### PR TITLE
chore: enforce LF for shell scripts and ignore Android .gradle cache

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/tauri-plugin-vpnservice/android/.gitignore
+++ b/tauri-plugin-vpnservice/android/.gitignore
@@ -1,2 +1,3 @@
 /build
 /.tauri
+/.gradle


### PR DESCRIPTION
## What

Two small repository-hygiene fixes:

1. Add a root `.gitattributes` pinning shell scripts to LF: `*.sh text eol=lf`.
2. Ignore `tauri-plugin-vpnservice/android/.gradle/`.

## Why

**Shell script line endings**

The repo stores all `.sh` files as LF, but without a `.gitattributes` rule, Windows checkouts with `core.autocrlf=true` rewrite them as CRLF in the working tree. Scripts such as `easytier-contrib/easytier-android-jni/build.sh` then fail immediately when run from WSL/bash with confusing errors (`$'\r': command not found`, `set: Illegal option -`, etc.).

Pinning `*.sh` to `eol=lf` makes git check out shell scripts with LF regardless of platform, keeping them executable everywhere. All `.sh` blobs are already LF in the index, so no renormalization is needed and this introduces zero diff churn — it only affects future checkouts.

**Gradle cache noise**

Gradle regenerates `tauri-plugin-vpnservice/android/.gradle/` on every sync, leaving a permanent untracked entry in `git status`. Ignored alongside the existing `/build` and `/.tauri` entries in the same file.

## Verification

- [x] `git check-attr text eol -- easytier-contrib/easytier-android-jni/build.sh` reports `text: set`, `eol: lf`
- [x] Force re-checkout of `build.sh` after the attribute lands produces pure-LF content; `git status` stays clean