### PR TITLE
mobile: add data-plane TCP forwarders for Android and iOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2421,6 +2421,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2543,6 +2543,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "easytier-ios"
+version = "0.1.0"
+dependencies = [
+ "easytier-ffi",
+ "libc",
+ "log",
+ "once_cell",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "easytier-mini"
 version = "2.6.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "easytier-contrib/easytier-ffi",
     "easytier-contrib/easytier-uptime",
     "easytier-contrib/easytier-android-jni",
+    "easytier-contrib/easytier-ios",
 ]
 default-members = ["easytier", "easytier-web"]
 exclude = [

--- a/easytier-contrib/easytier-android-jni/Cargo.toml
+++ b/easytier-contrib/easytier-android-jni/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 jni = "0.21"
@@ -14,4 +14,10 @@ android_logger = "0.13"
 serde = { version = "1.0.220", features = ["derive"] }
 serde_json = "1.0"
 easytier = { path = "../../easytier" }
-easytier-ffi = { path = "../easytier-ffi", default-features = false }
+easytier-ffi = { path = "../easytier-ffi", default-features = false, features = [
+    "c-abi",
+    "ffi-dataplane",
+] }
+
+[dev-dependencies]
+uuid = "1"

--- a/easytier-contrib/easytier-android-jni/kotlin/com/easytier/jni/EasyTierForwarder.kt
+++ b/easytier-contrib/easytier-android-jni/kotlin/com/easytier/jni/EasyTierForwarder.kt
@@ -1,0 +1,41 @@
+package com.easytier.jni
+
+/**
+ * 本地 TCP 端口转发器封装。
+ *
+ * 监听 `127.0.0.1` 本地端口，把每条连接经 EasyTier data plane 转发到虚拟网络内的
+ * 目标 IP:端口。适用于内嵌 EasyTier 但不使用 TUN/VpnService 的场景：应用内
+ * 的 HTTP/TCP 客户端直接连接 `127.0.0.1:本地端口` 即可访问虚拟网络服务。
+ *
+ * 每个实例同一时刻只能有一个转发器（native data plane session 每实例仅一个）。
+ */
+object EasyTierForwarder {
+
+    /**
+     * 启动转发器。
+     *
+     * @param instanceName EasyTier 实例名称
+     * @param targetIp 虚拟网络内的目标 IPv4 地址
+     * @param targetPort 目标端口
+     * @param listenPort 本地监听端口，传 0 由系统分配
+     * @return 实际监听的本地端口
+     * @throws RuntimeException 启动失败时抛出，消息来自 [EasyTierJNI.getLastError]
+     */
+    @JvmStatic
+    fun start(instanceName: String, targetIp: String, targetPort: Int, listenPort: Int = 0): Int {
+        val port = EasyTierJNI.startTcpForwarder(instanceName, targetIp, targetPort, listenPort)
+        if (port < 0) {
+            throw RuntimeException(EasyTierJNI.getLastError() ?: "forwarder start failed")
+        }
+        return port
+    }
+
+    /**
+     * 停止转发器。
+     * @param localPort [start] 返回的本地端口；不存在时静默成功
+     */
+    @JvmStatic
+    fun stop(localPort: Int) {
+        EasyTierJNI.stopTcpForwarder(localPort)
+    }
+}

--- a/easytier-contrib/easytier-android-jni/kotlin/com/easytier/jni/EasyTierJNI.kt
+++ b/easytier-contrib/easytier-android-jni/kotlin/com/easytier/jni/EasyTierJNI.kt
@@ -125,6 +125,35 @@ object EasyTierJNI {
     @JvmStatic external fun getLastError(): String?
 
     /**
+     * 启动本地 TCP 端口转发器
+     *
+     * 在 `127.0.0.1:listenPort` 监听，把每条连接经 EasyTier data plane 转发到
+     * 虚拟网络中的 `targetIp:targetPort`。无需 TUN/VpnService。
+     *
+     * @param instanceName EasyTier 实例名称
+     * @param targetIp 虚拟网络内的目标 IPv4 地址
+     * @param targetPort 目标端口
+     * @param listenPort 本地监听端口，传 0 由系统分配
+     * @return 实际监听的本地端口；失败返回 -1
+     * @throws RuntimeException 当启动失败时抛出异常
+     */
+    @JvmStatic
+    external fun startTcpForwarder(
+            instanceName: String,
+            targetIp: String,
+            targetPort: Int,
+            listenPort: Int
+    ): Int
+
+    /**
+     * 停止本地 TCP 端口转发器
+     * @param localPort [startTcpForwarder] 返回的本地端口
+     * @return 0 表示成功或该转发器不存在，-1 表示失败
+     * @throws RuntimeException 当停止失败时抛出异常
+     */
+    @JvmStatic external fun stopTcpForwarder(localPort: Int): Int
+
+    /**
      * 便利方法：停止所有网络实例
      * @return 0 表示成功，-1 表示失败
      * @throws RuntimeException 当操作失败时抛出异常

--- a/easytier-contrib/easytier-android-jni/src/forwarder.rs
+++ b/easytier-contrib/easytier-android-jni/src/forwarder.rs
@@ -1,0 +1,1192 @@
+//! Local TCP forwarder over the EasyTier data-plane FFI.
+//!
+//! A `TcpForwarder` listens on `127.0.0.1:<local_port>` and relays every
+//! accepted connection to a fixed virtual-network `target` through the
+//! data-plane C ABI exported by `easytier-ffi`. It is the transport layer used
+//! by apps that embed EasyTier without a TUN/VpnService: local clients simply
+//! dial a loopback port.
+//!
+//! ## Session concurrency model (verified against easytier-ffi)
+//!
+//! `easytier-ffi/src/data_plane/session.rs::open` rejects a second native
+//! session for the same instance with `ResourceLimit` ("instance already has an
+//! open native data-plane session"), and `DATA_PLANE_ABI.md` states "One native
+//! session may be open for an EasyTier instance at a time". Per-connection
+//! sessions are therefore impossible.
+//!
+//! Accordingly, one forwarder owns exactly one session for its instance and
+//! multiplexes all connections over it: a single event loop drives
+//! `data_plane_completion_wait` / `data_plane_completion_drain` and dispatches
+//! completions by `operation_id`. The core session
+//! (`easytier-core/src/gateway/dataplane/session.rs`) admits concurrent
+//! operations per stream — reads and writes use independent deadline and
+//! cancellation plumbing — and the default limits (4096 resources, 4096
+//! outstanding operations, 64 MiB retained results) leave ample headroom. A JNI
+//! layer may run several forwarders as long as they use distinct instances;
+//! starting a second forwarder on the same instance fails with `ResourceLimit`.
+//!
+//! Every inbound connection is served by a pair of blocking std::threads that
+//! exchange chunks with the event loop through `std::sync::mpsc` channels.
+//! Local reads stay in 64 KiB chunks and the event loop keeps exactly one
+//! remote read per connection outstanding, so each connection retains at most
+//! one read payload and one pending write in the session. No tokio runtime is
+//! involved in the forwarding path.
+
+use std::{
+    collections::HashMap,
+    io::{self, Read, Write},
+    net::{Ipv4Addr, Shutdown, SocketAddrV4, TcpListener, TcpStream},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        mpsc,
+    },
+    thread::JoinHandle,
+    time::{Duration, Instant},
+};
+
+use easytier_ffi::{
+    DataPlaneCompletion, DataPlaneSocketAddr, data_plane_completion_drain,
+    data_plane_completion_wait, data_plane_operation_free, data_plane_resource_close,
+    data_plane_session_close, data_plane_session_open, data_plane_tcp_connect_result_take,
+    data_plane_tcp_connect_submit, data_plane_tcp_read_result_take, data_plane_tcp_read_submit,
+    data_plane_tcp_write_result_take, data_plane_tcp_write_submit,
+};
+
+use crate::{error::get_last_error, strings::cstring_for};
+
+/// Operation kinds from the data-plane ABI.
+const OP_TCP_CONNECT: u16 = 1;
+const OP_TCP_READ: u16 = 4;
+const OP_TCP_WRITE: u16 = 5;
+
+/// `data_plane_tcp_read_submit` chunk size.
+const READ_CHUNK: u32 = 64 * 1024;
+
+/// Timeout for the data-plane TCP connect towards the forward target.
+const CONNECT_TIMEOUT_MS: u64 = 10_000;
+
+/// Maximum time `stop()` waits for one worker thread to exit.
+const STOP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Safety net per blocking local write. When it fires, the local socket write
+/// fails and the connection is torn down; a broken remote side unblocks the
+/// writer earlier via the `Broken` flag.
+const LOCAL_WRITE_TIMEOUT: Duration = Duration::from_secs(60);
+
+fn failed(message: impl Into<String>) -> io::Error {
+    io::Error::other(message.into())
+}
+
+fn spawn_failed(error: io::Error) -> io::Error {
+    failed(format!("failed to spawn forwarder thread: {error}"))
+}
+
+fn broken_pipe(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::BrokenPipe, message.into())
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(|error| error.into_inner())
+}
+
+/// Observed by both local worker threads of a connection: the remote side is
+/// torn down (or the forwarder is stopping) and the workers must exit.
+#[derive(Clone)]
+struct Broken(Arc<AtomicBool>);
+
+impl Broken {
+    fn new() -> Self {
+        Self(Arc::new(AtomicBool::new(false)))
+    }
+
+    fn break_it(&self) {
+        self.0.store(true, Ordering::Release);
+    }
+
+    fn is_broken(&self) -> bool {
+        self.0.load(Ordering::Acquire)
+    }
+}
+
+/// Command issued by connection threads towards the event loop.
+enum Command {
+    /// Inbound data to forward; the reply carries the completed write result.
+    Write {
+        connection: u64,
+        data: Vec<u8>,
+        reply: mpsc::Sender<io::Result<()>>,
+    },
+    /// One local worker exited; the stream is released once both are done.
+    ConnectionDone { connection: u64 },
+}
+
+/// Result of a completed remote read, handed to the owning local writer
+/// through its per-connection channel.
+struct ReadOutcome {
+    data: Vec<u8>,
+    eof: bool,
+}
+
+/// Per-connection channel state shared between the acceptor, the event loop
+/// and `stop`. `read_taken` is the acknowledgement the writer sends after
+/// taking a result; the event loop waits on it before submitting the next
+/// remote read for the connection. `socket` lets `stop` shut the local socket
+/// down so a blocked reader/writer wakes immediately.
+struct ConnectionHandles {
+    broken: Broken,
+    read_results: mpsc::Sender<ReadOutcome>,
+    read_taken: Mutex<Option<mpsc::Receiver<()>>>,
+    socket: TcpStream,
+}
+
+impl ConnectionHandles {
+    fn pair(
+        broken: Broken,
+        socket: TcpStream,
+    ) -> (Arc<Self>, mpsc::Receiver<ReadOutcome>, mpsc::Sender<()>) {
+        let (results_tx, results_rx) = mpsc::channel();
+        let (taken_tx, taken_rx) = mpsc::channel();
+        (
+            Arc::new(Self {
+                broken,
+                read_results: results_tx,
+                read_taken: Mutex::new(Some(taken_rx)),
+                socket,
+            }),
+            results_rx,
+            taken_tx,
+        )
+    }
+}
+
+/// A registered connect attempt: the event loop resolves the attempt id to the
+/// per-connection reply channel once the FFI-assigned operation id arrives.
+struct ConnectAttempt {
+    reply: mpsc::Sender<io::Result<u64>>,
+    operation: Option<u64>,
+}
+
+/// Connect attempts, keyed by attempt id (== connection id).
+type PendingConnects = Arc<Mutex<HashMap<u64, ConnectAttempt>>>;
+
+struct SharedSession {
+    handle: u64,
+    connects: PendingConnects,
+    /// FFI operation id -> attempt id, for connect completions.
+    connect_ops: Arc<Mutex<HashMap<u64, u64>>>,
+}
+
+impl SharedSession {
+    fn open(instance_name: &str) -> io::Result<Arc<Self>> {
+        let name = cstring_for(instance_name, "instance name")?;
+        let mut handle = 0u64;
+        // SAFETY: `name` is a valid NUL-terminated string and `handle` points
+        // to writable storage for one `u64`.
+        let result = unsafe { data_plane_session_open(name.as_ptr(), &mut handle) };
+        if result != 0 || handle == 0 {
+            let mut message = format!(
+                "failed to open data-plane session for instance \"{instance_name}\" (code {result})"
+            );
+            if let Some(error) = get_last_error() {
+                message.push_str(": ");
+                message.push_str(&error);
+            }
+            return Err(failed(message));
+        }
+        Ok(Arc::new(Self {
+            handle,
+            connects: PendingConnects::default(),
+            connect_ops: Arc::new(Mutex::new(HashMap::new())),
+        }))
+    }
+
+    fn submit_connect(&self, attempt: u64, target: SocketAddrV4) -> io::Result<u64> {
+        let mut address = [0u8; 16];
+        address[..4].copy_from_slice(&target.ip().octets());
+        let peer = DataPlaneSocketAddr {
+            family: 4,
+            port: target.port(),
+            address,
+        };
+        let mut operation = 0u64;
+        // Hold `connect_ops` across the FFI submit and the registration: the
+        // session may complete the connect as soon as the submit returns, and
+        // `complete_connect` resolves completions under this same lock, so the
+        // operation -> attempt mapping is always registered before the
+        // completion can be dispatched.
+        let mut connect_ops = lock(&self.connect_ops);
+        // SAFETY: `peer` is a plain value and `operation` points to writable
+        // storage for one `u64`.
+        let result = unsafe {
+            data_plane_tcp_connect_submit(self.handle, peer, CONNECT_TIMEOUT_MS, &mut operation)
+        };
+        if result != 0 {
+            lock(&self.connects).remove(&attempt);
+            return Err(failed(format!(
+                "data-plane TCP connect submit failed (code {result})"
+            )));
+        }
+        // The completion arrives keyed by the FFI operation id, which the
+        // session allocates independently of our attempt/connection ids.
+        if let Some(entry) = lock(&self.connects).get_mut(&attempt) {
+            entry.operation = Some(operation);
+        }
+        connect_ops.insert(operation, attempt);
+        Ok(operation)
+    }
+
+    /// Idempotent close; safe to call from `stop` while the event loop blocks
+    /// in `completion_wait`, which then wakes up with no completions.
+    fn close(&self) {
+        data_plane_session_close(self.handle);
+    }
+}
+
+impl Drop for SharedSession {
+    fn drop(&mut self) {
+        data_plane_session_close(self.handle);
+    }
+}
+
+struct ConnectionState {
+    handles: Arc<ConnectionHandles>,
+    /// Stream handle; set to 0 after `data_plane_resource_close`.
+    stream: u64,
+    /// Number of submitted-but-undrained operations referencing `stream`.
+    in_flight: u16,
+    /// Local workers that have not exited yet.
+    live_workers: u8,
+    /// Expected length and reply for the outstanding inbound write.
+    write_reply: Option<(u32, mpsc::Sender<io::Result<()>>)>,
+    /// A remote read is outstanding.
+    read_pending: bool,
+}
+
+impl ConnectionState {
+    fn new(handles: Arc<ConnectionHandles>, stream: u64) -> Self {
+        Self {
+            handles,
+            stream,
+            in_flight: 0,
+            live_workers: 2,
+            write_reply: None,
+            read_pending: false,
+        }
+    }
+}
+
+/// All live connections (pending and established), shared with `stop` so it
+/// can wake blocked workers without waiting for the event loop.
+type LiveConnections = Arc<Mutex<HashMap<u64, Arc<ConnectionHandles>>>>;
+
+enum Wait {
+    Ready,
+    TimedOut,
+    Closed,
+}
+
+/// Blocking event loop driving one shared data-plane session.
+struct EventLoop {
+    session: Arc<SharedSession>,
+    commands: mpsc::Receiver<Command>,
+    stopped: Arc<AtomicBool>,
+    connections: HashMap<u64, ConnectionState>,
+    /// operation_id -> connection for in-flight reads and writes.
+    operations: HashMap<u64, u64>,
+    /// Connections whose connect completion has not arrived yet.
+    pending_handles: Arc<Mutex<HashMap<u64, Arc<ConnectionHandles>>>>,
+    /// Receives connection ids whose writer acknowledged a read result.
+    pump_commands: mpsc::Receiver<u64>,
+    /// Live connections shared with `stop` for worker wakeup.
+    live: LiveConnections,
+}
+
+impl EventLoop {
+    fn run(mut self) {
+        while !self.stopped.load(Ordering::Acquire) {
+            // Apply all queued commands before blocking again so a wait never
+            // parks while work is already available. The wait below uses a
+            // short (5ms) timeout because the data-plane ABI has no self-wakeup
+            // for newly queued write/read commands; this bounds the added
+            // latency of an idle connection's first local→remote write.
+            while let Ok(command) = self.commands.try_recv() {
+                self.handle_command(command);
+            }
+            while let Ok(connection) = self.pump_commands.try_recv() {
+                self.submit_read(connection);
+            }
+            match self.wait() {
+                Wait::Ready => self.drain(),
+                Wait::TimedOut => continue,
+                Wait::Closed => break,
+            }
+        }
+        self.fail_all();
+    }
+
+    fn wait(&self) -> Wait {
+        if self.stopped.load(Ordering::Acquire) {
+            return Wait::TimedOut;
+        }
+        let result = data_plane_completion_wait(self.session.handle, 5);
+        match result {
+            1 => Wait::Ready,
+            0 => Wait::TimedOut,
+            _ => {
+                Wait::Closed
+            }
+        }
+    }
+
+    fn handle_command(&mut self, command: Command) {
+        match command {
+            Command::Write {
+                connection,
+                data,
+                reply,
+            } => self.submit_write(connection, data, reply),
+            Command::ConnectionDone { connection } => {
+                if let Some(state) = self.connections.get_mut(&connection) {
+                    state.live_workers = state.live_workers.saturating_sub(1);
+                    if state.live_workers == 0 {
+                        state.handles.broken.break_it();
+                    }
+                }
+                self.maybe_remove(connection);
+            }
+        }
+    }
+
+    fn submit_read(&mut self, connection: u64) {
+        let Some(state) = self.connections.get(&connection) else {
+            return;
+        };
+        if state.stream == 0 || state.read_pending || state.handles.broken.is_broken() {
+            return;
+        }
+        let stream = state.stream;
+        let mut operation = 0u64;
+        // SAFETY: `operation` points to writable storage for one `u64`.
+        let result = unsafe {
+            data_plane_tcp_read_submit(self.session.handle, stream, READ_CHUNK, &mut operation)
+        };
+        if result != 0 {
+            self.fail_stream(
+                connection,
+                &format!("data-plane read submit failed (code {result})"),
+            );
+            return;
+        }
+        let state = self
+            .connections
+            .get_mut(&connection)
+            .expect("connection state checked above");
+        state.in_flight += 1;
+        state.read_pending = true;
+        self.operations.insert(operation, connection);
+    }
+
+    fn submit_write(&mut self, connection: u64, data: Vec<u8>, reply: mpsc::Sender<io::Result<()>>) {
+        let Some(state) = self.connections.get(&connection) else {
+            let _ = reply.send(Err(broken_pipe("tcp forwarder connection is closed")));
+            return;
+        };
+        if state.handles.broken.is_broken() || state.stream == 0 {
+            let _ = reply.send(Err(broken_pipe("remote stream is closed")));
+            return;
+        }
+        let stream = state.stream;
+        let data_len = data.len() as u32;
+        let mut operation = 0u64;
+        // SAFETY: the ABI copies `data` before returning and `operation`
+        // points to writable storage for one `u64`.
+        let result = unsafe {
+            data_plane_tcp_write_submit(
+                self.session.handle,
+                stream,
+                data.as_ptr(),
+                data_len,
+                &mut operation,
+            )
+        };
+        if result != 0 {
+            let error = failed(format!("data-plane write submit failed (code {result})"));
+            self.fail_stream(connection, &error.to_string());
+            let _ = reply.send(Err(error));
+            return;
+        }
+        let state = self
+            .connections
+            .get_mut(&connection)
+            .expect("connection state checked above");
+        state.in_flight += 1;
+        state.write_reply = Some((data_len, reply));
+        self.operations.insert(operation, connection);
+    }
+
+    fn drain(&mut self) {
+        let mut completions = [DataPlaneCompletion::default(); 64];
+        // SAFETY: `completions` is writable storage for 64 descriptors.
+        let count = unsafe {
+            data_plane_completion_drain(
+                self.session.handle,
+                completions.as_mut_ptr(),
+                completions.len() as u32,
+            )
+        };
+        if count < 0 {
+            self.fail_all();
+            return;
+        }
+        for completion in completions.iter().take(count as usize) {
+            self.dispatch(completion);
+        }
+    }
+
+    fn dispatch(&mut self, completion: &DataPlaneCompletion) {
+        match completion.operation_kind {
+            OP_TCP_CONNECT => self.complete_connect(completion),
+            OP_TCP_READ | OP_TCP_WRITE => {
+                let Some(connection) = self.operations.remove(&completion.operation_id) else {
+                    // Cancelled or superseded operation; release its result.
+                    data_plane_operation_free(self.session.handle, completion.operation_id);
+                    return;
+                };
+                if completion.operation_kind == OP_TCP_READ {
+                    self.complete_read(connection, completion);
+                } else {
+                    self.complete_write(connection, completion);
+                }
+            }
+            _ => {
+                data_plane_operation_free(self.session.handle, completion.operation_id);
+            }
+        }
+    }
+
+    fn complete_connect(&mut self, completion: &DataPlaneCompletion) {
+        let operation = completion.operation_id;
+        // Resolve the FFI operation id back to the attempt/connection id used
+        // when the attempt was registered.
+        let Some(connection) = lock(&self.session.connect_ops).remove(&operation) else {
+            data_plane_operation_free(self.session.handle, operation);
+            return;
+        };
+        let attempt = lock(&self.session.connects).remove(&connection);
+        let Some(attempt) = attempt else {
+            data_plane_operation_free(self.session.handle, operation);
+            return;
+        };
+        let reply = attempt.reply;
+        let Some(handles) = lock(&self.pending_handles).remove(&connection) else {
+            // The acceptor was stopped mid-connect; release the operation.
+            data_plane_operation_free(self.session.handle, operation);
+            return;
+        };
+        if completion.status != 0 {
+            data_plane_operation_free(self.session.handle, operation);
+            handles.broken.break_it();
+            let _ = reply.send(Err(failed(format!(
+                "data-plane connect failed (status {})",
+                completion.status
+            ))));
+            return;
+        }
+        let mut stream = 0u64;
+        let mut local_addr = DataPlaneSocketAddr::default();
+        let mut peer_addr = DataPlaneSocketAddr::default();
+        // SAFETY: all output pointers reference writable storage of their
+        // respective types and do not overlap.
+        let result = unsafe {
+            data_plane_tcp_connect_result_take(
+                self.session.handle,
+                operation,
+                &mut stream,
+                &mut local_addr,
+                &mut peer_addr,
+            )
+        };
+        if result != 0 || stream == 0 {
+            handles.broken.break_it();
+            let _ = reply.send(Err(failed(format!(
+                "data-plane connect result take failed (code {result})"
+            ))));
+            return;
+        }
+        lock(&self.live).insert(connection, handles.clone());
+        self.connections
+            .insert(connection, ConnectionState::new(handles, stream));
+        let _ = reply.send(Ok(stream));
+        // Kick the remote-to-local pump.
+        self.submit_read(connection);
+    }
+
+    fn complete_read(&mut self, connection: u64, completion: &DataPlaneCompletion) {
+        if let Some(state) = self.connections.get_mut(&connection) {
+            state.in_flight = state.in_flight.saturating_sub(1);
+            state.read_pending = false;
+        }
+        if completion.status != 0 {
+            data_plane_operation_free(self.session.handle, completion.operation_id);
+            self.fail_stream(
+                connection,
+                &format!("data-plane read failed (status {})", completion.status),
+            );
+            self.maybe_remove(connection);
+            return;
+        }
+        let mut buffer = vec![0u8; READ_CHUNK as usize];
+        let mut len = 0u32;
+        let mut eof = false;
+        // SAFETY: `buffer` is writable for `READ_CHUNK` bytes and the scalar
+        // outputs reference writable, non-overlapping storage. The buffer
+        // always satisfies the maximum read size submitted for this session.
+        let result = unsafe {
+            data_plane_tcp_read_result_take(
+                self.session.handle,
+                completion.operation_id,
+                buffer.as_mut_ptr(),
+                buffer.len() as u32,
+                &mut len,
+                &mut eof,
+            )
+        };
+        if result != 0 {
+            self.fail_stream(
+                connection,
+                &format!("data-plane read result take failed (code {result})"),
+            );
+            self.maybe_remove(connection);
+            return;
+        }
+        buffer.truncate(len as usize);
+        let Some(state) = self.connections.get(&connection) else {
+            return;
+        };
+        // Hand the payload to the owning local writer. The writer acknowledges
+        // the take through `read_taken`, which the loop waits on before
+        // submitting the next read for this connection.
+        if state
+            .handles
+            .read_results
+            .send(ReadOutcome { data: buffer, eof })
+            .is_err()
+        {
+            self.fail_stream(connection, "tcp forwarder read result channel closed");
+        }
+        self.maybe_remove(connection);
+    }
+
+    fn complete_write(&mut self, connection: u64, completion: &DataPlaneCompletion) {
+        let mut written = 0u32;
+        let mut result = if completion.status != 0 {
+            data_plane_operation_free(self.session.handle, completion.operation_id);
+            Err(failed(format!(
+                "data-plane write failed (status {})",
+                completion.status
+            )))
+        } else {
+            // SAFETY: `written` points to writable storage for one `u32`.
+            let result = unsafe {
+                data_plane_tcp_write_result_take(
+                    self.session.handle,
+                    completion.operation_id,
+                    &mut written,
+                )
+            };
+            if result != 0 {
+                Err(failed(format!(
+                    "data-plane write result take failed (code {result})"
+                )))
+            } else {
+                Ok(())
+            }
+        };
+        let reply = self.connections.get_mut(&connection).and_then(|state| {
+            state.in_flight = state.in_flight.saturating_sub(1);
+            state.write_reply.take()
+        });
+        if result.is_ok()
+            && let Some((expected, _)) = &reply
+            && written != *expected
+        {
+            result = Err(failed(format!(
+                "data-plane write completed after {written} of {expected} bytes"
+            )));
+        }
+        if result.is_err() {
+            // Reuse `fail_stream` so a writer blocked on the read-result
+            // channel is woken with an EOF sentinel, not just flagged broken.
+            self.fail_stream(connection, "data-plane write failed");
+        }
+        if let Some((_, reply)) = reply {
+            let _ = reply.send(result);
+        }
+        self.maybe_remove(connection);
+    }
+
+    /// Release a connection once both workers exited and no operation still
+    /// references its stream.
+    fn maybe_remove(&mut self, connection: u64) {
+        let (close_stream, remove) = match self.connections.get(&connection) {
+            Some(state) if state.live_workers == 0 && state.in_flight == 0 => {
+                (state.stream != 0, true)
+            }
+            _ => (false, false),
+        };
+        if !remove {
+            return;
+        }
+        let state = self.connections.remove(&connection).expect("checked above");
+        lock(&self.live).remove(&connection);
+        if close_stream {
+            data_plane_resource_close(self.session.handle, state.stream);
+        }
+    }
+
+    /// Mark the remote side of `connection` as torn down and release its
+    /// stream as soon as no in-flight operation references it.
+    fn fail_stream(&mut self, connection: u64, reason: &str) {
+        let write_reply = self.connections.get_mut(&connection).and_then(|state| {
+            state.handles.broken.break_it();
+            // Wake a writer blocked on the read-result channel.
+            let _ = state.handles.read_results.send(ReadOutcome {
+                data: Vec::new(),
+                eof: true,
+            });
+            if state.stream != 0 && state.in_flight == 0 {
+                let stream = state.stream;
+                state.stream = 0;
+                data_plane_resource_close(self.session.handle, stream);
+            }
+            state.write_reply.take()
+        });
+        if let Some((_, reply)) = write_reply {
+            let _ = reply.send(Err(broken_pipe(reason)));
+        }
+    }
+
+    /// Tear down every tracked connection and fail pending connects; used when
+    /// the session dies or the forwarder stops.
+    fn fail_all(&mut self) {
+        for (_, attempt) in lock(&self.session.connects).drain() {
+            let _ = attempt.reply.send(Err(failed("data-plane session closed")));
+        }
+        lock(&self.session.connect_ops).clear();
+        for (_, handles) in lock(&self.pending_handles).drain() {
+            handles.broken.break_it();
+        }
+        lock(&self.live).clear();
+        let connections = std::mem::take(&mut self.connections);
+        for (_, mut state) in connections {
+            state.handles.broken.break_it();
+            // Wake a writer blocked on the read-result channel.
+            let _ = state.handles.read_results.send(ReadOutcome {
+                data: Vec::new(),
+                eof: true,
+            });
+            if state.stream != 0 {
+                data_plane_resource_close(self.session.handle, state.stream);
+            }
+            if let Some((_, reply)) = state.write_reply.take() {
+                let _ = reply.send(Err(broken_pipe("data-plane session is closed")));
+            }
+        }
+        self.operations.clear();
+    }
+}
+
+/// Shared state handed to the accept loop.
+struct Acceptor {
+    target: SocketAddrV4,
+    session: Arc<SharedSession>,
+    commands: mpsc::Sender<Command>,
+    /// Connections accepted but whose connect completion has not arrived yet;
+    /// moved into the event loop's connection table on connect success.
+    pending_handles: Arc<Mutex<HashMap<u64, Arc<ConnectionHandles>>>>,
+    workers: Arc<Mutex<Vec<JoinHandle<()>>>>,
+    next_connection: Arc<AtomicU64>,
+    pump_requests: mpsc::Sender<u64>,
+    stop: Arc<AtomicBool>,
+}
+
+/// A loopback TCP port forwarder bound to one EasyTier instance and target.
+///
+/// `start` spawns all threads; dropping the value (or calling `stop`) closes
+/// the listener, the data-plane session and joins the threads.
+pub struct TcpForwarder {
+    /// Actual bound loopback port.
+    pub local_port: u16,
+    instance_name: String,
+    target: SocketAddrV4,
+    stop: Arc<AtomicBool>,
+    session: Arc<SharedSession>,
+    /// Kept so the event loop's command channel stays alive while stopping.
+    #[allow(dead_code)]
+    commands: mpsc::Sender<Command>,
+    pending_handles: Arc<Mutex<HashMap<u64, Arc<ConnectionHandles>>>>,
+    live: LiveConnections,
+    workers: Arc<Mutex<Vec<JoinHandle<()>>>>,
+    /// Kept so pump threads can always reach the event loop; dropped on `stop`.
+    #[allow(dead_code)]
+    pump_requests: mpsc::Sender<u64>,
+    event_loop: Mutex<Option<JoinHandle<()>>>,
+    acceptor: Mutex<Option<JoinHandle<()>>>,
+    stopped: Mutex<bool>,
+}
+
+impl TcpForwarder {
+    /// Start forwarding `127.0.0.1:listen_port` (0 = auto-assign) to `target`
+    /// through the data plane of the EasyTier instance named `instance_name`.
+    ///
+    /// Succeeds without any peer connectivity; connect failures surface per
+    /// connection. Fails when the instance has no free native data-plane
+    /// session (one per instance, shared by all connections of a forwarder).
+    pub fn start(
+        instance_name: String,
+        target: SocketAddrV4,
+        listen_port: u16,
+    ) -> io::Result<Self> {
+        let session = SharedSession::open(&instance_name)?;
+        let listener = TcpListener::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, listen_port))?;
+        let local_addr = listener.local_addr()?;
+        let local_port = match local_addr {
+            std::net::SocketAddr::V4(addr) => addr.port(),
+            std::net::SocketAddr::V6(_) => unreachable!("bound an IPv4 listener"),
+        };
+        listener.set_nonblocking(true)?;
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let (command_tx, command_rx) = mpsc::channel::<Command>();
+        let (pump_tx, pump_rx) = mpsc::channel::<u64>();
+        let pending_handles: Arc<Mutex<HashMap<u64, Arc<ConnectionHandles>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let live: LiveConnections = Arc::new(Mutex::new(HashMap::new()));
+        let workers: Arc<Mutex<Vec<JoinHandle<()>>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let event_loop = std::thread::Builder::new()
+            .name(format!("tcp-fwd-loop-{local_port}"))
+            .spawn({
+                let session = session.clone();
+                let stop = stop.clone();
+                let pending_handles = pending_handles.clone();
+                let live = live.clone();
+                move || {
+                    EventLoop {
+                        session,
+                        commands: command_rx,
+                        stopped: stop,
+                        connections: HashMap::new(),
+                        operations: HashMap::new(),
+                        pending_handles,
+                        pump_commands: pump_rx,
+                        live,
+                    }
+                    .run();
+                }
+            })
+            .map_err(spawn_failed)?;
+
+        let acceptor = std::thread::Builder::new()
+            .name(format!("tcp-fwd-accept-{local_port}"))
+            .spawn({
+                let acceptor = Acceptor {
+                    target,
+                    session: session.clone(),
+                    commands: command_tx.clone(),
+                    pending_handles: pending_handles.clone(),
+                    workers: workers.clone(),
+                    next_connection: Arc::new(AtomicU64::new(1)),
+                    pump_requests: pump_tx.clone(),
+                    stop: stop.clone(),
+                };
+                move || accept_loop(listener, acceptor)
+            });
+        let acceptor = match acceptor {
+            Ok(acceptor) => acceptor,
+            Err(error) => {
+                stop.store(true, Ordering::Release);
+                session.close();
+                let _ = event_loop.join();
+                return Err(spawn_failed(error));
+            }
+        };
+
+        Ok(Self {
+            local_port,
+            instance_name,
+            target,
+            stop,
+            session,
+            commands: command_tx,
+            pending_handles,
+            live,
+            workers,
+            pump_requests: pump_tx,
+            event_loop: Mutex::new(Some(event_loop)),
+            acceptor: Mutex::new(Some(acceptor)),
+            stopped: Mutex::new(false),
+        })
+    }
+
+    /// Instance this forwarder is bound to.
+    #[allow(dead_code)]
+    pub fn instance_name(&self) -> &str {
+        &self.instance_name
+    }
+
+    /// Virtual-network target of every forwarded connection.
+    #[allow(dead_code)]
+    pub fn target(&self) -> SocketAddrV4 {
+        self.target
+    }
+
+    /// Stop the forwarder: close the listener and session, then join threads.
+    pub fn stop(&self) -> io::Result<()> {
+        {
+            let mut stopped = lock(&self.stopped);
+            if *stopped {
+                return Ok(());
+            }
+            *stopped = true;
+        }
+        self.stop.store(true, Ordering::Release);
+        // Break every connection, wake a blocked writer with an EOF sentinel,
+        // and shut the local socket down so a blocked reader exits too.
+        for (_, handles) in lock(&self.pending_handles).iter() {
+            handles.broken.break_it();
+            let _ = handles.read_results.send(ReadOutcome {
+                data: Vec::new(),
+                eof: true,
+            });
+            let _ = handles.socket.shutdown(Shutdown::Both);
+        }
+        for (_, handles) in lock(&self.live).iter() {
+            handles.broken.break_it();
+            let _ = handles.read_results.send(ReadOutcome {
+                data: Vec::new(),
+                eof: true,
+            });
+            let _ = handles.socket.shutdown(Shutdown::Both);
+        }
+        // Unblock the nonblocking accept loop immediately.
+        let _ = TcpStream::connect(SocketAddrV4::new(Ipv4Addr::LOCALHOST, self.local_port));
+        // Unblock the event loop: closing the session wakes a pending
+        // `completion_wait` and makes every subsequent FFI call fail, so the
+        // loop unwinds and tears the connections down. `close` is idempotent
+        // across the `SharedSession` drop.
+        self.session.close();
+
+        let deadline = Instant::now() + STOP_TIMEOUT;
+        let join = |handle: &Mutex<Option<JoinHandle<()>>>| -> io::Result<()> {
+            let handle = lock(handle).take();
+            if let Some(handle) = handle {
+                if handle.is_finished() {
+                    return handle.join().map_err(|_| failed("forwarder thread panicked"));
+                }
+                while !handle.is_finished() && Instant::now() < deadline {
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+                if handle.is_finished() {
+                    handle.join().map_err(|_| failed("forwarder thread panicked"))?;
+                }
+            }
+            Ok(())
+        };
+        let accept_result = join(&self.acceptor);
+        let loop_result = join(&self.event_loop);
+        // The event loop is gone, so no completion is ever dispatched again.
+        // A connection whose spawn raced `stop` may have registered its
+        // connect attempt after the loop's final `fail_all`; fail such
+        // attempts here so readers blocked in `await_connect` can exit.
+        for (_, attempt) in lock(&self.session.connects).drain() {
+            let _ = attempt.reply.send(Err(failed("tcp forwarder stopped")));
+        }
+        lock(&self.session.connect_ops).clear();
+        for (_, handles) in lock(&self.pending_handles).drain() {
+            handles.broken.break_it();
+            let _ = handles.read_results.send(ReadOutcome {
+                data: Vec::new(),
+                eof: true,
+            });
+            let _ = handles.socket.shutdown(Shutdown::Both);
+        }
+        let workers: Vec<_> = lock(&self.workers).drain(..).collect();
+        // A worker may outlive the teardown (e.g. its connect attempt raced
+        // `stop`); bound the wait like the acceptor/event-loop joins instead
+        // of blocking forever. A worker still alive at the deadline is
+        // detached by dropping its join handle.
+        let deadline = Instant::now() + STOP_TIMEOUT;
+        for handle in workers {
+            while !handle.is_finished() && Instant::now() < deadline {
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            if handle.is_finished() {
+                let _ = handle.join();
+            }
+        }
+        accept_result.and(loop_result)
+    }
+}
+
+impl Drop for TcpForwarder {
+    fn drop(&mut self) {
+        let _ = self.stop();
+    }
+}
+
+impl std::fmt::Debug for TcpForwarder {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("TcpForwarder")
+            .field("local_port", &self.local_port)
+            .field("instance_name", &self.instance_name)
+            .field("target", &self.target)
+            .finish()
+    }
+}
+
+fn accept_loop(listener: TcpListener, acceptor: Acceptor) {
+    while !acceptor.stop.load(Ordering::Acquire) {
+        match listener.accept() {
+            Ok((socket, _)) => {
+                if acceptor.stop.load(Ordering::Acquire) {
+                    return;
+                }
+                if let Err(error) = spawn_connection(socket, &acceptor) {
+                    log::warn!("tcp forwarder failed to spawn connection: {error}");
+                }
+            }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(_) => {
+                if acceptor.stop.load(Ordering::Acquire) {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        }
+    }
+}
+
+/// Spawn the per-connection reader/writer/pump threads and submit the
+/// data-plane connect. The workers wait for the connect outcome before
+/// touching streams.
+fn spawn_connection(socket: TcpStream, acceptor: &Acceptor) -> io::Result<()> {
+    socket.set_nodelay(true).ok();
+    let connection = acceptor.next_connection.fetch_add(1, Ordering::Relaxed);
+    let broken = Broken::new();
+    let handle_socket = socket
+        .try_clone()
+        .map_err(|error| failed(format!("failed to clone connection socket: {error}")))?;
+    let (handles, results_rx, taken_tx) = ConnectionHandles::pair(broken.clone(), handle_socket);
+    let (connect_tx, connect_rx) = mpsc::channel();
+
+    let reader_socket = socket
+        .try_clone()
+        .map_err(|error| failed(format!("failed to clone connection socket: {error}")))?;
+    // Wake the reader periodically so it observes a broken remote side even
+    // while the local client stays silent; the data-plane ABI has no half-close
+    // for the write direction, so this is how teardown reaches a blocked read.
+    reader_socket
+        .set_read_timeout(Some(Duration::from_millis(500)))
+        .ok();
+    let reader = std::thread::Builder::new()
+        .name(format!("tcp-fwd-reader-{connection}"))
+        .spawn({
+            let commands = acceptor.commands.clone();
+            let broken = broken.clone();
+            move || reader_loop(connection, reader_socket, broken, commands, connect_rx)
+        })
+        .map_err(spawn_failed)?;
+    lock(&acceptor.workers).push(reader);
+    let writer = std::thread::Builder::new()
+        .name(format!("tcp-fwd-writer-{connection}"))
+        .spawn({
+            let commands = acceptor.commands.clone();
+            move || writer_loop(connection, socket, broken, commands, results_rx, taken_tx)
+        })
+        .map_err(|error| {
+            stop_connection_workers(&handles);
+            spawn_failed(error)
+        })?;
+    lock(&acceptor.workers).push(writer);
+    let pump = std::thread::Builder::new()
+        .name(format!("tcp-fwd-pump-{connection}"))
+        .spawn({
+            let pump_requests = acceptor.pump_requests.clone();
+            let handles = handles.clone();
+            move || pump_loop(connection, handles, pump_requests)
+        })
+        .map_err(|error| {
+            stop_connection_workers(&handles);
+            spawn_failed(error)
+        })?;
+    lock(&acceptor.workers).push(pump);
+
+    lock(&acceptor.session.connects).insert(
+        connection,
+        ConnectAttempt {
+            reply: connect_tx,
+            operation: None,
+        },
+    );
+    lock(&acceptor.pending_handles).insert(connection, handles.clone());
+    if let Err(error) = acceptor.session.submit_connect(connection, acceptor.target) {
+        lock(&acceptor.pending_handles).remove(&connection);
+        stop_connection_workers(&handles);
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn stop_connection_workers(handles: &ConnectionHandles) {
+    handles.broken.break_it();
+    let _ = handles.read_results.send(ReadOutcome {
+        data: Vec::new(),
+        eof: true,
+    });
+    let _ = handles.socket.shutdown(Shutdown::Both);
+}
+
+/// Per-connection read pump: waits for the writer to acknowledge the previous
+/// read result, then asks the event loop to submit the next remote read.
+/// Blocks without touching the session, so it cannot stall other connections.
+fn pump_loop(
+    connection: u64,
+    handles: Arc<ConnectionHandles>,
+    pump_requests: mpsc::Sender<u64>,
+) {
+    loop {
+        if handles.broken.is_broken() {
+            return;
+        }
+        // Poll with a short sleep instead of a blocking recv: the event loop
+        // only consults the receiver through short try_recv bursts, and a
+        // blocking recv here would hold the mutex forever once no result is
+        // pending, deadlocking `stop`.
+        let acknowledged = {
+            let taken = lock(&handles.read_taken);
+            match taken.as_ref() {
+                Some(taken) => taken.try_recv().is_ok(),
+                None => return,
+            }
+        };
+        if !acknowledged {
+            std::thread::sleep(Duration::from_millis(20));
+            continue;
+        }
+        if handles.broken.is_broken() {
+            return;
+        }
+        if pump_requests.send(connection).is_err() {
+            return;
+        }
+    }
+}
+
+/// Wait for the connect completion; returns the remote stream handle.
+fn await_connect(reply: &mpsc::Receiver<io::Result<u64>>) -> Option<u64> {
+    match reply.recv() {
+        Ok(Ok(stream)) => Some(stream),
+        Ok(Err(error)) => {
+            log::debug!("tcp forwarder connect failed: {error}");
+            None
+        }
+        Err(_) => None,
+    }
+}
+
+/// Local -> remote copy loop.
+fn reader_loop(
+    connection: u64,
+    mut socket: TcpStream,
+    broken: Broken,
+    commands: mpsc::Sender<Command>,
+    connect_reply: mpsc::Receiver<io::Result<u64>>,
+) {
+    if await_connect(&connect_reply).is_none() {
+        let _ = socket.shutdown(Shutdown::Both);
+        let _ = commands.send(Command::ConnectionDone { connection });
+        return;
+    }
+    let mut buffer = [0u8; 16 * 1024];
+    loop {
+        if broken.is_broken() {
+            break;
+        }
+        match socket.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(len) => {
+                let (reply_tx, reply_rx) = mpsc::channel();
+                if commands
+                    .send(Command::Write {
+                        connection,
+                        data: buffer[..len].to_vec(),
+                        reply: reply_tx,
+                    })
+                    .is_err()
+                {
+                    break;
+                }
+                match reply_rx.recv() {
+                    Ok(Ok(())) => {}
+                    Ok(Err(error)) => {
+                        log::debug!("tcp forwarder write failed: {error}");
+                        break;
+                    }
+                    Err(_) => break,
+                }
+            }
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+            Err(error)
+                if error.kind() == io::ErrorKind::WouldBlock
+                    || error.kind() == io::ErrorKind::TimedOut =>
+            {
+                // Read-timeout tick: re-check the broken flag.
+                continue;
+            }
+            Err(_) => break,
+        }
+    }
+    // No more local data; the writer keeps delivering remote data until EOF.
+    let _ = socket.shutdown(Shutdown::Read);
+    let _ = commands.send(Command::ConnectionDone { connection });
+}
+
+/// Remote -> local copy loop. Blocks on the per-connection read-result
+/// channel; after writing each payload to the local socket it acknowledges the
+/// take so the event loop submits the next remote read for this connection.
+fn writer_loop(
+    connection: u64,
+    mut socket: TcpStream,
+    broken: Broken,
+    commands: mpsc::Sender<Command>,
+    read_rx: mpsc::Receiver<ReadOutcome>,
+    taken_tx: mpsc::Sender<()>,
+) {
+    socket.set_write_timeout(Some(LOCAL_WRITE_TIMEOUT)).ok();
+    loop {
+        if broken.is_broken() {
+            break;
+        }
+        let outcome = match read_rx.recv() {
+            Ok(outcome) => outcome,
+            Err(_) => break,
+        };
+        if !outcome.data.is_empty() && socket.write_all(&outcome.data).is_err() {
+            break;
+        }
+        let _ = taken_tx.send(());
+        if outcome.eof {
+            let _ = socket.shutdown(Shutdown::Write);
+            break;
+        }
+    }
+    let _ = commands.send(Command::ConnectionDone { connection });
+}
+
+#[cfg(test)]
+mod tests;

--- a/easytier-contrib/easytier-android-jni/src/forwarder/tests.rs
+++ b/easytier-contrib/easytier-android-jni/src/forwarder/tests.rs
@@ -1,0 +1,668 @@
+//! Host-target tests for `TcpForwarder`.
+//!
+//! The first three tests need no overlay connectivity. `forward_echo_roundtrip`
+//! links two real FFI instances over the process-wide ring registry (through
+//! the always-on `ring://<instance-id>` listener and a TOML ring connector)
+//! and verifies a full byte round trip through the forwarder and the data
+//! plane.
+
+use std::{
+    ffi::CString,
+    io::{Read, Write},
+    net::{Ipv4Addr, SocketAddrV4, TcpStream},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use easytier_ffi::{
+    DataPlaneSocketAddr, data_plane_completion_wait, data_plane_operation_free,
+    data_plane_resource_close, data_plane_session_close, data_plane_session_open,
+    data_plane_tcp_accept_result_take, data_plane_tcp_accept_submit,
+    data_plane_tcp_bind_result_take, data_plane_tcp_bind_submit, data_plane_tcp_read_result_take,
+    data_plane_tcp_read_submit, data_plane_tcp_write_result_take, data_plane_tcp_write_submit,
+};
+
+use super::*;
+
+/// Names of instances started by the current test, stopped on guard drop.
+static INSTANCES: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+fn unique_instance(tag: &str) -> String {
+    format!("fwd-{tag}-{}", &uuid::Uuid::new_v4().simple().to_string()[..12])
+}
+
+fn run_instance(config: &str, register_as: &str) {
+    let config = CString::new(config).unwrap();
+    // SAFETY: `config` is a valid NUL-terminated string.
+    let result = unsafe { easytier_ffi::run_network_instance(config.as_ptr()) };
+    if result != 0 {
+        let message = crate::error::get_last_error().unwrap_or_default();
+        panic!("run_network_instance failed: {result}: {message}");
+    }
+    lock(&INSTANCES).push(register_as.to_string());
+}
+
+/// Open a forwarder session once the instance's data-plane session is
+/// available; `run_network_instance` returns before `instance.start()` finishes
+/// bringing the data plane up.
+fn start_forwarder(
+    instance: &str,
+    target: SocketAddrV4,
+    listen_port: u16,
+) -> io::Result<TcpForwarder> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        match TcpForwarder::start(instance.to_string(), target, listen_port) {
+            Ok(forwarder) => {
+                return Ok(forwarder);
+            }
+            Err(error) => {
+                if Instant::now() >= deadline {
+                    return Err(error);
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        }
+    }
+}
+
+fn start_instance(instance: &str, ipv4: &str) {
+    run_instance(
+        &format!(
+            "instance_name = \"{instance}\"\n\
+             instance_id = \"{}\"\n\
+             ipv4 = \"{ipv4}\"\n\
+             listeners = []\n\
+             flags.no_tun = true\n",
+            uuid::Uuid::new_v4()
+        ),
+        instance,
+    );
+}
+
+fn stop_all_instances() {
+    let names = std::mem::take(&mut *lock(&INSTANCES));
+    if names.is_empty() {
+        return;
+    }
+    let cstrings: Vec<CString> = names
+        .iter()
+        .map(|name| CString::new(name.as_str()).unwrap())
+        .collect();
+    let pointers: Vec<*const std::ffi::c_char> =
+        cstrings.iter().map(|name| name.as_ptr()).collect();
+    // SAFETY: `pointers` references `cstrings`, all valid NUL-terminated
+    // strings, for the duration of the call.
+    unsafe { easytier_ffi::delete_network_instance(pointers.as_ptr(), pointers.len()) };
+}
+
+struct TestGuard(std::sync::MutexGuard<'static, ()>);
+
+/// Tests share one process-wide FFI context and per-instance native sessions;
+/// run them serially to avoid cross-test session/instance interference.
+static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+fn acquire() -> TestGuard {
+    let guard = TEST_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+    TestGuard(guard)
+}
+
+impl Drop for TestGuard {
+    fn drop(&mut self) {
+        stop_all_instances();
+    }
+}
+
+/// Probe `data_plane_session_open` until the instance's data-plane runtime is
+/// running, i.e. a submitted operation would not fail with InstanceStopped.
+fn wait_data_plane_running(instance: &str) {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while !session_openable(instance) {
+        assert!(Instant::now() < deadline, "data-plane runtime never started for {instance}");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn session_openable(instance: &str) -> bool {
+    let name = CString::new(instance).unwrap();
+    let mut session = 0u64;
+    // SAFETY: `name` is a valid NUL-terminated string and `session` points to
+    // writable storage for one `u64`.
+    let result = unsafe { data_plane_session_open(name.as_ptr(), &mut session) };
+    if result == 0 && session != 0 {
+        data_plane_session_close(session);
+        return true;
+    }
+    false
+}
+
+fn open_session(instance: &str) -> u64 {
+    let name = CString::new(instance).unwrap();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let mut session = 0u64;
+        // SAFETY: `name` is a valid NUL-terminated string and `session` points
+        // to writable storage for one `u64`.
+        let result = unsafe { data_plane_session_open(name.as_ptr(), &mut session) };
+        if result == 0 && session != 0 {
+            return session;
+        }
+        // The instance's data-plane session comes up asynchronously after
+        // `run_network_instance` returns.
+        assert!(Instant::now() < deadline, "data_plane_session_open timed out: {result}");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn wait_completion(session: u64, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if data_plane_completion_wait(session, 100) == 1 {
+            return;
+        }
+        assert!(Instant::now() < deadline, "data-plane completion timed out");
+    }
+}
+
+/// Wait for the next completion and drain it, returning its descriptor.
+fn next_completion(session: u64, timeout: Duration) -> easytier_ffi::DataPlaneCompletion {
+    wait_completion(session, timeout);
+    let mut completions = [easytier_ffi::DataPlaneCompletion::default(); 8];
+    // SAFETY: `completions` is writable storage for 8 descriptors.
+    let count = unsafe {
+        easytier_ffi::data_plane_completion_drain(
+            session,
+            completions.as_mut_ptr(),
+            completions.len() as u32,
+        )
+    };
+    assert!(count > 0, "completion drain returned {count}");
+    completions[0]
+}
+
+#[test]
+fn start_fails_for_unknown_instance_and_sets_error() {
+    let _guard = acquire();
+    let instance = unique_instance("missing");
+    let error = TcpForwarder::start(
+        instance.clone(),
+        SocketAddrV4::new(Ipv4Addr::new(10, 126, 126, 99), 22),
+        0,
+    )
+    .unwrap_err();
+    assert!(
+        error.to_string().contains(&instance),
+        "unexpected error: {error}"
+    );
+    let message = crate::error::get_last_error().expect("FFI error must be recorded");
+    assert!(
+        message.contains("instance not found"),
+        "unexpected FFI error: {message}"
+    );
+}
+
+#[test]
+fn unreachable_target_fails_connect_not_start() {
+    let _guard = acquire();
+    let instance = unique_instance("unreachable");
+    start_instance(&instance, "10.126.126.1");
+    let forwarder = start_forwarder(
+        &instance,
+        SocketAddrV4::new(Ipv4Addr::new(10, 126, 126, 99), 22),
+        0,
+    )
+    .expect("forwarder start must not require overlay connectivity");
+    let port = forwarder.local_port;
+    assert_ne!(port, 0);
+
+    let mut socket = TcpStream::connect(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port))
+        .expect("loopback connect must succeed");
+    socket
+        .set_read_timeout(Some(Duration::from_secs(20)))
+        .unwrap();
+    let mut buffer = [0u8; 1];
+    let started = Instant::now();
+    let outcome = socket.read(&mut buffer);
+    match outcome {
+        Ok(0) => {}
+        Err(error) => assert!(
+            error.kind() == io::ErrorKind::WouldBlock
+                || error.kind() == io::ErrorKind::TimedOut
+                || error.kind() == io::ErrorKind::ConnectionReset,
+            "unexpected read error: {error:?}"
+        ),
+        Ok(_) => panic!("unexpected payload from unreachable target"),
+    }
+    assert!(
+        started.elapsed() <= Duration::from_secs(20),
+        "connect failure must surface within the data-plane timeout"
+    );
+
+    forwarder.stop().expect("stop must succeed");
+}
+
+#[test]
+fn stop_releases_session_and_is_idempotent() {
+    let _guard = acquire();
+    let instance = unique_instance("stop");
+    start_instance(&instance, "10.126.126.1");
+    let forwarder = start_forwarder(
+        &instance,
+        SocketAddrV4::new(Ipv4Addr::new(10, 126, 126, 99), 22),
+        0,
+    )
+    .unwrap();
+    let port = forwarder.local_port;
+    forwarder.stop().unwrap();
+    forwarder.stop().unwrap();
+    assert!(
+        TcpStream::connect(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port)).is_err(),
+        "listener must be closed after stop"
+    );
+    // The shared per-instance session must be reusable after stop.
+    let session = open_session(&instance);
+    data_plane_session_close(session);
+}
+
+#[test]
+fn forward_echo_roundtrip() {
+    let _guard = acquire();
+    let instance_a = unique_instance("echo-a");
+    let instance_b = unique_instance("echo-b");
+    let id_b = uuid::Uuid::new_v4();
+    run_instance(
+        &format!(
+            "instance_name = \"{instance_b}\"\n\
+             instance_id = \"{id_b}\"\n\
+             ipv4 = \"10.126.126.2\"\n\
+             listeners = []\n\
+             flags.no_tun = true\n"
+        ),
+        &instance_b,
+    );
+    run_instance(
+        &format!(
+            "instance_name = \"{instance_a}\"\n\
+             instance_id = \"{id_a}\"\n\
+             ipv4 = \"10.126.126.1\"\n\
+             listeners = []\n\
+             flags.no_tun = true\n\
+             [[peer]]\n\
+             uri = \"ring://{id_b}\"\n",
+            id_a = uuid::Uuid::new_v4(),
+        ),
+        &instance_a,
+    );
+
+    let echo_port = 15871u16;
+    let echo_stop = Arc::new(AtomicBool::new(false));
+    let echo = std::thread::spawn({
+        let echo_stop = echo_stop.clone();
+        let instance_b = instance_b.clone();
+        move || echo_server(&instance_b, echo_port, echo_stop)
+    });
+
+    // The data-plane runtime comes up asynchronously after
+    // `run_network_instance`. The echo server holds instance B's single native
+    // session, so only probe A here; B's readiness is implied by the echo
+    // server passing its own bind. Give the ring link and routes a moment to
+    // settle before forwarding.
+    wait_data_plane_running(&instance_a);
+    std::thread::sleep(Duration::from_millis(500));
+
+    let forwarder = start_forwarder(
+        &instance_a,
+        SocketAddrV4::new(Ipv4Addr::new(10, 126, 126, 2), echo_port),
+        0,
+    )
+    .unwrap();
+    // Run several sequential connections: the FFI allocates operation ids from
+    // a monotonically increasing broker namespace independent of the
+    // forwarder's connection counter, so the second connection onwards only
+    // succeeds if connect completions are dispatched by operation id.
+    for round in 0..3 {
+        let mut socket =
+            TcpStream::connect(SocketAddrV4::new(Ipv4Addr::LOCALHOST, forwarder.local_port))
+                .expect("loopback connect failed");
+        socket
+            .set_read_timeout(Some(Duration::from_secs(25)))
+            .unwrap();
+        socket
+            .set_write_timeout(Some(Duration::from_secs(10)))
+            .unwrap();
+        let request = format!("ping{round}").into_bytes();
+        socket.write_all(&request).unwrap();
+        let mut buffer = vec![0u8; request.len()];
+        socket.read_exact(&mut buffer).expect("echo read failed");
+        assert_eq!(buffer, request, "round {round} payload mismatch");
+        drop(socket);
+    }
+
+    forwarder.stop().unwrap();
+    echo_stop.store(true, Ordering::Release);
+    echo.join().expect("echo server thread panicked");
+}
+
+/// Run a data-plane echo server on `instance`: bind `port`, then loop accepting
+/// a stream, reading one payload and replying "pong", until `stop` is set.
+fn echo_server(instance: &str, port: u16, stop: Arc<AtomicBool>) {
+    let session = open_session(instance);
+
+    let mut bind_operation = 0u64;
+    // The data-plane runtime starts after the instance; retry the bind until
+    // it is up.
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        // SAFETY: `bind_operation` points to writable storage for one `u64`.
+        let result =
+            unsafe { data_plane_tcp_bind_submit(session, port, 15_000, &mut bind_operation) };
+        if result == 0 {
+            break;
+        }
+        let message = crate::error::get_last_error().unwrap_or_default();
+        if Instant::now() >= deadline {
+            panic!("bind submit failed: {result}: {message}");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let bind_completion = next_completion(session, Duration::from_secs(15));
+    assert_eq!(bind_completion.operation_id, bind_operation);
+    assert_eq!(bind_completion.status, 0, "bind failed: {}", bind_completion.status);
+    let mut listener = 0u64;
+    let mut local = DataPlaneSocketAddr::default();
+    // SAFETY: outputs reference writable, non-overlapping storage.
+    let result = unsafe {
+        data_plane_tcp_bind_result_take(session, bind_operation, &mut listener, &mut local)
+    };
+    if result != 0 {
+        let message = crate::error::get_last_error().unwrap_or_default();
+        panic!("bind result take failed: {result}: {message}");
+    }
+
+    while !stop.load(Ordering::Acquire) {
+        let mut accept_operation = 0u64;
+        // SAFETY: `accept_operation` points to writable storage for one `u64`.
+        let result = unsafe {
+            data_plane_tcp_accept_submit(session, listener, 5_000, &mut accept_operation)
+        };
+        assert_eq!(result, 0, "accept submit failed: {result}");
+        let accept_completion = next_completion(session, Duration::from_secs(10));
+        assert_eq!(accept_completion.operation_id, accept_operation);
+        if accept_completion.status != 0 {
+            // Accept timed out or the listener was closed; re-check stop and
+            // either loop for the next connection or exit.
+            data_plane_operation_free(session, accept_operation);
+            if stop.load(Ordering::Acquire) {
+                break;
+            }
+            continue;
+        }
+        let mut stream = 0u64;
+        let mut peer = DataPlaneSocketAddr::default();
+        // SAFETY: outputs reference writable, non-overlapping storage.
+        let result = unsafe {
+            data_plane_tcp_accept_result_take(
+                session,
+                accept_operation,
+                &mut stream,
+                &mut local,
+                &mut peer,
+            )
+        };
+        assert_eq!(result, 0, "accept result take failed: {result}");
+
+        let mut read_operation = 0u64;
+        // SAFETY: `read_operation` points to writable storage for one `u64`.
+        let result =
+            unsafe { data_plane_tcp_read_submit(session, stream, 4096, &mut read_operation) };
+        assert_eq!(result, 0, "read submit failed: {result}");
+        let read_completion = next_completion(session, Duration::from_secs(15));
+        assert_eq!(read_completion.operation_id, read_operation);
+        assert_eq!(read_completion.status, 0, "read failed: {}", read_completion.status);
+        let mut data = [0u8; 4096];
+        let mut len = 0u32;
+        let mut eof = false;
+        // SAFETY: `data` is writable for its length and the scalar outputs
+        // reference writable, non-overlapping storage.
+        let result = unsafe {
+            data_plane_tcp_read_result_take(
+                session,
+                read_operation,
+                data.as_mut_ptr(),
+                data.len() as u32,
+                &mut len,
+                &mut eof,
+            )
+        };
+        assert_eq!(result, 0, "read result take failed: {result}");
+        assert!(!eof, "unexpected eof before payload");
+
+        // Echo the received payload back verbatim.
+        let payload = data[..len as usize].to_vec();
+        let mut write_operation = 0u64;
+        // SAFETY: the ABI copies `payload` before returning.
+        let result = unsafe {
+            data_plane_tcp_write_submit(
+                session,
+                stream,
+                payload.as_ptr(),
+                payload.len() as u32,
+                &mut write_operation,
+            )
+        };
+        assert_eq!(result, 0, "write submit failed: {result}");
+        let write_completion = next_completion(session, Duration::from_secs(15));
+        assert_eq!(write_completion.operation_id, write_operation);
+        assert_eq!(
+            write_completion.status, 0,
+            "write failed: {}",
+            write_completion.status
+        );
+        let mut written = 0u32;
+        // SAFETY: `written` points to writable storage for one `u32`.
+        let result =
+            unsafe { data_plane_tcp_write_result_take(session, write_operation, &mut written) };
+        assert_eq!(result, 0, "write result take failed: {result}");
+        assert_eq!(written as usize, payload.len());
+        data_plane_resource_close(session, stream);
+    }
+    data_plane_resource_close(session, listener);
+    data_plane_session_close(session);
+}
+
+#[test]
+fn two_instances_both_start_data_plane() {
+    let _guard = acquire();
+    let a = unique_instance("two-a");
+    let b = unique_instance("two-b");
+    run_instance(&format!("instance_name = \"{a}\"\ninstance_id = \"{}\"\nipv4 = \"10.126.126.1\"\nlisteners = []\nflags.no_tun = true\n", uuid::Uuid::new_v4()), &a);
+    run_instance(&format!("instance_name = \"{b}\"\ninstance_id = \"{}\"\nipv4 = \"10.126.126.2\"\nlisteners = []\nflags.no_tun = true\n", uuid::Uuid::new_v4()), &b);
+    wait_data_plane_running(&a);
+    wait_data_plane_running(&b);
+}
+
+/// Regression: a read completing with an error after both workers exited must
+/// release the connection (the error path used to skip `maybe_remove`, leaking
+/// the connection state until `stop`).
+#[test]
+fn failed_read_completion_releases_finished_connection() {
+    let _guard = acquire();
+    let instance = unique_instance("readfail");
+    start_instance(&instance, "10.126.126.1");
+    wait_data_plane_running(&instance);
+    let session = SharedSession::open(&instance).unwrap();
+    let (_command_tx, commands) = mpsc::channel();
+    let (_pump_tx, pump_commands) = mpsc::channel();
+    let live: LiveConnections = LiveConnections::default();
+    let mut event_loop = EventLoop {
+        session: session.clone(),
+        commands,
+        stopped: Arc::new(AtomicBool::new(false)),
+        connections: HashMap::new(),
+        operations: HashMap::new(),
+        pending_handles: Arc::new(Mutex::new(HashMap::new())),
+        pump_commands,
+        live: live.clone(),
+    };
+    // The leak scenario: both workers already exited while a remote read was
+    // still in flight, then the read completes with an error. The operation
+    // and stream ids below are bogus; the FFI treats freeing/closing unknown
+    // ids as a no-op.
+    let listener = TcpListener::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let socket = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+    let (handles, _results, _taken) = ConnectionHandles::pair(Broken::new(), socket);
+    let mut state = ConnectionState::new(handles.clone(), 4242);
+    state.in_flight = 1;
+    state.live_workers = 0;
+    state.read_pending = true;
+    event_loop.connections.insert(7, state);
+    lock(&live).insert(7, handles);
+
+    let completion = DataPlaneCompletion {
+        operation_id: 999,
+        operation_kind: OP_TCP_READ,
+        status: 1,
+    };
+    event_loop.complete_read(7, &completion);
+
+    assert!(
+        !event_loop.connections.contains_key(&7),
+        "failed read completion must release the finished connection"
+    );
+    assert!(lock(&live).is_empty(), "live connection entry leaked");
+}
+
+/// Regression: `submit_connect` must register the operation -> attempt mapping
+/// while holding `connect_ops`, so the event loop (which resolves connect
+/// completions under the same lock) can never dispatch a completion before the
+/// mapping exists. The race window itself is a thread interleaving that cannot
+/// be forced deterministically; this test pins the fix's observable property:
+/// no FFI connect is submitted while `connect_ops` is held by someone else.
+#[test]
+fn connect_submit_waits_for_connect_ops_lock() {
+    let _guard = acquire();
+    let instance = unique_instance("connreg");
+    start_instance(&instance, "10.126.126.1");
+    wait_data_plane_running(&instance);
+    let session = SharedSession::open(&instance).unwrap();
+    let (reply, _reply_rx) = mpsc::channel();
+    lock(&session.connects).insert(
+        7,
+        ConnectAttempt {
+            reply,
+            operation: None,
+        },
+    );
+
+    let connect_ops = lock(&session.connect_ops);
+    let worker = std::thread::spawn({
+        let session = session.clone();
+        move || session.submit_connect(7, SocketAddrV4::new(Ipv4Addr::new(10, 126, 126, 99), 22))
+    });
+    // The FFI submit itself must not have happened while the lock is held, so
+    // the attempt still has no operation id assigned.
+    std::thread::sleep(Duration::from_millis(300));
+    assert!(
+        lock(&session.connects).get(&7).unwrap().operation.is_none(),
+        "connect submit proceeded while connect_ops was locked"
+    );
+    drop(connect_ops);
+
+    let operation = worker.join().unwrap().expect("connect submit failed");
+    assert_eq!(lock(&session.connect_ops).get(&operation), Some(&7));
+    assert_eq!(
+        lock(&session.connects).get(&7).unwrap().operation,
+        Some(operation)
+    );
+}
+
+/// Regression: a connect attempt registered after the event loop's final
+/// `fail_all` (the acceptor/spawn racing `stop`) would never get a completion
+/// dispatched. `stop` must fail such stranded attempts so a reader blocked in
+/// `await_connect` exits instead of hanging forever.
+#[test]
+fn stop_fails_connect_registered_after_event_loop_exit() {
+    let _guard = acquire();
+    let instance = unique_instance("stoprace");
+    start_instance(&instance, "10.126.126.1");
+    let forwarder = start_forwarder(
+        &instance,
+        SocketAddrV4::new(Ipv4Addr::new(10, 126, 126, 99), 22),
+        0,
+    )
+    .unwrap();
+    // Force the event loop out before `stop`: closing the session fails the
+    // completion wait, so the loop breaks and runs its final `fail_all`.
+    forwarder.session.close();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let exited = lock(&forwarder.event_loop)
+            .as_ref()
+            .map(|handle| handle.is_finished())
+            .unwrap_or(true);
+        if exited {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "event loop did not exit on session close"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    // Register an attempt now: no event loop remains to dispatch its
+    // completion, exactly like the spawn/stop race.
+    let (reply, reply_rx) = mpsc::channel();
+    lock(&forwarder.session.connects).insert(
+        77,
+        ConnectAttempt {
+            reply,
+            operation: None,
+        },
+    );
+    let reader = std::thread::spawn(move || await_connect(&reply_rx));
+
+    forwarder.stop().expect("stop must succeed");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !reader.is_finished() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(
+        reader.is_finished(),
+        "reader stayed blocked in await_connect after stop"
+    );
+    assert_eq!(reader.join().unwrap(), None);
+}
+
+/// Regression: `stop` must not hang forever joining a worker that survived
+/// the teardown; after `STOP_TIMEOUT` it detaches the worker and returns.
+#[test]
+fn stop_detaches_unresponsive_worker_after_deadline() {
+    let _guard = acquire();
+    let instance = unique_instance("stuck");
+    start_instance(&instance, "10.126.126.1");
+    let forwarder = start_forwarder(
+        &instance,
+        SocketAddrV4::new(Ipv4Addr::new(10, 126, 126, 99), 22),
+        0,
+    )
+    .unwrap();
+    lock(&forwarder.workers).push(std::thread::spawn(|| {
+        std::thread::sleep(Duration::from_secs(3600));
+    }));
+
+    let started = Instant::now();
+    forwarder.stop().expect("stop must succeed");
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed >= STOP_TIMEOUT,
+        "stop returned before the worker deadline: {elapsed:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(30),
+        "stop hung on the unresponsive worker: {elapsed:?}"
+    );
+}

--- a/easytier-contrib/easytier-android-jni/src/forwarder_api.rs
+++ b/easytier-contrib/easytier-android-jni/src/forwarder_api.rs
@@ -1,0 +1,122 @@
+//! JNI glue for the local TCP forwarder.
+//!
+//! Keeps a process-wide registry of running forwarders keyed by their bound
+//! loopback port. Each forwarder owns the single native data-plane session of
+//! its instance, so an instance can back at most one forwarder at a time; a
+//! second `start` on the same instance fails with the FFI `ResourceLimit`
+//! error message.
+
+use std::{collections::HashMap, net::SocketAddrV4, sync::Mutex};
+
+use jni::JNIEnv;
+use jni::objects::{JClass, JString};
+use jni::sys::jint;
+use once_cell::sync::Lazy;
+
+use crate::{error::throw_exception, forwarder::TcpForwarder, strings::jstring_to_cstring};
+
+static FORWARDERS: Lazy<Mutex<HashMap<u16, TcpForwarder>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+
+fn registry() -> std::sync::MutexGuard<'static, HashMap<u16, TcpForwarder>> {
+    FORWARDERS.lock().unwrap_or_else(|error| error.into_inner())
+}
+
+/// Java signature:
+/// `EasyTierJNI.startTcpForwarder(instanceName, targetIp, targetPort, listenPort): int`
+///
+/// Returns the bound loopback port (`listenPort` when non-zero, otherwise the
+/// system-assigned port). Returns -1 on failure and throws `RuntimeException`
+/// with the error message when one is available.
+pub(crate) fn start_tcp_forwarder_jni(
+    mut env: JNIEnv,
+    _class: JClass,
+    instance_name: JString,
+    target_ip: JString,
+    target_port: jint,
+    listen_port: jint,
+) -> jint {
+    let instance_name = match jstring_to_cstring(&mut env, &instance_name) {
+        Ok(name) => name,
+        Err(error) => {
+            throw_exception(&mut env, &format!("Invalid instance name: {error}"));
+            return -1;
+        }
+    };
+    let instance_name = match instance_name.into_string() {
+        Ok(name) => name,
+        Err(_) => {
+            throw_exception(&mut env, "Invalid instance name: not valid UTF-8");
+            return -1;
+        }
+    };
+    let target_ip = match jstring_to_cstring(&mut env, &target_ip) {
+        Ok(ip) => ip,
+        Err(error) => {
+            throw_exception(&mut env, &format!("Invalid target IP: {error}"));
+            return -1;
+        }
+    };
+    let target_ip = match target_ip.to_str() {
+        Ok(ip) => ip,
+        Err(_) => {
+            throw_exception(&mut env, "Invalid target IP: not valid UTF-8");
+            return -1;
+        }
+    };
+    let target_ip: std::net::Ipv4Addr = match target_ip.parse() {
+        Ok(ip) => ip,
+        Err(_) => {
+            throw_exception(&mut env, "Invalid target IP: expected an IPv4 address");
+            return -1;
+        }
+    };
+    if !(0..=u16::MAX as jint).contains(&target_port) {
+        throw_exception(&mut env, "Invalid target port");
+        return -1;
+    }
+    if !(0..=u16::MAX as jint).contains(&listen_port) {
+        throw_exception(&mut env, "Invalid listen port");
+        return -1;
+    }
+    let target = SocketAddrV4::new(target_ip, target_port as u16);
+
+    let forwarder = match TcpForwarder::start(instance_name, target, listen_port as u16) {
+        Ok(forwarder) => forwarder,
+        Err(error) => {
+            throw_exception(&mut env, &error.to_string());
+            return -1;
+        }
+    };
+    let local_port = forwarder.local_port;
+    // A stale forwarder still owning this port (e.g. the OS reassigned it) is
+    // stopped here, releasing the port for the new owner. Remove it before
+    // inserting so its `stop` (which joins threads) runs outside the registry
+    // lock and cannot block other JNI registry calls.
+    let stale = registry().remove(&local_port);
+    registry().insert(local_port, forwarder);
+    drop(stale);
+    local_port as jint
+}
+
+/// Java signature:
+/// `EasyTierJNI.stopTcpForwarder(localPort): int`
+///
+/// Stops the forwarder bound to `localPort`. Returns 0 on success or when no
+/// such forwarder exists, -1 on failure.
+pub(crate) fn stop_tcp_forwarder_jni(mut env: JNIEnv, _class: JClass, local_port: jint) -> jint {
+    if !(0..=u16::MAX as jint).contains(&local_port) {
+        throw_exception(&mut env, "Invalid local port");
+        return -1;
+    }
+    let forwarder = registry().remove(&(local_port as u16));
+    let Some(forwarder) = forwarder else {
+        return 0;
+    };
+    match forwarder.stop() {
+        Ok(()) => 0,
+        Err(error) => {
+            throw_exception(&mut env, &format!("failed to stop tcp forwarder: {error}"));
+            -1
+        }
+    }
+}

--- a/easytier-contrib/easytier-android-jni/src/lib.rs
+++ b/easytier-contrib/easytier-android-jni/src/lib.rs
@@ -22,9 +22,17 @@
 //! Error API:
 //! - `getLastError()`: return the latest FFI/JNI error string for the calling thread.
 //!
+//! TCP forwarder APIs:
+//! - `startTcpForwarder(instanceName, targetIp, targetPort, listenPort)`: listen
+//!   on `127.0.0.1:listenPort` and relay each connection to `targetIp:targetPort`
+//!   through the instance's data plane.
+//! - `stopTcpForwarder(localPort)`: stop the forwarder bound to `localPort`.
+//!
 mod callback;
 mod config_server_api;
 mod error;
+mod forwarder;
+mod forwarder_api;
 mod json_rpc_api;
 mod logger;
 mod network_api;
@@ -184,6 +192,52 @@ pub extern "system" fn Java_com_easytier_jni_EasyTierJNI_getLastError(
     class: JClass,
 ) -> jstring {
     error::get_last_error_jni(env, class)
+}
+
+/// Start a loopback TCP forwarder into the virtual network.
+///
+/// Java signature:
+/// `EasyTierJNI.startTcpForwarder(instanceName, targetIp, targetPort, listenPort): int`
+///
+/// Listens on `127.0.0.1:listenPort` (0 = auto-assign) and relays every
+/// connection to `targetIp:targetPort` through the data plane of the instance
+/// named `instanceName`. Returns the bound local port; on failure returns -1
+/// and throws `RuntimeException` with the error message when one is available.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_com_easytier_jni_EasyTierJNI_startTcpForwarder(
+    env: JNIEnv,
+    class: JClass,
+    instance_name: JString,
+    target_ip: JString,
+    target_port: jint,
+    listen_port: jint,
+) -> jint {
+    logger::init();
+    forwarder_api::start_tcp_forwarder_jni(
+        env,
+        class,
+        instance_name,
+        target_ip,
+        target_port,
+        listen_port,
+    )
+}
+
+/// Stop a loopback TCP forwarder.
+///
+/// Java signature:
+/// `EasyTierJNI.stopTcpForwarder(localPort): int`
+///
+/// Stops the forwarder bound to `localPort`. Returns 0 on success or when no
+/// such forwarder exists; on failure returns -1 and throws `RuntimeException`.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_com_easytier_jni_EasyTierJNI_stopTcpForwarder(
+    env: JNIEnv,
+    class: JClass,
+    local_port: jint,
+) -> jint {
+    logger::init();
+    forwarder_api::stop_tcp_forwarder_jni(env, class, local_port)
 }
 
 /// Start the managed config-server client.

--- a/easytier-contrib/easytier-android-jni/src/strings.rs
+++ b/easytier-contrib/easytier-android-jni/src/strings.rs
@@ -21,3 +21,9 @@ pub(crate) fn optional_jstring_to_cstring(
 
     jstring_to_cstring(env, jstr).map(Some)
 }
+
+/// Build a NUL-terminated C string from a Rust string for FFI calls.
+pub(crate) fn cstring_for(value: &str, what: &str) -> std::io::Result<CString> {
+    CString::new(value)
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, format!("{what} contains a null byte")))
+}

--- a/easytier-contrib/easytier-ios/Cargo.toml
+++ b/easytier-contrib/easytier-ios/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "easytier-ios"
+version = "0.1.0"
+edition.workspace = true
+
+[lib]
+crate-type = ["staticlib", "rlib"]
+
+[dependencies]
+once_cell = "1.18.0"
+libc = "0.2"
+serde_json = "1.0"
+log = "0.4"
+easytier-ffi = { path = "../easytier-ffi", default-features = false, features = [
+    "c-abi",
+    "ffi-dataplane",
+] }
+
+[dev-dependencies]
+uuid = "1"

--- a/easytier-contrib/easytier-ios/build-xcframework.sh
+++ b/easytier-contrib/easytier-ios/build-xcframework.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Build easytier-ios as an XCFramework for the Flutter iOS client.
+#
+# This script only runs on macOS: it needs the Apple SDK (aarch64-apple-ios*,
+# x86_64-apple-ios targets) plus `lipo` and `xcodebuild`. Run it from the
+# EasyTier repository root or from this crate directory.
+#
+#   rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+#   ./build-xcframework.sh
+#
+# Output: ./xcframework/easytier_ios.xcframework with
+#   - ios-arm64          (device)
+#   - ios-arm64_x86_64-simulator (Apple Silicon + Intel simulator)
+
+set -euo pipefail
+
+CRATE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# The crate lives in a workspace; build artifacts land in the workspace root
+# target directory regardless of the current directory.
+WORKSPACE_ROOT="$(cd "${CRATE_DIR}/../.." && pwd)"
+TARGET_DIR="${WORKSPACE_ROOT}/target"
+OUT_DIR="${CRATE_DIR}/xcframework"
+HEADERS_DIR="${OUT_DIR}/headers"
+
+if [[ "$(uname)" != "Darwin" ]]; then
+    echo "error: build-xcframework.sh must run on macOS (needs Apple SDK, lipo, xcodebuild)" >&2
+    exit 1
+fi
+
+cd "${WORKSPACE_ROOT}"
+
+# The Rust iOS targets emit a `___chkstk_darwin` stack-probe call but do not
+# link the compiler-rt archive that provides it. Point the linker at the
+# matching device or simulator archive shipped inside the Xcode toolchain.
+CLANG_BIN="$(xcrun --find clang)"          # .../Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
+TOOLCHAIN_USR="${CLANG_BIN%/bin/clang}"    # .../XcodeDefault.xctoolchain/usr
+CLANG_RT_DIR="$(cd "${TOOLCHAIN_USR}/lib/clang" && cd "$(ls | sort -V | tail -1)/lib/darwin" && pwd)"
+CLANG_RT_RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-L${CLANG_RT_DIR}"
+echo "==> using libclang_rt from ${CLANG_RT_DIR}"
+
+# kcp-sys's bindgen rejects the `-sim` in the aarch64-apple-ios-sim target
+# triple; give bindgen an explicit simulator target so the C bindings build.
+SIM_SDK="$(xcrun --sdk iphonesimulator --show-sdk-path)"
+
+echo "==> building aarch64-apple-ios (device)"
+RUSTFLAGS="${CLANG_RT_RUSTFLAGS} -C link-arg=-lclang_rt.ios" \
+    cargo build -p easytier-ios --release --target aarch64-apple-ios
+
+echo "==> building aarch64-apple-ios-sim (Apple Silicon simulator)"
+BINDGEN_EXTRA_CLANG_ARGS="--target=arm64-apple-ios17.0-simulator -isysroot ${SIM_SDK}" \
+    RUSTFLAGS="${CLANG_RT_RUSTFLAGS} -C link-arg=-lclang_rt.iossim" \
+    cargo build -p easytier-ios --release --target aarch64-apple-ios-sim
+
+echo "==> building x86_64-apple-ios (Intel simulator)"
+BINDGEN_EXTRA_CLANG_ARGS="--target=x86_64-apple-ios17.0-simulator -isysroot ${SIM_SDK}" \
+    RUSTFLAGS="${CLANG_RT_RUSTFLAGS} -C link-arg=-lclang_rt.iossim" \
+    cargo build -p easytier-ios --release --target x86_64-apple-ios
+
+rm -rf "${OUT_DIR}"
+mkdir -p "${HEADERS_DIR}" "${OUT_DIR}/sim"
+cp "${CRATE_DIR}/easytier-ios.h" "${HEADERS_DIR}/"
+
+echo "==> lipo: merge simulator slices"
+lipo -create \
+    "${TARGET_DIR}/aarch64-apple-ios-sim/release/libeasytier_ios.a" \
+    "${TARGET_DIR}/x86_64-apple-ios/release/libeasytier_ios.a" \
+    -output "${OUT_DIR}/sim/libeasytier_ios.a"
+
+echo "==> xcodebuild: create xcframework"
+xcodebuild -create-xcframework \
+    -library "${TARGET_DIR}/aarch64-apple-ios/release/libeasytier_ios.a" \
+    -headers "${HEADERS_DIR}" \
+    -library "${OUT_DIR}/sim/libeasytier_ios.a" \
+    -headers "${HEADERS_DIR}" \
+    -output "${OUT_DIR}/easytier_ios.xcframework"
+
+rm -rf "${OUT_DIR}/sim" "${HEADERS_DIR}"
+
+echo "==> done: ${OUT_DIR}/easytier_ios.xcframework"

--- a/easytier-contrib/easytier-ios/easytier-ios.h
+++ b/easytier-contrib/easytier-ios/easytier-ios.h
@@ -1,0 +1,123 @@
+/**
+ * @file easytier-ios.h
+ * @brief iOS-facing C ABI for EasyTier.
+ *
+ * This library embeds EasyTier into an iOS app without a TUN device or
+ * NEPacketTunnel: it manages EasyTier instances and forwards local loopback
+ * TCP connections into the virtual network through the data plane.
+ *
+ * Error handling: functions returning `int` return 0 on success (or a
+ * non-negative value such as a bound port) and -1 on failure. Call
+ * easytier_ios_last_error() on the same thread to retrieve details.
+ *
+ * Threading: all functions are safe to call from any thread. The last-error
+ * buffer is thread-local, so query it on the thread that received the
+ * failure.
+ */
+
+#ifndef EASYTIER_IOS_H
+#define EASYTIER_IOS_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Start one EasyTier network instance from a TOML config string.
+ *
+ * The config's `instance_name` must be unique among instances started
+ * through this library. The instance returns before its data-plane runtime
+ * is fully up; starting a forwarder right away may briefly fail and should
+ * be retried by the caller.
+ *
+ * @param toml Non-null pointer to a NUL-terminated UTF-8 TOML config string.
+ * @return 0 on success, -1 on failure.
+ */
+int easytier_ios_run_instance(const char *toml);
+
+/**
+ * @brief Keep the named instances and stop all others.
+ *
+ * @param names_json Null, empty, or a NUL-terminated JSON array of instance
+ *                   name strings. Null / empty / `[]` stops every running
+ *                   instance.
+ * @return 0 on success, -1 on failure.
+ */
+int easytier_ios_retain_instances(const char *names_json);
+
+/**
+ * @brief Collect running instance information as a JSON object.
+ *
+ * The result maps each instance name to its running info JSON object.
+ *
+ * @param max_length Maximum number of instances to report.
+ * @return A newly allocated NUL-terminated JSON string on success, NULL on
+ *         failure.
+ *
+ * @ownership The caller owns the returned string and must release it with
+ *            easytier_ios_free_string().
+ */
+char *easytier_ios_collect_network_infos(int max_length);
+
+/**
+ * @brief Start a loopback TCP forwarder into the virtual network.
+ *
+ * Listens on 127.0.0.1:`listen_port` (0 = auto-assign) and relays every
+ * accepted connection to `target_ip`:`target_port` through the data plane
+ * of the instance named `inst_name`.
+ *
+ * One instance admits a single native data-plane session, so only one
+ * forwarder may be active per instance; starting a second one fails.
+ *
+ * @param inst_name   Non-null NUL-terminated instance name.
+ * @param target_ip   Non-null NUL-terminated IPv4 address (virtual network).
+ * @param target_port Target port in the virtual network.
+ * @param listen_port Loopback port to bind; 0 picks a free port.
+ * @return The bound local port (> 0) on success, -1 on failure.
+ */
+int easytier_ios_start_tcp_forwarder(const char *inst_name,
+                                     const char *target_ip,
+                                     uint16_t target_port,
+                                     uint16_t listen_port);
+
+/**
+ * @brief Stop the TCP forwarder bound to `local_port`.
+ *
+ * @param local_port Port previously returned by
+ *                   easytier_ios_start_tcp_forwarder().
+ * @return 0 on success, -1 when no forwarder is registered on that port.
+ */
+int easytier_ios_stop_tcp_forwarder(int local_port);
+
+/**
+ * @brief Return the last error message on this thread.
+ *
+ * Combines forwarder-side errors recorded by this library with the
+ * easytier-ffi last FFI error.
+ *
+ * @return A newly allocated NUL-terminated string, or NULL when there is no
+ *         recorded error.
+ *
+ * @ownership The caller owns the returned string and must release it with
+ *            easytier_ios_free_string().
+ */
+char *easytier_ios_last_error(void);
+
+/**
+ * @brief Release a string returned by this library.
+ *
+ * Use this for strings returned by easytier_ios_collect_network_infos() and
+ * easytier_ios_last_error(). Passing NULL is a no-op. The string must not
+ * be used after this call.
+ *
+ * @param s NULL, or a string previously returned by this library.
+ */
+void easytier_ios_free_string(char *s);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EASYTIER_IOS_H */

--- a/easytier-contrib/easytier-ios/src/error.rs
+++ b/easytier-contrib/easytier-ios/src/error.rs
@@ -1,0 +1,77 @@
+use std::{
+    cell::RefCell,
+    ffi::{CStr, CString, c_char},
+    ptr,
+};
+
+thread_local! {
+    // Thread-local last error for the easytier-ios C ABI. `easytier_ios_*`
+    // wrappers record forwarder-side failures here (instance APIs record
+    // theirs in easytier-ffi's own buffer); `last_error` merges both layers.
+    static LAST_ERROR: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
+}
+
+pub(crate) fn set_error(message: &str) {
+    LAST_ERROR.with(|cell| {
+        let mut buffer = cell.borrow_mut();
+        buffer.clear();
+        buffer.extend_from_slice(message.as_bytes());
+    });
+}
+
+pub(crate) fn clear_error() {
+    LAST_ERROR.with(|cell| cell.borrow_mut().clear());
+}
+
+fn thread_local_error() -> Option<String> {
+    LAST_ERROR.with(|cell| {
+        let buffer = cell.borrow();
+        if buffer.is_empty() {
+            None
+        } else {
+            Some(String::from_utf8_lossy(&buffer).into_owned())
+        }
+    })
+}
+
+fn ffi_error() -> Option<String> {
+    unsafe {
+        let mut error_ptr: *const c_char = ptr::null();
+        easytier_ffi::get_error_msg(&mut error_ptr);
+        if error_ptr.is_null() {
+            None
+        } else {
+            let error_str = CStr::from_ptr(error_ptr).to_string_lossy().into_owned();
+            easytier_ffi::free_string(error_ptr);
+            Some(error_str)
+        }
+    }
+}
+
+/// Merge both error layers: the iOS wrapper's own thread-local buffer and
+/// easytier-ffi's last FFI error.
+pub(crate) fn last_error() -> Option<String> {
+    match (ffi_error(), thread_local_error()) {
+        (Some(ffi_error), Some(local_error)) => Some(format!("{local_error}; {ffi_error}")),
+        (Some(ffi_error), None) => Some(ffi_error),
+        (None, Some(local_error)) => Some(local_error),
+        (None, None) => None,
+    }
+}
+
+/// Alias kept under the android-jni name so the shared forwarder test suite
+/// stays byte-identical across both crates.
+#[cfg(test)]
+pub(crate) fn get_last_error() -> Option<String> {
+    last_error()
+}
+
+/// Copy the merged last error into a newly allocated C string (null when
+/// there is no error). The caller owns the result and must release it with
+/// `easytier_ios_free_string`.
+pub(crate) fn last_error_raw() -> *mut c_char {
+    match last_error().and_then(|message| CString::new(message).ok()) {
+        Some(message) => message.into_raw(),
+        None => ptr::null_mut(),
+    }
+}

--- a/easytier-contrib/easytier-ios/src/forwarder.rs
+++ b/easytier-contrib/easytier-ios/src/forwarder.rs
@@ -1,0 +1,1187 @@
+//! Local TCP forwarder over the EasyTier data-plane FFI.
+//!
+//! A `TcpForwarder` listens on `127.0.0.1:<local_port>` and relays every
+//! accepted connection to a fixed virtual-network `target` through the
+//! data-plane C ABI exported by `easytier-ffi`. It is the transport layer used
+//! by apps that embed EasyTier without a TUN/VpnService: local clients simply
+//! dial a loopback port.
+//!
+//! ## Session concurrency model (verified against easytier-ffi)
+//!
+//! `easytier-ffi/src/data_plane/session.rs::open` rejects a second native
+//! session for the same instance with `ResourceLimit` ("instance already has an
+//! open native data-plane session"), and `DATA_PLANE_ABI.md` states "One native
+//! session may be open for an EasyTier instance at a time". Per-connection
+//! sessions are therefore impossible.
+//!
+//! Accordingly, one forwarder owns exactly one session for its instance and
+//! multiplexes all connections over it: a single event loop drives
+//! `data_plane_completion_wait` / `data_plane_completion_drain` and dispatches
+//! completions by `operation_id`. The core session
+//! (`easytier-core/src/gateway/dataplane/session.rs`) admits concurrent
+//! operations per stream — reads and writes use independent deadline and
+//! cancellation plumbing — and the default limits (4096 resources, 4096
+//! outstanding operations, 64 MiB retained results) leave ample headroom. A JNI
+//! layer may run several forwarders as long as they use distinct instances;
+//! starting a second forwarder on the same instance fails with `ResourceLimit`.
+//!
+//! Every inbound connection is served by a pair of blocking std::threads that
+//! exchange chunks with the event loop through `std::sync::mpsc` channels.
+//! Local reads stay in 64 KiB chunks and the event loop keeps exactly one
+//! remote read per connection outstanding, so each connection retains at most
+//! one read payload and one pending write in the session. No tokio runtime is
+//! involved in the forwarding path.
+
+use std::{
+    collections::HashMap,
+    io::{self, Read, Write},
+    net::{Ipv4Addr, Shutdown, SocketAddrV4, TcpListener, TcpStream},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        mpsc,
+    },
+    thread::JoinHandle,
+    time::{Duration, Instant},
+};
+
+use easytier_ffi::{
+    DataPlaneCompletion, DataPlaneSocketAddr, data_plane_completion_drain,
+    data_plane_completion_wait, data_plane_operation_free, data_plane_resource_close,
+    data_plane_session_close, data_plane_session_open, data_plane_tcp_connect_result_take,
+    data_plane_tcp_connect_submit, data_plane_tcp_read_result_take, data_plane_tcp_read_submit,
+    data_plane_tcp_write_result_take, data_plane_tcp_write_submit,
+};
+
+use crate::strings::cstring_for;
+
+/// Operation kinds from the data-plane ABI.
+const OP_TCP_CONNECT: u16 = 1;
+const OP_TCP_READ: u16 = 4;
+const OP_TCP_WRITE: u16 = 5;
+
+/// `data_plane_tcp_read_submit` chunk size.
+const READ_CHUNK: u32 = 64 * 1024;
+
+/// Timeout for the data-plane TCP connect towards the forward target.
+const CONNECT_TIMEOUT_MS: u64 = 10_000;
+
+/// Maximum time `stop()` waits for one worker thread to exit.
+const STOP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Safety net per blocking local write. When it fires, the local socket write
+/// fails and the connection is torn down; a broken remote side unblocks the
+/// writer earlier via the `Broken` flag.
+const LOCAL_WRITE_TIMEOUT: Duration = Duration::from_secs(60);
+
+fn failed(message: impl Into<String>) -> io::Error {
+    io::Error::other(message.into())
+}
+
+fn spawn_failed(error: io::Error) -> io::Error {
+    failed(format!("failed to spawn forwarder thread: {error}"))
+}
+
+fn broken_pipe(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::BrokenPipe, message.into())
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(|error| error.into_inner())
+}
+
+/// Observed by both local worker threads of a connection: the remote side is
+/// torn down (or the forwarder is stopping) and the workers must exit.
+#[derive(Clone)]
+struct Broken(Arc<AtomicBool>);
+
+impl Broken {
+    fn new() -> Self {
+        Self(Arc::new(AtomicBool::new(false)))
+    }
+
+    fn break_it(&self) {
+        self.0.store(true, Ordering::Release);
+    }
+
+    fn is_broken(&self) -> bool {
+        self.0.load(Ordering::Acquire)
+    }
+}
+
+/// Command issued by connection threads towards the event loop.
+enum Command {
+    /// Inbound data to forward; the reply carries the completed write result.
+    Write {
+        connection: u64,
+        data: Vec<u8>,
+        reply: mpsc::Sender<io::Result<()>>,
+    },
+    /// One local worker exited; the stream is released once both are done.
+    ConnectionDone { connection: u64 },
+}
+
+/// Result of a completed remote read, handed to the owning local writer
+/// through its per-connection channel.
+struct ReadOutcome {
+    data: Vec<u8>,
+    eof: bool,
+}
+
+/// Per-connection channel state shared between the acceptor, the event loop
+/// and `stop`. `read_taken` is the acknowledgement the writer sends after
+/// taking a result; the event loop waits on it before submitting the next
+/// remote read for the connection. `socket` lets `stop` shut the local socket
+/// down so a blocked reader/writer wakes immediately.
+struct ConnectionHandles {
+    broken: Broken,
+    read_results: mpsc::Sender<ReadOutcome>,
+    read_taken: Mutex<Option<mpsc::Receiver<()>>>,
+    socket: TcpStream,
+}
+
+impl ConnectionHandles {
+    fn pair(
+        broken: Broken,
+        socket: TcpStream,
+    ) -> (Arc<Self>, mpsc::Receiver<ReadOutcome>, mpsc::Sender<()>) {
+        let (results_tx, results_rx) = mpsc::channel();
+        let (taken_tx, taken_rx) = mpsc::channel();
+        (
+            Arc::new(Self {
+                broken,
+                read_results: results_tx,
+                read_taken: Mutex::new(Some(taken_rx)),
+                socket,
+            }),
+            results_rx,
+            taken_tx,
+        )
+    }
+}
+
+/// A registered connect attempt: the event loop resolves the attempt id to the
+/// per-connection reply channel once the FFI-assigned operation id arrives.
+struct ConnectAttempt {
+    reply: mpsc::Sender<io::Result<u64>>,
+    operation: Option<u64>,
+}
+
+/// Connect attempts, keyed by attempt id (== connection id).
+type PendingConnects = Arc<Mutex<HashMap<u64, ConnectAttempt>>>;
+
+struct SharedSession {
+    handle: u64,
+    connects: PendingConnects,
+    /// FFI operation id -> attempt id, for connect completions.
+    connect_ops: Arc<Mutex<HashMap<u64, u64>>>,
+}
+
+impl SharedSession {
+    fn open(instance_name: &str) -> io::Result<Arc<Self>> {
+        let name = cstring_for(instance_name, "instance name")?;
+        let mut handle = 0u64;
+        // SAFETY: `name` is a valid NUL-terminated string and `handle` points
+        // to writable storage for one `u64`.
+        let result = unsafe { data_plane_session_open(name.as_ptr(), &mut handle) };
+        if result != 0 || handle == 0 {
+            return Err(failed(format!(
+                "failed to open data-plane session for instance \"{instance_name}\" (code {result})"
+            )));
+        }
+        Ok(Arc::new(Self {
+            handle,
+            connects: PendingConnects::default(),
+            connect_ops: Arc::new(Mutex::new(HashMap::new())),
+        }))
+    }
+
+    fn submit_connect(&self, attempt: u64, target: SocketAddrV4) -> io::Result<u64> {
+        let mut address = [0u8; 16];
+        address[..4].copy_from_slice(&target.ip().octets());
+        let peer = DataPlaneSocketAddr {
+            family: 4,
+            port: target.port(),
+            address,
+        };
+        let mut operation = 0u64;
+        // Hold `connect_ops` across the FFI submit and the registration: the
+        // session may complete the connect as soon as the submit returns, and
+        // `complete_connect` resolves completions under this same lock, so the
+        // operation -> attempt mapping is always registered before the
+        // completion can be dispatched.
+        let mut connect_ops = lock(&self.connect_ops);
+        // SAFETY: `peer` is a plain value and `operation` points to writable
+        // storage for one `u64`.
+        let result = unsafe {
+            data_plane_tcp_connect_submit(self.handle, peer, CONNECT_TIMEOUT_MS, &mut operation)
+        };
+        if result != 0 {
+            lock(&self.connects).remove(&attempt);
+            return Err(failed(format!(
+                "data-plane TCP connect submit failed (code {result})"
+            )));
+        }
+        // The completion arrives keyed by the FFI operation id, which the
+        // session allocates independently of our attempt/connection ids.
+        if let Some(entry) = lock(&self.connects).get_mut(&attempt) {
+            entry.operation = Some(operation);
+        }
+        connect_ops.insert(operation, attempt);
+        Ok(operation)
+    }
+
+    /// Idempotent close; safe to call from `stop` while the event loop blocks
+    /// in `completion_wait`, which then wakes up with no completions.
+    fn close(&self) {
+        data_plane_session_close(self.handle);
+    }
+}
+
+impl Drop for SharedSession {
+    fn drop(&mut self) {
+        data_plane_session_close(self.handle);
+    }
+}
+
+struct ConnectionState {
+    handles: Arc<ConnectionHandles>,
+    /// Stream handle; set to 0 after `data_plane_resource_close`.
+    stream: u64,
+    /// Number of submitted-but-undrained operations referencing `stream`.
+    in_flight: u16,
+    /// Local workers that have not exited yet.
+    live_workers: u8,
+    /// Expected length and reply for the outstanding inbound write.
+    write_reply: Option<(u32, mpsc::Sender<io::Result<()>>)>,
+    /// A remote read is outstanding.
+    read_pending: bool,
+}
+
+impl ConnectionState {
+    fn new(handles: Arc<ConnectionHandles>, stream: u64) -> Self {
+        Self {
+            handles,
+            stream,
+            in_flight: 0,
+            live_workers: 2,
+            write_reply: None,
+            read_pending: false,
+        }
+    }
+}
+
+/// All live connections (pending and established), shared with `stop` so it
+/// can wake blocked workers without waiting for the event loop.
+type LiveConnections = Arc<Mutex<HashMap<u64, Arc<ConnectionHandles>>>>;
+
+enum Wait {
+    Ready,
+    TimedOut,
+    Closed,
+}
+
+/// Blocking event loop driving one shared data-plane session.
+struct EventLoop {
+    session: Arc<SharedSession>,
+    commands: mpsc::Receiver<Command>,
+    stopped: Arc<AtomicBool>,
+    connections: HashMap<u64, ConnectionState>,
+    /// operation_id -> connection for in-flight reads and writes.
+    operations: HashMap<u64, u64>,
+    /// Connections whose connect completion has not arrived yet.
+    pending_handles: Arc<Mutex<HashMap<u64, Arc<ConnectionHandles>>>>,
+    /// Receives connection ids whose writer acknowledged a read result.
+    pump_commands: mpsc::Receiver<u64>,
+    /// Live connections shared with `stop` for worker wakeup.
+    live: LiveConnections,
+}
+
+impl EventLoop {
+    fn run(mut self) {
+        while !self.stopped.load(Ordering::Acquire) {
+            // Apply all queued commands before blocking again so a wait never
+            // parks while work is already available. The wait below uses a
+            // short (5ms) timeout because the data-plane ABI has no self-wakeup
+            // for newly queued write/read commands; this bounds the added
+            // latency of an idle connection's first local→remote write.
+            while let Ok(command) = self.commands.try_recv() {
+                self.handle_command(command);
+            }
+            while let Ok(connection) = self.pump_commands.try_recv() {
+                self.submit_read(connection);
+            }
+            match self.wait() {
+                Wait::Ready => self.drain(),
+                Wait::TimedOut => continue,
+                Wait::Closed => break,
+            }
+        }
+        self.fail_all();
+    }
+
+    fn wait(&self) -> Wait {
+        if self.stopped.load(Ordering::Acquire) {
+            return Wait::TimedOut;
+        }
+        let result = data_plane_completion_wait(self.session.handle, 5);
+        match result {
+            1 => Wait::Ready,
+            0 => Wait::TimedOut,
+            _ => {
+                Wait::Closed
+            }
+        }
+    }
+
+    fn handle_command(&mut self, command: Command) {
+        match command {
+            Command::Write {
+                connection,
+                data,
+                reply,
+            } => self.submit_write(connection, data, reply),
+            Command::ConnectionDone { connection } => {
+                if let Some(state) = self.connections.get_mut(&connection) {
+                    state.live_workers = state.live_workers.saturating_sub(1);
+                    if state.live_workers == 0 {
+                        state.handles.broken.break_it();
+                    }
+                }
+                self.maybe_remove(connection);
+            }
+        }
+    }
+
+    fn submit_read(&mut self, connection: u64) {
+        let Some(state) = self.connections.get(&connection) else {
+            return;
+        };
+        if state.stream == 0 || state.read_pending || state.handles.broken.is_broken() {
+            return;
+        }
+        let stream = state.stream;
+        let mut operation = 0u64;
+        // SAFETY: `operation` points to writable storage for one `u64`.
+        let result = unsafe {
+            data_plane_tcp_read_submit(self.session.handle, stream, READ_CHUNK, &mut operation)
+        };
+        if result != 0 {
+            self.fail_stream(
+                connection,
+                &format!("data-plane read submit failed (code {result})"),
+            );
+            return;
+        }
+        let state = self
+            .connections
+            .get_mut(&connection)
+            .expect("connection state checked above");
+        state.in_flight += 1;
+        state.read_pending = true;
+        self.operations.insert(operation, connection);
+    }
+
+    fn submit_write(&mut self, connection: u64, data: Vec<u8>, reply: mpsc::Sender<io::Result<()>>) {
+        let Some(state) = self.connections.get(&connection) else {
+            let _ = reply.send(Err(broken_pipe("tcp forwarder connection is closed")));
+            return;
+        };
+        if state.handles.broken.is_broken() || state.stream == 0 {
+            let _ = reply.send(Err(broken_pipe("remote stream is closed")));
+            return;
+        }
+        let stream = state.stream;
+        let data_len = data.len() as u32;
+        let mut operation = 0u64;
+        // SAFETY: the ABI copies `data` before returning and `operation`
+        // points to writable storage for one `u64`.
+        let result = unsafe {
+            data_plane_tcp_write_submit(
+                self.session.handle,
+                stream,
+                data.as_ptr(),
+                data_len,
+                &mut operation,
+            )
+        };
+        if result != 0 {
+            let error = failed(format!("data-plane write submit failed (code {result})"));
+            self.fail_stream(connection, &error.to_string());
+            let _ = reply.send(Err(error));
+            return;
+        }
+        let state = self
+            .connections
+            .get_mut(&connection)
+            .expect("connection state checked above");
+        state.in_flight += 1;
+        state.write_reply = Some((data_len, reply));
+        self.operations.insert(operation, connection);
+    }
+
+    fn drain(&mut self) {
+        let mut completions = [DataPlaneCompletion::default(); 64];
+        // SAFETY: `completions` is writable storage for 64 descriptors.
+        let count = unsafe {
+            data_plane_completion_drain(
+                self.session.handle,
+                completions.as_mut_ptr(),
+                completions.len() as u32,
+            )
+        };
+        if count < 0 {
+            self.fail_all();
+            return;
+        }
+        for completion in completions.iter().take(count as usize) {
+            self.dispatch(completion);
+        }
+    }
+
+    fn dispatch(&mut self, completion: &DataPlaneCompletion) {
+        match completion.operation_kind {
+            OP_TCP_CONNECT => self.complete_connect(completion),
+            OP_TCP_READ | OP_TCP_WRITE => {
+                let Some(connection) = self.operations.remove(&completion.operation_id) else {
+                    // Cancelled or superseded operation; release its result.
+                    data_plane_operation_free(self.session.handle, completion.operation_id);
+                    return;
+                };
+                if completion.operation_kind == OP_TCP_READ {
+                    self.complete_read(connection, completion);
+                } else {
+                    self.complete_write(connection, completion);
+                }
+            }
+            _ => {
+                data_plane_operation_free(self.session.handle, completion.operation_id);
+            }
+        }
+    }
+
+    fn complete_connect(&mut self, completion: &DataPlaneCompletion) {
+        let operation = completion.operation_id;
+        // Resolve the FFI operation id back to the attempt/connection id used
+        // when the attempt was registered.
+        let Some(connection) = lock(&self.session.connect_ops).remove(&operation) else {
+            data_plane_operation_free(self.session.handle, operation);
+            return;
+        };
+        let attempt = lock(&self.session.connects).remove(&connection);
+        let Some(attempt) = attempt else {
+            data_plane_operation_free(self.session.handle, operation);
+            return;
+        };
+        let reply = attempt.reply;
+        let Some(handles) = lock(&self.pending_handles).remove(&connection) else {
+            // The acceptor was stopped mid-connect; release the operation.
+            data_plane_operation_free(self.session.handle, operation);
+            return;
+        };
+        if completion.status != 0 {
+            data_plane_operation_free(self.session.handle, operation);
+            handles.broken.break_it();
+            let _ = reply.send(Err(failed(format!(
+                "data-plane connect failed (status {})",
+                completion.status
+            ))));
+            return;
+        }
+        let mut stream = 0u64;
+        let mut local_addr = DataPlaneSocketAddr::default();
+        let mut peer_addr = DataPlaneSocketAddr::default();
+        // SAFETY: all output pointers reference writable storage of their
+        // respective types and do not overlap.
+        let result = unsafe {
+            data_plane_tcp_connect_result_take(
+                self.session.handle,
+                operation,
+                &mut stream,
+                &mut local_addr,
+                &mut peer_addr,
+            )
+        };
+        if result != 0 || stream == 0 {
+            handles.broken.break_it();
+            let _ = reply.send(Err(failed(format!(
+                "data-plane connect result take failed (code {result})"
+            ))));
+            return;
+        }
+        lock(&self.live).insert(connection, handles.clone());
+        self.connections
+            .insert(connection, ConnectionState::new(handles, stream));
+        let _ = reply.send(Ok(stream));
+        // Kick the remote-to-local pump.
+        self.submit_read(connection);
+    }
+
+    fn complete_read(&mut self, connection: u64, completion: &DataPlaneCompletion) {
+        if let Some(state) = self.connections.get_mut(&connection) {
+            state.in_flight = state.in_flight.saturating_sub(1);
+            state.read_pending = false;
+        }
+        if completion.status != 0 {
+            data_plane_operation_free(self.session.handle, completion.operation_id);
+            self.fail_stream(
+                connection,
+                &format!("data-plane read failed (status {})", completion.status),
+            );
+            self.maybe_remove(connection);
+            return;
+        }
+        let mut buffer = vec![0u8; READ_CHUNK as usize];
+        let mut len = 0u32;
+        let mut eof = false;
+        // SAFETY: `buffer` is writable for `READ_CHUNK` bytes and the scalar
+        // outputs reference writable, non-overlapping storage. The buffer
+        // always satisfies the maximum read size submitted for this session.
+        let result = unsafe {
+            data_plane_tcp_read_result_take(
+                self.session.handle,
+                completion.operation_id,
+                buffer.as_mut_ptr(),
+                buffer.len() as u32,
+                &mut len,
+                &mut eof,
+            )
+        };
+        if result != 0 {
+            self.fail_stream(
+                connection,
+                &format!("data-plane read result take failed (code {result})"),
+            );
+            self.maybe_remove(connection);
+            return;
+        }
+        buffer.truncate(len as usize);
+        let Some(state) = self.connections.get(&connection) else {
+            return;
+        };
+        // Hand the payload to the owning local writer. The writer acknowledges
+        // the take through `read_taken`, which the loop waits on before
+        // submitting the next read for this connection.
+        if state
+            .handles
+            .read_results
+            .send(ReadOutcome { data: buffer, eof })
+            .is_err()
+        {
+            self.fail_stream(connection, "tcp forwarder read result channel closed");
+        }
+        self.maybe_remove(connection);
+    }
+
+    fn complete_write(&mut self, connection: u64, completion: &DataPlaneCompletion) {
+        let mut written = 0u32;
+        let mut result = if completion.status != 0 {
+            data_plane_operation_free(self.session.handle, completion.operation_id);
+            Err(failed(format!(
+                "data-plane write failed (status {})",
+                completion.status
+            )))
+        } else {
+            // SAFETY: `written` points to writable storage for one `u32`.
+            let result = unsafe {
+                data_plane_tcp_write_result_take(
+                    self.session.handle,
+                    completion.operation_id,
+                    &mut written,
+                )
+            };
+            if result != 0 {
+                Err(failed(format!(
+                    "data-plane write result take failed (code {result})"
+                )))
+            } else {
+                Ok(())
+            }
+        };
+        let reply = self.connections.get_mut(&connection).and_then(|state| {
+            state.in_flight = state.in_flight.saturating_sub(1);
+            state.write_reply.take()
+        });
+        if result.is_ok()
+            && let Some((expected, _)) = &reply
+            && written != *expected
+        {
+            result = Err(failed(format!(
+                "data-plane write completed after {written} of {expected} bytes"
+            )));
+        }
+        if result.is_err() {
+            // Reuse `fail_stream` so a writer blocked on the read-result
+            // channel is woken with an EOF sentinel, not just flagged broken.
+            self.fail_stream(connection, "data-plane write failed");
+        }
+        if let Some((_, reply)) = reply {
+            let _ = reply.send(result);
+        }
+        self.maybe_remove(connection);
+    }
+
+    /// Release a connection once both workers exited and no operation still
+    /// references its stream.
+    fn maybe_remove(&mut self, connection: u64) {
+        let (close_stream, remove) = match self.connections.get(&connection) {
+            Some(state) if state.live_workers == 0 && state.in_flight == 0 => {
+                (state.stream != 0, true)
+            }
+            _ => (false, false),
+        };
+        if !remove {
+            return;
+        }
+        let state = self.connections.remove(&connection).expect("checked above");
+        lock(&self.live).remove(&connection);
+        if close_stream {
+            data_plane_resource_close(self.session.handle, state.stream);
+        }
+    }
+
+    /// Mark the remote side of `connection` as torn down and release its
+    /// stream as soon as no in-flight operation references it.
+    fn fail_stream(&mut self, connection: u64, reason: &str) {
+        let write_reply = self.connections.get_mut(&connection).and_then(|state| {
+            state.handles.broken.break_it();
+            // Wake a writer blocked on the read-result channel.
+            let _ = state.handles.read_results.send(ReadOutcome {
+                data: Vec::new(),
+                eof: true,
+            });
+            if state.stream != 0 && state.in_flight == 0 {
+                let stream = state.stream;
+                state.stream = 0;
+                data_plane_resource_close(self.session.handle, stream);
+            }
+            state.write_reply.take()
+        });
+        if let Some((_, reply)) = write_reply {
+            let _ = reply.send(Err(broken_pipe(reason)));
+        }
+    }
+
+    /// Tear down every tracked connection and fail pending connects; used when
+    /// the session dies or the forwarder stops.
+    fn fail_all(&mut self) {
+        for (_, attempt) in lock(&self.session.connects).drain() {
+            let _ = attempt.reply.send(Err(failed("data-plane session closed")));
+        }
+        lock(&self.session.connect_ops).clear();
+        for (_, handles) in lock(&self.pending_handles).drain() {
+            handles.broken.break_it();
+        }
+        lock(&self.live).clear();
+        let connections = std::mem::take(&mut self.connections);
+        for (_, mut state) in connections {
+            state.handles.broken.break_it();
+            // Wake a writer blocked on the read-result channel.
+            let _ = state.handles.read_results.send(ReadOutcome {
+                data: Vec::new(),
+                eof: true,
+            });
+            if state.stream != 0 {
+                data_plane_resource_close(self.session.handle, state.stream);
+            }
+            if let Some((_, reply)) = state.write_reply.take() {
+                let _ = reply.send(Err(broken_pipe("data-plane session is closed")));
+            }
+        }
+        self.operations.clear();
+    }
+}
+
+/// Shared state handed to the accept loop.
+struct Acceptor {
+    target: SocketAddrV4,
+    session: Arc<SharedSession>,
+    commands: mpsc::Sender<Command>,
+    /// Connections accepted but whose connect completion has not arrived yet;
+    /// moved into the event loop's connection table on connect success.
+    pending_handles: Arc<Mutex<HashMap<u64, Arc<ConnectionHandles>>>>,
+    workers: Arc<Mutex<Vec<JoinHandle<()>>>>,
+    next_connection: Arc<AtomicU64>,
+    pump_requests: mpsc::Sender<u64>,
+    stop: Arc<AtomicBool>,
+}
+
+/// A loopback TCP port forwarder bound to one EasyTier instance and target.
+///
+/// `start` spawns all threads; dropping the value (or calling `stop`) closes
+/// the listener, the data-plane session and joins the threads.
+pub struct TcpForwarder {
+    /// Actual bound loopback port.
+    pub local_port: u16,
+    instance_name: String,
+    target: SocketAddrV4,
+    stop: Arc<AtomicBool>,
+    session: Arc<SharedSession>,
+    /// Kept so the event loop's command channel stays alive while stopping.
+    #[allow(dead_code)]
+    commands: mpsc::Sender<Command>,
+    pending_handles: Arc<Mutex<HashMap<u64, Arc<ConnectionHandles>>>>,
+    live: LiveConnections,
+    workers: Arc<Mutex<Vec<JoinHandle<()>>>>,
+    /// Kept so pump threads can always reach the event loop; dropped on `stop`.
+    #[allow(dead_code)]
+    pump_requests: mpsc::Sender<u64>,
+    event_loop: Mutex<Option<JoinHandle<()>>>,
+    acceptor: Mutex<Option<JoinHandle<()>>>,
+    stopped: Mutex<bool>,
+}
+
+impl TcpForwarder {
+    /// Start forwarding `127.0.0.1:listen_port` (0 = auto-assign) to `target`
+    /// through the data plane of the EasyTier instance named `instance_name`.
+    ///
+    /// Succeeds without any peer connectivity; connect failures surface per
+    /// connection. Fails when the instance has no free native data-plane
+    /// session (one per instance, shared by all connections of a forwarder).
+    pub fn start(
+        instance_name: String,
+        target: SocketAddrV4,
+        listen_port: u16,
+    ) -> io::Result<Self> {
+        let session = SharedSession::open(&instance_name)?;
+        let listener = TcpListener::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, listen_port))?;
+        let local_addr = listener.local_addr()?;
+        let local_port = match local_addr {
+            std::net::SocketAddr::V4(addr) => addr.port(),
+            std::net::SocketAddr::V6(_) => unreachable!("bound an IPv4 listener"),
+        };
+        listener.set_nonblocking(true)?;
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let (command_tx, command_rx) = mpsc::channel::<Command>();
+        let (pump_tx, pump_rx) = mpsc::channel::<u64>();
+        let pending_handles: Arc<Mutex<HashMap<u64, Arc<ConnectionHandles>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let live: LiveConnections = Arc::new(Mutex::new(HashMap::new()));
+        let workers: Arc<Mutex<Vec<JoinHandle<()>>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let event_loop = std::thread::Builder::new()
+            .name(format!("tcp-fwd-loop-{local_port}"))
+            .spawn({
+                let session = session.clone();
+                let stop = stop.clone();
+                let pending_handles = pending_handles.clone();
+                let live = live.clone();
+                move || {
+                    EventLoop {
+                        session,
+                        commands: command_rx,
+                        stopped: stop,
+                        connections: HashMap::new(),
+                        operations: HashMap::new(),
+                        pending_handles,
+                        pump_commands: pump_rx,
+                        live,
+                    }
+                    .run();
+                }
+            })
+            .map_err(spawn_failed)?;
+
+        let acceptor = std::thread::Builder::new()
+            .name(format!("tcp-fwd-accept-{local_port}"))
+            .spawn({
+                let acceptor = Acceptor {
+                    target,
+                    session: session.clone(),
+                    commands: command_tx.clone(),
+                    pending_handles: pending_handles.clone(),
+                    workers: workers.clone(),
+                    next_connection: Arc::new(AtomicU64::new(1)),
+                    pump_requests: pump_tx.clone(),
+                    stop: stop.clone(),
+                };
+                move || accept_loop(listener, acceptor)
+            });
+        let acceptor = match acceptor {
+            Ok(acceptor) => acceptor,
+            Err(error) => {
+                stop.store(true, Ordering::Release);
+                session.close();
+                let _ = event_loop.join();
+                return Err(spawn_failed(error));
+            }
+        };
+
+        Ok(Self {
+            local_port,
+            instance_name,
+            target,
+            stop,
+            session,
+            commands: command_tx,
+            pending_handles,
+            live,
+            workers,
+            pump_requests: pump_tx,
+            event_loop: Mutex::new(Some(event_loop)),
+            acceptor: Mutex::new(Some(acceptor)),
+            stopped: Mutex::new(false),
+        })
+    }
+
+    /// Instance this forwarder is bound to.
+    #[allow(dead_code)]
+    pub fn instance_name(&self) -> &str {
+        &self.instance_name
+    }
+
+    /// Virtual-network target of every forwarded connection.
+    #[allow(dead_code)]
+    pub fn target(&self) -> SocketAddrV4 {
+        self.target
+    }
+
+    /// Stop the forwarder: close the listener and session, then join threads.
+    pub fn stop(&self) -> io::Result<()> {
+        {
+            let mut stopped = lock(&self.stopped);
+            if *stopped {
+                return Ok(());
+            }
+            *stopped = true;
+        }
+        self.stop.store(true, Ordering::Release);
+        // Break every connection, wake a blocked writer with an EOF sentinel,
+        // and shut the local socket down so a blocked reader exits too.
+        for (_, handles) in lock(&self.pending_handles).iter() {
+            handles.broken.break_it();
+            let _ = handles.read_results.send(ReadOutcome {
+                data: Vec::new(),
+                eof: true,
+            });
+            let _ = handles.socket.shutdown(Shutdown::Both);
+        }
+        for (_, handles) in lock(&self.live).iter() {
+            handles.broken.break_it();
+            let _ = handles.read_results.send(ReadOutcome {
+                data: Vec::new(),
+                eof: true,
+            });
+            let _ = handles.socket.shutdown(Shutdown::Both);
+        }
+        // Unblock the nonblocking accept loop immediately.
+        let _ = TcpStream::connect(SocketAddrV4::new(Ipv4Addr::LOCALHOST, self.local_port));
+        // Unblock the event loop: closing the session wakes a pending
+        // `completion_wait` and makes every subsequent FFI call fail, so the
+        // loop unwinds and tears the connections down. `close` is idempotent
+        // across the `SharedSession` drop.
+        self.session.close();
+
+        let deadline = Instant::now() + STOP_TIMEOUT;
+        let join = |handle: &Mutex<Option<JoinHandle<()>>>| -> io::Result<()> {
+            let handle = lock(handle).take();
+            if let Some(handle) = handle {
+                if handle.is_finished() {
+                    return handle.join().map_err(|_| failed("forwarder thread panicked"));
+                }
+                while !handle.is_finished() && Instant::now() < deadline {
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+                if handle.is_finished() {
+                    handle.join().map_err(|_| failed("forwarder thread panicked"))?;
+                }
+            }
+            Ok(())
+        };
+        let accept_result = join(&self.acceptor);
+        let loop_result = join(&self.event_loop);
+        // The event loop is gone, so no completion is ever dispatched again.
+        // A connection whose spawn raced `stop` may have registered its
+        // connect attempt after the loop's final `fail_all`; fail such
+        // attempts here so readers blocked in `await_connect` can exit.
+        for (_, attempt) in lock(&self.session.connects).drain() {
+            let _ = attempt.reply.send(Err(failed("tcp forwarder stopped")));
+        }
+        lock(&self.session.connect_ops).clear();
+        for (_, handles) in lock(&self.pending_handles).drain() {
+            handles.broken.break_it();
+            let _ = handles.read_results.send(ReadOutcome {
+                data: Vec::new(),
+                eof: true,
+            });
+            let _ = handles.socket.shutdown(Shutdown::Both);
+        }
+        let workers: Vec<_> = lock(&self.workers).drain(..).collect();
+        // A worker may outlive the teardown (e.g. its connect attempt raced
+        // `stop`); bound the wait like the acceptor/event-loop joins instead
+        // of blocking forever. A worker still alive at the deadline is
+        // detached by dropping its join handle.
+        let deadline = Instant::now() + STOP_TIMEOUT;
+        for handle in workers {
+            while !handle.is_finished() && Instant::now() < deadline {
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            if handle.is_finished() {
+                let _ = handle.join();
+            }
+        }
+        accept_result.and(loop_result)
+    }
+}
+
+impl Drop for TcpForwarder {
+    fn drop(&mut self) {
+        let _ = self.stop();
+    }
+}
+
+impl std::fmt::Debug for TcpForwarder {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("TcpForwarder")
+            .field("local_port", &self.local_port)
+            .field("instance_name", &self.instance_name)
+            .field("target", &self.target)
+            .finish()
+    }
+}
+
+fn accept_loop(listener: TcpListener, acceptor: Acceptor) {
+    while !acceptor.stop.load(Ordering::Acquire) {
+        match listener.accept() {
+            Ok((socket, _)) => {
+                if acceptor.stop.load(Ordering::Acquire) {
+                    return;
+                }
+                if let Err(error) = spawn_connection(socket, &acceptor) {
+                    log::warn!("tcp forwarder failed to spawn connection: {error}");
+                }
+            }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(_) => {
+                if acceptor.stop.load(Ordering::Acquire) {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        }
+    }
+}
+
+/// Spawn the per-connection reader/writer/pump threads and submit the
+/// data-plane connect. The workers wait for the connect outcome before
+/// touching streams.
+fn spawn_connection(socket: TcpStream, acceptor: &Acceptor) -> io::Result<()> {
+    socket.set_nodelay(true).ok();
+    let connection = acceptor.next_connection.fetch_add(1, Ordering::Relaxed);
+    let broken = Broken::new();
+    let handle_socket = socket
+        .try_clone()
+        .map_err(|error| failed(format!("failed to clone connection socket: {error}")))?;
+    let (handles, results_rx, taken_tx) = ConnectionHandles::pair(broken.clone(), handle_socket);
+    let (connect_tx, connect_rx) = mpsc::channel();
+
+    let reader_socket = socket
+        .try_clone()
+        .map_err(|error| failed(format!("failed to clone connection socket: {error}")))?;
+    // Wake the reader periodically so it observes a broken remote side even
+    // while the local client stays silent; the data-plane ABI has no half-close
+    // for the write direction, so this is how teardown reaches a blocked read.
+    reader_socket
+        .set_read_timeout(Some(Duration::from_millis(500)))
+        .ok();
+    let reader = std::thread::Builder::new()
+        .name(format!("tcp-fwd-reader-{connection}"))
+        .spawn({
+            let commands = acceptor.commands.clone();
+            let broken = broken.clone();
+            move || reader_loop(connection, reader_socket, broken, commands, connect_rx)
+        })
+        .map_err(spawn_failed)?;
+    lock(&acceptor.workers).push(reader);
+    let writer = std::thread::Builder::new()
+        .name(format!("tcp-fwd-writer-{connection}"))
+        .spawn({
+            let commands = acceptor.commands.clone();
+            move || writer_loop(connection, socket, broken, commands, results_rx, taken_tx)
+        })
+        .map_err(|error| {
+            stop_connection_workers(&handles);
+            spawn_failed(error)
+        })?;
+    lock(&acceptor.workers).push(writer);
+    let pump = std::thread::Builder::new()
+        .name(format!("tcp-fwd-pump-{connection}"))
+        .spawn({
+            let pump_requests = acceptor.pump_requests.clone();
+            let handles = handles.clone();
+            move || pump_loop(connection, handles, pump_requests)
+        })
+        .map_err(|error| {
+            stop_connection_workers(&handles);
+            spawn_failed(error)
+        })?;
+    lock(&acceptor.workers).push(pump);
+
+    lock(&acceptor.session.connects).insert(
+        connection,
+        ConnectAttempt {
+            reply: connect_tx,
+            operation: None,
+        },
+    );
+    lock(&acceptor.pending_handles).insert(connection, handles.clone());
+    if let Err(error) = acceptor.session.submit_connect(connection, acceptor.target) {
+        lock(&acceptor.pending_handles).remove(&connection);
+        stop_connection_workers(&handles);
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn stop_connection_workers(handles: &ConnectionHandles) {
+    handles.broken.break_it();
+    let _ = handles.read_results.send(ReadOutcome {
+        data: Vec::new(),
+        eof: true,
+    });
+    let _ = handles.socket.shutdown(Shutdown::Both);
+}
+
+/// Per-connection read pump: waits for the writer to acknowledge the previous
+/// read result, then asks the event loop to submit the next remote read.
+/// Blocks without touching the session, so it cannot stall other connections.
+fn pump_loop(
+    connection: u64,
+    handles: Arc<ConnectionHandles>,
+    pump_requests: mpsc::Sender<u64>,
+) {
+    loop {
+        if handles.broken.is_broken() {
+            return;
+        }
+        // Poll with a short sleep instead of a blocking recv: the event loop
+        // only consults the receiver through short try_recv bursts, and a
+        // blocking recv here would hold the mutex forever once no result is
+        // pending, deadlocking `stop`.
+        let acknowledged = {
+            let taken = lock(&handles.read_taken);
+            match taken.as_ref() {
+                Some(taken) => taken.try_recv().is_ok(),
+                None => return,
+            }
+        };
+        if !acknowledged {
+            std::thread::sleep(Duration::from_millis(20));
+            continue;
+        }
+        if handles.broken.is_broken() {
+            return;
+        }
+        if pump_requests.send(connection).is_err() {
+            return;
+        }
+    }
+}
+
+/// Wait for the connect completion; returns the remote stream handle.
+fn await_connect(reply: &mpsc::Receiver<io::Result<u64>>) -> Option<u64> {
+    match reply.recv() {
+        Ok(Ok(stream)) => Some(stream),
+        Ok(Err(error)) => {
+            log::debug!("tcp forwarder connect failed: {error}");
+            None
+        }
+        Err(_) => None,
+    }
+}
+
+/// Local -> remote copy loop.
+fn reader_loop(
+    connection: u64,
+    mut socket: TcpStream,
+    broken: Broken,
+    commands: mpsc::Sender<Command>,
+    connect_reply: mpsc::Receiver<io::Result<u64>>,
+) {
+    if await_connect(&connect_reply).is_none() {
+        let _ = socket.shutdown(Shutdown::Both);
+        let _ = commands.send(Command::ConnectionDone { connection });
+        return;
+    }
+    let mut buffer = [0u8; 16 * 1024];
+    loop {
+        if broken.is_broken() {
+            break;
+        }
+        match socket.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(len) => {
+                let (reply_tx, reply_rx) = mpsc::channel();
+                if commands
+                    .send(Command::Write {
+                        connection,
+                        data: buffer[..len].to_vec(),
+                        reply: reply_tx,
+                    })
+                    .is_err()
+                {
+                    break;
+                }
+                match reply_rx.recv() {
+                    Ok(Ok(())) => {}
+                    Ok(Err(error)) => {
+                        log::debug!("tcp forwarder write failed: {error}");
+                        break;
+                    }
+                    Err(_) => break,
+                }
+            }
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+            Err(error)
+                if error.kind() == io::ErrorKind::WouldBlock
+                    || error.kind() == io::ErrorKind::TimedOut =>
+            {
+                // Read-timeout tick: re-check the broken flag.
+                continue;
+            }
+            Err(_) => break,
+        }
+    }
+    // No more local data; the writer keeps delivering remote data until EOF.
+    let _ = socket.shutdown(Shutdown::Read);
+    let _ = commands.send(Command::ConnectionDone { connection });
+}
+
+/// Remote -> local copy loop. Blocks on the per-connection read-result
+/// channel; after writing each payload to the local socket it acknowledges the
+/// take so the event loop submits the next remote read for this connection.
+fn writer_loop(
+    connection: u64,
+    mut socket: TcpStream,
+    broken: Broken,
+    commands: mpsc::Sender<Command>,
+    read_rx: mpsc::Receiver<ReadOutcome>,
+    taken_tx: mpsc::Sender<()>,
+) {
+    socket.set_write_timeout(Some(LOCAL_WRITE_TIMEOUT)).ok();
+    loop {
+        if broken.is_broken() {
+            break;
+        }
+        let outcome = match read_rx.recv() {
+            Ok(outcome) => outcome,
+            Err(_) => break,
+        };
+        if !outcome.data.is_empty() && socket.write_all(&outcome.data).is_err() {
+            break;
+        }
+        let _ = taken_tx.send(());
+        if outcome.eof {
+            let _ = socket.shutdown(Shutdown::Write);
+            break;
+        }
+    }
+    let _ = commands.send(Command::ConnectionDone { connection });
+}
+
+#[cfg(test)]
+mod tests;

--- a/easytier-contrib/easytier-ios/src/forwarder/tests.rs
+++ b/easytier-contrib/easytier-ios/src/forwarder/tests.rs
@@ -1,0 +1,668 @@
+//! Host-target tests for `TcpForwarder`.
+//!
+//! The first three tests need no overlay connectivity. `forward_echo_roundtrip`
+//! links two real FFI instances over the process-wide ring registry (through
+//! the always-on `ring://<instance-id>` listener and a TOML ring connector)
+//! and verifies a full byte round trip through the forwarder and the data
+//! plane.
+
+use std::{
+    ffi::CString,
+    io::{Read, Write},
+    net::{Ipv4Addr, SocketAddrV4, TcpStream},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use easytier_ffi::{
+    DataPlaneSocketAddr, data_plane_completion_wait, data_plane_operation_free,
+    data_plane_resource_close, data_plane_session_close, data_plane_session_open,
+    data_plane_tcp_accept_result_take, data_plane_tcp_accept_submit,
+    data_plane_tcp_bind_result_take, data_plane_tcp_bind_submit, data_plane_tcp_read_result_take,
+    data_plane_tcp_read_submit, data_plane_tcp_write_result_take, data_plane_tcp_write_submit,
+};
+
+use super::*;
+
+/// Names of instances started by the current test, stopped on guard drop.
+static INSTANCES: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+fn unique_instance(tag: &str) -> String {
+    format!("fwd-{tag}-{}", &uuid::Uuid::new_v4().simple().to_string()[..12])
+}
+
+fn run_instance(config: &str, register_as: &str) {
+    let config = CString::new(config).unwrap();
+    // SAFETY: `config` is a valid NUL-terminated string.
+    let result = unsafe { easytier_ffi::run_network_instance(config.as_ptr()) };
+    if result != 0 {
+        let message = crate::error::get_last_error().unwrap_or_default();
+        panic!("run_network_instance failed: {result}: {message}");
+    }
+    lock(&INSTANCES).push(register_as.to_string());
+}
+
+/// Open a forwarder session once the instance's data-plane session is
+/// available; `run_network_instance` returns before `instance.start()` finishes
+/// bringing the data plane up.
+fn start_forwarder(
+    instance: &str,
+    target: SocketAddrV4,
+    listen_port: u16,
+) -> io::Result<TcpForwarder> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        match TcpForwarder::start(instance.to_string(), target, listen_port) {
+            Ok(forwarder) => {
+                return Ok(forwarder);
+            }
+            Err(error) => {
+                if Instant::now() >= deadline {
+                    return Err(error);
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        }
+    }
+}
+
+fn start_instance(instance: &str, ipv4: &str) {
+    run_instance(
+        &format!(
+            "instance_name = \"{instance}\"\n\
+             instance_id = \"{}\"\n\
+             ipv4 = \"{ipv4}\"\n\
+             listeners = []\n\
+             flags.no_tun = true\n",
+            uuid::Uuid::new_v4()
+        ),
+        instance,
+    );
+}
+
+fn stop_all_instances() {
+    let names = std::mem::take(&mut *lock(&INSTANCES));
+    if names.is_empty() {
+        return;
+    }
+    let cstrings: Vec<CString> = names
+        .iter()
+        .map(|name| CString::new(name.as_str()).unwrap())
+        .collect();
+    let pointers: Vec<*const std::ffi::c_char> =
+        cstrings.iter().map(|name| name.as_ptr()).collect();
+    // SAFETY: `pointers` references `cstrings`, all valid NUL-terminated
+    // strings, for the duration of the call.
+    unsafe { easytier_ffi::delete_network_instance(pointers.as_ptr(), pointers.len()) };
+}
+
+struct TestGuard(std::sync::MutexGuard<'static, ()>);
+
+/// Tests share one process-wide FFI context and per-instance native sessions;
+/// run them serially to avoid cross-test session/instance interference.
+static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+fn acquire() -> TestGuard {
+    let guard = TEST_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+    TestGuard(guard)
+}
+
+impl Drop for TestGuard {
+    fn drop(&mut self) {
+        stop_all_instances();
+    }
+}
+
+/// Probe `data_plane_session_open` until the instance's data-plane runtime is
+/// running, i.e. a submitted operation would not fail with InstanceStopped.
+fn wait_data_plane_running(instance: &str) {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while !session_openable(instance) {
+        assert!(Instant::now() < deadline, "data-plane runtime never started for {instance}");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn session_openable(instance: &str) -> bool {
+    let name = CString::new(instance).unwrap();
+    let mut session = 0u64;
+    // SAFETY: `name` is a valid NUL-terminated string and `session` points to
+    // writable storage for one `u64`.
+    let result = unsafe { data_plane_session_open(name.as_ptr(), &mut session) };
+    if result == 0 && session != 0 {
+        data_plane_session_close(session);
+        return true;
+    }
+    false
+}
+
+fn open_session(instance: &str) -> u64 {
+    let name = CString::new(instance).unwrap();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let mut session = 0u64;
+        // SAFETY: `name` is a valid NUL-terminated string and `session` points
+        // to writable storage for one `u64`.
+        let result = unsafe { data_plane_session_open(name.as_ptr(), &mut session) };
+        if result == 0 && session != 0 {
+            return session;
+        }
+        // The instance's data-plane session comes up asynchronously after
+        // `run_network_instance` returns.
+        assert!(Instant::now() < deadline, "data_plane_session_open timed out: {result}");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn wait_completion(session: u64, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if data_plane_completion_wait(session, 100) == 1 {
+            return;
+        }
+        assert!(Instant::now() < deadline, "data-plane completion timed out");
+    }
+}
+
+/// Wait for the next completion and drain it, returning its descriptor.
+fn next_completion(session: u64, timeout: Duration) -> easytier_ffi::DataPlaneCompletion {
+    wait_completion(session, timeout);
+    let mut completions = [easytier_ffi::DataPlaneCompletion::default(); 8];
+    // SAFETY: `completions` is writable storage for 8 descriptors.
+    let count = unsafe {
+        easytier_ffi::data_plane_completion_drain(
+            session,
+            completions.as_mut_ptr(),
+            completions.len() as u32,
+        )
+    };
+    assert!(count > 0, "completion drain returned {count}");
+    completions[0]
+}
+
+#[test]
+fn start_fails_for_unknown_instance_and_sets_error() {
+    let _guard = acquire();
+    let instance = unique_instance("missing");
+    let error = TcpForwarder::start(
+        instance.clone(),
+        SocketAddrV4::new(Ipv4Addr::new(10, 126, 126, 99), 22),
+        0,
+    )
+    .unwrap_err();
+    assert!(
+        error.to_string().contains(&instance),
+        "unexpected error: {error}"
+    );
+    let message = crate::error::get_last_error().expect("FFI error must be recorded");
+    assert!(
+        message.contains("instance not found"),
+        "unexpected FFI error: {message}"
+    );
+}
+
+#[test]
+fn unreachable_target_fails_connect_not_start() {
+    let _guard = acquire();
+    let instance = unique_instance("unreachable");
+    start_instance(&instance, "10.126.126.1");
+    let forwarder = start_forwarder(
+        &instance,
+        SocketAddrV4::new(Ipv4Addr::new(10, 126, 126, 99), 22),
+        0,
+    )
+    .expect("forwarder start must not require overlay connectivity");
+    let port = forwarder.local_port;
+    assert_ne!(port, 0);
+
+    let mut socket = TcpStream::connect(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port))
+        .expect("loopback connect must succeed");
+    socket
+        .set_read_timeout(Some(Duration::from_secs(20)))
+        .unwrap();
+    let mut buffer = [0u8; 1];
+    let started = Instant::now();
+    let outcome = socket.read(&mut buffer);
+    match outcome {
+        Ok(0) => {}
+        Err(error) => assert!(
+            error.kind() == io::ErrorKind::WouldBlock
+                || error.kind() == io::ErrorKind::TimedOut
+                || error.kind() == io::ErrorKind::ConnectionReset,
+            "unexpected read error: {error:?}"
+        ),
+        Ok(_) => panic!("unexpected payload from unreachable target"),
+    }
+    assert!(
+        started.elapsed() <= Duration::from_secs(20),
+        "connect failure must surface within the data-plane timeout"
+    );
+
+    forwarder.stop().expect("stop must succeed");
+}
+
+#[test]
+fn stop_releases_session_and_is_idempotent() {
+    let _guard = acquire();
+    let instance = unique_instance("stop");
+    start_instance(&instance, "10.126.126.1");
+    let forwarder = start_forwarder(
+        &instance,
+        SocketAddrV4::new(Ipv4Addr::new(10, 126, 126, 99), 22),
+        0,
+    )
+    .unwrap();
+    let port = forwarder.local_port;
+    forwarder.stop().unwrap();
+    forwarder.stop().unwrap();
+    assert!(
+        TcpStream::connect(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port)).is_err(),
+        "listener must be closed after stop"
+    );
+    // The shared per-instance session must be reusable after stop.
+    let session = open_session(&instance);
+    data_plane_session_close(session);
+}
+
+#[test]
+fn forward_echo_roundtrip() {
+    let _guard = acquire();
+    let instance_a = unique_instance("echo-a");
+    let instance_b = unique_instance("echo-b");
+    let id_b = uuid::Uuid::new_v4();
+    run_instance(
+        &format!(
+            "instance_name = \"{instance_b}\"\n\
+             instance_id = \"{id_b}\"\n\
+             ipv4 = \"10.126.126.2\"\n\
+             listeners = []\n\
+             flags.no_tun = true\n"
+        ),
+        &instance_b,
+    );
+    run_instance(
+        &format!(
+            "instance_name = \"{instance_a}\"\n\
+             instance_id = \"{id_a}\"\n\
+             ipv4 = \"10.126.126.1\"\n\
+             listeners = []\n\
+             flags.no_tun = true\n\
+             [[peer]]\n\
+             uri = \"ring://{id_b}\"\n",
+            id_a = uuid::Uuid::new_v4(),
+        ),
+        &instance_a,
+    );
+
+    let echo_port = 15871u16;
+    let echo_stop = Arc::new(AtomicBool::new(false));
+    let echo = std::thread::spawn({
+        let echo_stop = echo_stop.clone();
+        let instance_b = instance_b.clone();
+        move || echo_server(&instance_b, echo_port, echo_stop)
+    });
+
+    // The data-plane runtime comes up asynchronously after
+    // `run_network_instance`. The echo server holds instance B's single native
+    // session, so only probe A here; B's readiness is implied by the echo
+    // server passing its own bind. Give the ring link and routes a moment to
+    // settle before forwarding.
+    wait_data_plane_running(&instance_a);
+    std::thread::sleep(Duration::from_millis(500));
+
+    let forwarder = start_forwarder(
+        &instance_a,
+        SocketAddrV4::new(Ipv4Addr::new(10, 126, 126, 2), echo_port),
+        0,
+    )
+    .unwrap();
+    // Run several sequential connections: the FFI allocates operation ids from
+    // a monotonically increasing broker namespace independent of the
+    // forwarder's connection counter, so the second connection onwards only
+    // succeeds if connect completions are dispatched by operation id.
+    for round in 0..3 {
+        let mut socket =
+            TcpStream::connect(SocketAddrV4::new(Ipv4Addr::LOCALHOST, forwarder.local_port))
+                .expect("loopback connect failed");
+        socket
+            .set_read_timeout(Some(Duration::from_secs(25)))
+            .unwrap();
+        socket
+            .set_write_timeout(Some(Duration::from_secs(10)))
+            .unwrap();
+        let request = format!("ping{round}").into_bytes();
+        socket.write_all(&request).unwrap();
+        let mut buffer = vec![0u8; request.len()];
+        socket.read_exact(&mut buffer).expect("echo read failed");
+        assert_eq!(buffer, request, "round {round} payload mismatch");
+        drop(socket);
+    }
+
+    forwarder.stop().unwrap();
+    echo_stop.store(true, Ordering::Release);
+    echo.join().expect("echo server thread panicked");
+}
+
+/// Run a data-plane echo server on `instance`: bind `port`, then loop accepting
+/// a stream, reading one payload and replying "pong", until `stop` is set.
+fn echo_server(instance: &str, port: u16, stop: Arc<AtomicBool>) {
+    let session = open_session(instance);
+
+    let mut bind_operation = 0u64;
+    // The data-plane runtime starts after the instance; retry the bind until
+    // it is up.
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        // SAFETY: `bind_operation` points to writable storage for one `u64`.
+        let result =
+            unsafe { data_plane_tcp_bind_submit(session, port, 15_000, &mut bind_operation) };
+        if result == 0 {
+            break;
+        }
+        let message = crate::error::get_last_error().unwrap_or_default();
+        if Instant::now() >= deadline {
+            panic!("bind submit failed: {result}: {message}");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let bind_completion = next_completion(session, Duration::from_secs(15));
+    assert_eq!(bind_completion.operation_id, bind_operation);
+    assert_eq!(bind_completion.status, 0, "bind failed: {}", bind_completion.status);
+    let mut listener = 0u64;
+    let mut local = DataPlaneSocketAddr::default();
+    // SAFETY: outputs reference writable, non-overlapping storage.
+    let result = unsafe {
+        data_plane_tcp_bind_result_take(session, bind_operation, &mut listener, &mut local)
+    };
+    if result != 0 {
+        let message = crate::error::get_last_error().unwrap_or_default();
+        panic!("bind result take failed: {result}: {message}");
+    }
+
+    while !stop.load(Ordering::Acquire) {
+        let mut accept_operation = 0u64;
+        // SAFETY: `accept_operation` points to writable storage for one `u64`.
+        let result = unsafe {
+            data_plane_tcp_accept_submit(session, listener, 5_000, &mut accept_operation)
+        };
+        assert_eq!(result, 0, "accept submit failed: {result}");
+        let accept_completion = next_completion(session, Duration::from_secs(10));
+        assert_eq!(accept_completion.operation_id, accept_operation);
+        if accept_completion.status != 0 {
+            // Accept timed out or the listener was closed; re-check stop and
+            // either loop for the next connection or exit.
+            data_plane_operation_free(session, accept_operation);
+            if stop.load(Ordering::Acquire) {
+                break;
+            }
+            continue;
+        }
+        let mut stream = 0u64;
+        let mut peer = DataPlaneSocketAddr::default();
+        // SAFETY: outputs reference writable, non-overlapping storage.
+        let result = unsafe {
+            data_plane_tcp_accept_result_take(
+                session,
+                accept_operation,
+                &mut stream,
+                &mut local,
+                &mut peer,
+            )
+        };
+        assert_eq!(result, 0, "accept result take failed: {result}");
+
+        let mut read_operation = 0u64;
+        // SAFETY: `read_operation` points to writable storage for one `u64`.
+        let result =
+            unsafe { data_plane_tcp_read_submit(session, stream, 4096, &mut read_operation) };
+        assert_eq!(result, 0, "read submit failed: {result}");
+        let read_completion = next_completion(session, Duration::from_secs(15));
+        assert_eq!(read_completion.operation_id, read_operation);
+        assert_eq!(read_completion.status, 0, "read failed: {}", read_completion.status);
+        let mut data = [0u8; 4096];
+        let mut len = 0u32;
+        let mut eof = false;
+        // SAFETY: `data` is writable for its length and the scalar outputs
+        // reference writable, non-overlapping storage.
+        let result = unsafe {
+            data_plane_tcp_read_result_take(
+                session,
+                read_operation,
+                data.as_mut_ptr(),
+                data.len() as u32,
+                &mut len,
+                &mut eof,
+            )
+        };
+        assert_eq!(result, 0, "read result take failed: {result}");
+        assert!(!eof, "unexpected eof before payload");
+
+        // Echo the received payload back verbatim.
+        let payload = data[..len as usize].to_vec();
+        let mut write_operation = 0u64;
+        // SAFETY: the ABI copies `payload` before returning.
+        let result = unsafe {
+            data_plane_tcp_write_submit(
+                session,
+                stream,
+                payload.as_ptr(),
+                payload.len() as u32,
+                &mut write_operation,
+            )
+        };
+        assert_eq!(result, 0, "write submit failed: {result}");
+        let write_completion = next_completion(session, Duration::from_secs(15));
+        assert_eq!(write_completion.operation_id, write_operation);
+        assert_eq!(
+            write_completion.status, 0,
+            "write failed: {}",
+            write_completion.status
+        );
+        let mut written = 0u32;
+        // SAFETY: `written` points to writable storage for one `u32`.
+        let result =
+            unsafe { data_plane_tcp_write_result_take(session, write_operation, &mut written) };
+        assert_eq!(result, 0, "write result take failed: {result}");
+        assert_eq!(written as usize, payload.len());
+        data_plane_resource_close(session, stream);
+    }
+    data_plane_resource_close(session, listener);
+    data_plane_session_close(session);
+}
+
+#[test]
+fn two_instances_both_start_data_plane() {
+    let _guard = acquire();
+    let a = unique_instance("two-a");
+    let b = unique_instance("two-b");
+    run_instance(&format!("instance_name = \"{a}\"\ninstance_id = \"{}\"\nipv4 = \"10.126.126.1\"\nlisteners = []\nflags.no_tun = true\n", uuid::Uuid::new_v4()), &a);
+    run_instance(&format!("instance_name = \"{b}\"\ninstance_id = \"{}\"\nipv4 = \"10.126.126.2\"\nlisteners = []\nflags.no_tun = true\n", uuid::Uuid::new_v4()), &b);
+    wait_data_plane_running(&a);
+    wait_data_plane_running(&b);
+}
+
+/// Regression: a read completing with an error after both workers exited must
+/// release the connection (the error path used to skip `maybe_remove`, leaking
+/// the connection state until `stop`).
+#[test]
+fn failed_read_completion_releases_finished_connection() {
+    let _guard = acquire();
+    let instance = unique_instance("readfail");
+    start_instance(&instance, "10.126.126.1");
+    wait_data_plane_running(&instance);
+    let session = SharedSession::open(&instance).unwrap();
+    let (_command_tx, commands) = mpsc::channel();
+    let (_pump_tx, pump_commands) = mpsc::channel();
+    let live: LiveConnections = LiveConnections::default();
+    let mut event_loop = EventLoop {
+        session: session.clone(),
+        commands,
+        stopped: Arc::new(AtomicBool::new(false)),
+        connections: HashMap::new(),
+        operations: HashMap::new(),
+        pending_handles: Arc::new(Mutex::new(HashMap::new())),
+        pump_commands,
+        live: live.clone(),
+    };
+    // The leak scenario: both workers already exited while a remote read was
+    // still in flight, then the read completes with an error. The operation
+    // and stream ids below are bogus; the FFI treats freeing/closing unknown
+    // ids as a no-op.
+    let listener = TcpListener::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let socket = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+    let (handles, _results, _taken) = ConnectionHandles::pair(Broken::new(), socket);
+    let mut state = ConnectionState::new(handles.clone(), 4242);
+    state.in_flight = 1;
+    state.live_workers = 0;
+    state.read_pending = true;
+    event_loop.connections.insert(7, state);
+    lock(&live).insert(7, handles);
+
+    let completion = DataPlaneCompletion {
+        operation_id: 999,
+        operation_kind: OP_TCP_READ,
+        status: 1,
+    };
+    event_loop.complete_read(7, &completion);
+
+    assert!(
+        !event_loop.connections.contains_key(&7),
+        "failed read completion must release the finished connection"
+    );
+    assert!(lock(&live).is_empty(), "live connection entry leaked");
+}
+
+/// Regression: `submit_connect` must register the operation -> attempt mapping
+/// while holding `connect_ops`, so the event loop (which resolves connect
+/// completions under the same lock) can never dispatch a completion before the
+/// mapping exists. The race window itself is a thread interleaving that cannot
+/// be forced deterministically; this test pins the fix's observable property:
+/// no FFI connect is submitted while `connect_ops` is held by someone else.
+#[test]
+fn connect_submit_waits_for_connect_ops_lock() {
+    let _guard = acquire();
+    let instance = unique_instance("connreg");
+    start_instance(&instance, "10.126.126.1");
+    wait_data_plane_running(&instance);
+    let session = SharedSession::open(&instance).unwrap();
+    let (reply, _reply_rx) = mpsc::channel();
+    lock(&session.connects).insert(
+        7,
+        ConnectAttempt {
+            reply,
+            operation: None,
+        },
+    );
+
+    let connect_ops = lock(&session.connect_ops);
+    let worker = std::thread::spawn({
+        let session = session.clone();
+        move || session.submit_connect(7, SocketAddrV4::new(Ipv4Addr::new(10, 126, 126, 99), 22))
+    });
+    // The FFI submit itself must not have happened while the lock is held, so
+    // the attempt still has no operation id assigned.
+    std::thread::sleep(Duration::from_millis(300));
+    assert!(
+        lock(&session.connects).get(&7).unwrap().operation.is_none(),
+        "connect submit proceeded while connect_ops was locked"
+    );
+    drop(connect_ops);
+
+    let operation = worker.join().unwrap().expect("connect submit failed");
+    assert_eq!(lock(&session.connect_ops).get(&operation), Some(&7));
+    assert_eq!(
+        lock(&session.connects).get(&7).unwrap().operation,
+        Some(operation)
+    );
+}
+
+/// Regression: a connect attempt registered after the event loop's final
+/// `fail_all` (the acceptor/spawn racing `stop`) would never get a completion
+/// dispatched. `stop` must fail such stranded attempts so a reader blocked in
+/// `await_connect` exits instead of hanging forever.
+#[test]
+fn stop_fails_connect_registered_after_event_loop_exit() {
+    let _guard = acquire();
+    let instance = unique_instance("stoprace");
+    start_instance(&instance, "10.126.126.1");
+    let forwarder = start_forwarder(
+        &instance,
+        SocketAddrV4::new(Ipv4Addr::new(10, 126, 126, 99), 22),
+        0,
+    )
+    .unwrap();
+    // Force the event loop out before `stop`: closing the session fails the
+    // completion wait, so the loop breaks and runs its final `fail_all`.
+    forwarder.session.close();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let exited = lock(&forwarder.event_loop)
+            .as_ref()
+            .map(|handle| handle.is_finished())
+            .unwrap_or(true);
+        if exited {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "event loop did not exit on session close"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    // Register an attempt now: no event loop remains to dispatch its
+    // completion, exactly like the spawn/stop race.
+    let (reply, reply_rx) = mpsc::channel();
+    lock(&forwarder.session.connects).insert(
+        77,
+        ConnectAttempt {
+            reply,
+            operation: None,
+        },
+    );
+    let reader = std::thread::spawn(move || await_connect(&reply_rx));
+
+    forwarder.stop().expect("stop must succeed");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !reader.is_finished() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(
+        reader.is_finished(),
+        "reader stayed blocked in await_connect after stop"
+    );
+    assert_eq!(reader.join().unwrap(), None);
+}
+
+/// Regression: `stop` must not hang forever joining a worker that survived
+/// the teardown; after `STOP_TIMEOUT` it detaches the worker and returns.
+#[test]
+fn stop_detaches_unresponsive_worker_after_deadline() {
+    let _guard = acquire();
+    let instance = unique_instance("stuck");
+    start_instance(&instance, "10.126.126.1");
+    let forwarder = start_forwarder(
+        &instance,
+        SocketAddrV4::new(Ipv4Addr::new(10, 126, 126, 99), 22),
+        0,
+    )
+    .unwrap();
+    lock(&forwarder.workers).push(std::thread::spawn(|| {
+        std::thread::sleep(Duration::from_secs(3600));
+    }));
+
+    let started = Instant::now();
+    forwarder.stop().expect("stop must succeed");
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed >= STOP_TIMEOUT,
+        "stop returned before the worker deadline: {elapsed:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(30),
+        "stop hung on the unresponsive worker: {elapsed:?}"
+    );
+}

--- a/easytier-contrib/easytier-ios/src/lib.rs
+++ b/easytier-contrib/easytier-ios/src/lib.rs
@@ -1,0 +1,487 @@
+//! iOS-facing C ABI for EasyTier.
+//!
+//! This crate is the iOS counterpart of `easytier-android-jni`: it wraps the
+//! easytier-ffi C ABI for instance management and reuses the same
+//! platform-agnostic loopback TCP forwarder (data-plane session + operation
+//! dispatch, no TUN involved). It builds as a static library for the Apple
+//! toolchain; `easytier-ios.h` declares the callable surface.
+//!
+//! All exported functions are panic-safe: panics are caught at the FFI
+//! boundary and reported through `easytier_ios_last_error`.
+
+mod error;
+mod forwarder;
+mod strings;
+
+use std::{
+    ffi::{CStr, c_char, c_int},
+    net::{Ipv4Addr, SocketAddrV4},
+    panic::{AssertUnwindSafe, catch_unwind},
+    ptr,
+    sync::Mutex,
+};
+
+use once_cell::sync::Lazy;
+
+use forwarder::TcpForwarder;
+use strings::cstring_for;
+
+/// Live forwarders keyed by their bound loopback port.
+static FORWARDERS: Lazy<Mutex<std::collections::HashMap<u16, TcpForwarder>>> =
+    Lazy::new(Default::default);
+
+fn forwarders() -> std::sync::MutexGuard<'static, std::collections::HashMap<u16, TcpForwarder>> {
+    FORWARDERS
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+}
+
+/// Run `body` catching any panic; panics are recorded in the last-error
+/// buffer so they never unwind across the FFI boundary.
+fn guarded<R>(default: R, body: impl FnOnce() -> R) -> R {
+    match catch_unwind(AssertUnwindSafe(body)) {
+        Ok(result) => result,
+        Err(_) => {
+            error::set_error("internal panic in easytier-ios");
+            default
+        }
+    }
+}
+
+/// Read a required non-null C string argument.
+///
+/// # Safety
+/// When non-null, `value` must point to a NUL-terminated string.
+unsafe fn cstr_arg<'a>(value: *const c_char, what: &str) -> Result<&'a str, String> {
+    if value.is_null() {
+        return Err(format!("{what} must not be null"));
+    }
+    // SAFETY: caller guarantees `value` is NUL-terminated.
+    let text = unsafe { CStr::from_ptr(value) };
+    text.to_str()
+        .map_err(|_| format!("{what} is not valid UTF-8"))
+}
+
+/// Start one EasyTier network instance from a TOML config string.
+///
+/// Returns 0 on success, -1 on failure (see `easytier_ios_last_error`).
+///
+/// # Safety
+/// `toml` must be a non-null pointer to a NUL-terminated UTF-8 string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn easytier_ios_run_instance(toml: *const c_char) -> c_int {
+    unsafe {
+        guarded(-1, || {
+            error::clear_error();
+            let toml = match cstr_arg(toml, "config string") {
+                Ok(toml) => toml,
+                Err(message) => {
+                    error::set_error(&message);
+                    return -1;
+                }
+            };
+            easytier_ffi::run_network_instance(toml.as_ptr() as *const c_char)
+        })
+    }
+}
+
+/// Keep the named instances and stop all others.
+///
+/// `names_json` is a JSON array of instance name strings; null, empty or `[]`
+/// stops every running instance. Returns 0 on success, -1 on failure.
+///
+/// # Safety
+/// `names_json` may be null; when non-null it must point to a NUL-terminated
+/// UTF-8 string containing a JSON array of strings.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn easytier_ios_retain_instances(names_json: *const c_char) -> c_int {
+    unsafe {
+        guarded(-1, || {
+            error::clear_error();
+            let names: Vec<String> = if names_json.is_null() {
+                Vec::new()
+            } else {
+                let text = match cstr_arg(names_json, "instance names JSON") {
+                    Ok(text) => text,
+                    Err(message) => {
+                        error::set_error(&message);
+                        return -1;
+                    }
+                };
+                if text.trim().is_empty() {
+                    Vec::new()
+                } else {
+                    match serde_json::from_str(text) {
+                        Ok(names) => names,
+                        Err(parse_error) => {
+                            error::set_error(&format!(
+                                "invalid instance names JSON: {parse_error}"
+                            ));
+                            return -1;
+                        }
+                    }
+                }
+            };
+            let c_names: Vec<std::ffi::CString> = match names
+                .iter()
+                .map(|name| cstring_for(name, "instance name"))
+                .collect::<std::io::Result<Vec<_>>>()
+            {
+                Ok(c_names) => c_names,
+                Err(invalid) => {
+                    error::set_error(&invalid.to_string());
+                    return -1;
+                }
+            };
+            let pointers: Vec<*const c_char> =
+                c_names.iter().map(|name| name.as_ptr()).collect();
+            easytier_ffi::retain_network_instance(pointers.as_ptr(), pointers.len())
+        })
+    }
+}
+
+/// Collect running instance information as a JSON object mapping each
+/// instance name to its running info JSON.
+///
+/// Returns a newly allocated string the caller must release with
+/// `easytier_ios_free_string`, or null on failure (see
+/// `easytier_ios_last_error`).
+#[unsafe(no_mangle)]
+pub extern "C" fn easytier_ios_collect_network_infos(max_length: c_int) -> *mut c_char {
+    guarded(ptr::null_mut(), || {
+        error::clear_error();
+        let max_length = max_length.max(0) as usize;
+        let mut infos = vec![
+            easytier_ffi::KeyValuePair {
+                key: ptr::null(),
+                value: ptr::null(),
+            };
+            max_length
+        ];
+        // SAFETY: `infos` is writable storage for `max_length` entries; every
+        // returned key/value string is released below with
+        // `easytier_ffi::free_string`.
+        let count = unsafe { easytier_ffi::collect_network_infos(infos.as_mut_ptr(), max_length) };
+        if count < 0 {
+            return ptr::null_mut();
+        }
+        let mut map = serde_json::Map::new();
+        for info in infos.iter().take(count as usize) {
+            if info.key.is_null() || info.value.is_null() {
+                break;
+            }
+            // SAFETY: non-null entries are NUL-terminated strings allocated by
+            // easytier-ffi, each released exactly once after copying.
+            let (key, value) = unsafe {
+                let key = CStr::from_ptr(info.key).to_string_lossy().into_owned();
+                let value = CStr::from_ptr(info.value).to_string_lossy().into_owned();
+                easytier_ffi::free_string(info.key);
+                easytier_ffi::free_string(info.value);
+                (key, value)
+            };
+            let value = serde_json::from_str(&value).unwrap_or(serde_json::Value::String(value));
+            map.insert(key, value);
+        }
+        let json = serde_json::Value::Object(map).to_string();
+        match std::ffi::CString::new(json) {
+            Ok(json) => json.into_raw(),
+            Err(_) => {
+                error::set_error("network info JSON contains a null byte");
+                ptr::null_mut()
+            }
+        }
+    })
+}
+
+/// Start a loopback TCP forwarder: listen on `127.0.0.1:listen_port`
+/// (0 = auto-assign) and relay every accepted connection to
+/// `target_ip:target_port` through the data plane of the instance named
+/// `inst_name`.
+///
+/// Returns the bound local port on success, -1 on failure (see
+/// `easytier_ios_last_error`).
+///
+/// # Safety
+/// `inst_name` and `target_ip` must be non-null pointers to NUL-terminated
+/// UTF-8 strings.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn easytier_ios_start_tcp_forwarder(
+    inst_name: *const c_char,
+    target_ip: *const c_char,
+    target_port: u16,
+    listen_port: u16,
+) -> c_int {
+    unsafe {
+        guarded(-1, || {
+            error::clear_error();
+            let instance = match cstr_arg(inst_name, "instance name") {
+                Ok(instance) => instance.to_owned(),
+                Err(message) => {
+                    error::set_error(&message);
+                    return -1;
+                }
+            };
+            let target_ip = match cstr_arg(target_ip, "target IP") {
+                Ok(target_ip) => target_ip,
+                Err(message) => {
+                    error::set_error(&message);
+                    return -1;
+                }
+            };
+            let target_ip: Ipv4Addr = match target_ip.parse() {
+                Ok(ip) => ip,
+                Err(_) => {
+                    error::set_error(&format!("invalid IPv4 target address: \"{target_ip}\""));
+                    return -1;
+                }
+            };
+            let target = SocketAddrV4::new(target_ip, target_port);
+            let forwarder = match TcpForwarder::start(instance, target, listen_port) {
+                Ok(forwarder) => forwarder,
+                Err(start_error) => {
+                    error::set_error(&format!("failed to start TCP forwarder: {start_error}"));
+                    return -1;
+                }
+            };
+            let local_port = forwarder.local_port;
+            forwarders().insert(local_port, forwarder);
+            c_int::from(local_port)
+        })
+    }
+}
+
+/// Stop the TCP forwarder bound to `local_port`.
+///
+/// Returns 0 on success, -1 when no forwarder is registered on that port.
+#[unsafe(no_mangle)]
+pub extern "C" fn easytier_ios_stop_tcp_forwarder(local_port: c_int) -> c_int {
+    guarded(-1, || {
+        error::clear_error();
+        if !(0..=u16::MAX as c_int).contains(&local_port) {
+            error::set_error(&format!("invalid local port: {local_port}"));
+            return -1;
+        }
+        let forwarder = forwarders().remove(&(local_port as u16));
+        match forwarder {
+            Some(forwarder) => match forwarder.stop() {
+                Ok(()) => 0,
+                Err(stop_error) => {
+                    error::set_error(&format!("failed to stop TCP forwarder: {stop_error}"));
+                    -1
+                }
+            },
+            None => {
+                error::set_error(&format!(
+                    "no TCP forwarder registered on local port {local_port}"
+                ));
+                -1
+            }
+        }
+    })
+}
+
+/// Return the last error message on this thread, or null when there is none.
+///
+/// Combines forwarder-side errors recorded by this library with the
+/// easytier-ffi last FFI error. The returned string is newly allocated and
+/// must be released with `easytier_ios_free_string`.
+#[unsafe(no_mangle)]
+pub extern "C" fn easytier_ios_last_error() -> *mut c_char {
+    guarded(ptr::null_mut(), error::last_error_raw)
+}
+
+/// Release a string returned by `easytier_ios_collect_network_infos` or
+/// `easytier_ios_last_error`. Passing null is a no-op.
+///
+/// # Safety
+/// `s` must be null or a string previously returned by this library, not yet
+/// freed.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn easytier_ios_free_string(s: *mut c_char) {
+    let _ = catch_unwind(AssertUnwindSafe(|| {
+        if !s.is_null() {
+            // SAFETY: caller guarantees `s` came from this library.
+            drop(unsafe { std::ffi::CString::from_raw(s) });
+        }
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    //! Host-target smoke tests for the C ABI surface. They exercise the
+    //! wrapper logic (argument validation, error propagation, the forwarder
+    //! registry and string ownership) against a real `no_tun` instance; no
+    //! peer connectivity is required.
+
+    use super::*;
+    use std::{
+        ffi::{CStr, CString},
+        sync::{Mutex, MutexGuard},
+        time::{Duration, Instant},
+    };
+
+    /// Tests share the process-wide easytier-ffi state and the forwarder
+    /// registry; run them serially.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn acquire() -> MutexGuard<'static, ()> {
+        TEST_LOCK.lock().unwrap_or_else(|error| error.into_inner())
+    }
+
+    fn unique_instance(tag: &str) -> String {
+        format!("ios-{tag}-{}", &uuid::Uuid::new_v4().simple().to_string()[..12])
+    }
+
+    fn minimal_config(instance: &str) -> CString {
+        CString::new(format!(
+            "instance_name = \"{instance}\"\n\
+             instance_id = \"{}\"\n\
+             ipv4 = \"10.126.126.1\"\n\
+             listeners = []\n\
+             flags.no_tun = true\n",
+            uuid::Uuid::new_v4()
+        ))
+        .unwrap()
+    }
+
+    fn retain_all() {
+        let empty = CString::new("[]").unwrap();
+        // SAFETY: `empty` is a valid NUL-terminated string.
+        assert_eq!(unsafe { easytier_ios_retain_instances(empty.as_ptr()) }, 0);
+    }
+
+    struct InstanceGuard;
+
+    impl InstanceGuard {
+        fn run(instance: &str) -> Self {
+            let config = minimal_config(instance);
+            // SAFETY: `config` is a valid NUL-terminated string.
+            let result = unsafe { easytier_ios_run_instance(config.as_ptr()) };
+            assert_eq!(result, 0, "run_instance failed: {:?}", take_last_error());
+            Self
+        }
+    }
+
+    impl Drop for InstanceGuard {
+        fn drop(&mut self) {
+            retain_all();
+        }
+    }
+
+    fn take_last_error() -> Option<String> {
+        let error_ptr = easytier_ios_last_error();
+        if error_ptr.is_null() {
+            return None;
+        }
+        // SAFETY: `error_ptr` was returned by `easytier_ios_last_error` and is
+        // freed exactly once below.
+        let message = unsafe { CStr::from_ptr(error_ptr) }
+            .to_string_lossy()
+            .into_owned();
+        unsafe { easytier_ios_free_string(error_ptr) };
+        Some(message)
+    }
+
+    fn collect_infos_json() -> String {
+        let json_ptr = easytier_ios_collect_network_infos(32);
+        assert!(!json_ptr.is_null(), "collect failed: {:?}", take_last_error());
+        // SAFETY: `json_ptr` was returned by `easytier_ios_collect_network_infos`
+        // and is freed exactly once below.
+        let json = unsafe { CStr::from_ptr(json_ptr) }
+            .to_string_lossy()
+            .into_owned();
+        unsafe { easytier_ios_free_string(json_ptr) };
+        json
+    }
+
+    #[test]
+    fn run_collect_retain_roundtrip() {
+        let _guard = acquire();
+        let instance = unique_instance("smoke");
+        let _instance = InstanceGuard::run(&instance);
+
+        let json = collect_infos_json();
+        let infos: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_str(&json).expect("collect_network_infos must return a JSON object");
+        assert!(
+            infos.contains_key(&instance),
+            "instance {instance} missing from collected infos: {json}"
+        );
+
+        retain_all();
+        let infos = collect_infos_json();
+        assert!(
+            !infos.contains(&instance),
+            "instance {instance} still listed after retain([]): {infos}"
+        );
+    }
+
+    #[test]
+    fn retain_instances_rejects_invalid_json() {
+        let _guard = acquire();
+        let garbage = CString::new("not json").unwrap();
+        // SAFETY: `garbage` is a valid NUL-terminated string.
+        let result = unsafe { easytier_ios_retain_instances(garbage.as_ptr()) };
+        assert_eq!(result, -1);
+        let message = take_last_error().expect("last error must be set");
+        assert!(
+            message.contains("invalid instance names JSON"),
+            "unexpected error: {message}"
+        );
+    }
+
+    #[test]
+    fn start_forwarder_fails_for_unknown_instance() {
+        let _guard = acquire();
+        let instance = unique_instance("missing");
+        let name = CString::new(instance.as_str()).unwrap();
+        let target = CString::new("10.126.126.99").unwrap();
+        // SAFETY: both pointers are valid NUL-terminated strings.
+        let result =
+            unsafe { easytier_ios_start_tcp_forwarder(name.as_ptr(), target.as_ptr(), 22, 0) };
+        assert_eq!(result, -1);
+        let message = take_last_error().expect("last error must be set");
+        assert!(
+            message.contains(&instance),
+            "error must mention the instance: {message}"
+        );
+    }
+
+    #[test]
+    fn forwarder_registry_start_and_stop() {
+        let _guard = acquire();
+        let instance = unique_instance("fwd");
+        let _instance = InstanceGuard::run(&instance);
+        let name = CString::new(instance.as_str()).unwrap();
+        let target = CString::new("10.126.126.99").unwrap();
+
+        // The data-plane runtime comes up asynchronously after
+        // `run_network_instance`; retry until the native session is available.
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let port = loop {
+            // SAFETY: both pointers are valid NUL-terminated strings.
+            let result =
+                unsafe { easytier_ios_start_tcp_forwarder(name.as_ptr(), target.as_ptr(), 22, 0) };
+            if result > 0 {
+                break result;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "start_tcp_forwarder never succeeded: {:?}",
+                take_last_error()
+            );
+            std::thread::sleep(Duration::from_millis(50));
+        };
+        assert!(forwarders().contains_key(&(port as u16)));
+
+        assert_eq!(easytier_ios_stop_tcp_forwarder(port), 0);
+        assert!(!forwarders().contains_key(&(port as u16)));
+        // Stopping again must fail with a recorded error.
+        assert_eq!(easytier_ios_stop_tcp_forwarder(port), -1);
+        let message = take_last_error().expect("last error must be set");
+        assert!(
+            message.contains(&port.to_string()),
+            "error must mention the port: {message}"
+        );
+    }
+}

--- a/easytier-contrib/easytier-ios/src/strings.rs
+++ b/easytier-contrib/easytier-ios/src/strings.rs
@@ -1,0 +1,7 @@
+use std::ffi::CString;
+
+/// Build a NUL-terminated C string from a Rust string for FFI calls.
+pub(crate) fn cstring_for(value: &str, what: &str) -> std::io::Result<CString> {
+    CString::new(value)
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, format!("{what} contains a null byte")))
+}


### PR DESCRIPTION
## Summary

- add Kotlin and JNI APIs for loopback TCP forwarding on Android
- add an iOS static-library C API and XCFramework build pipeline
- multiplex connections over one native data-plane session with write backpressure
- clean up failed startup paths and propagate platform-appropriate errors
- add host-side forwarding and lifecycle regression tests

## Testing

- cargo check -p easytier-android-jni -p easytier-ios
- cargo clippy -p easytier-android-jni -p easytier-ios --lib -- -D warnings
- Android forwarder tests: 9 passed
- iOS forwarder tests: 9 passed
- final Android and iOS echo regression tests passed
- bash syntax check for build-xcframework.sh
- verified Xcode device and simulator compiler-runtime architectures