### PR TITLE
fix(ohos): fix userspace TCP forwarding and local subnet routing

### DIFF
--- a/easytier-contrib/easytier-ohrs/src/config/services/schema_service.rs
+++ b/easytier-contrib/easytier-ohrs/src/config/services/schema_service.rs
@@ -119,7 +119,11 @@ fn enum_options(kind: Kind) -> Vec<FieldOption> {
             .values()
             .map(|value| FieldOption {
                 label: value.name().to_string(),
-                value: value.number().to_string(),
+                // protobuf JSON uses enum names rather than their numeric wire values.
+                // Returning the number here made ArkTS write (for example) `1`, while
+                // NetworkConfig deserialization expects `"None"`, so field-level saves
+                // were rejected by the repository validation step.
+                value: value.name().to_string(),
             })
             .collect(),
         _ => Vec::new(),
@@ -410,5 +414,17 @@ mod tests {
                 .iter()
                 .any(|option| option.label == "PublicServer")
         );
+
+        let data_compress_algo = schema
+            .children
+            .iter()
+            .find(|field| field.name == "data_compress_algo")
+            .expect("data_compress_algo field");
+        let none = data_compress_algo
+            .enum_options
+            .iter()
+            .find(|option| option.label == "None")
+            .expect("compression None option");
+        assert_eq!(none.value, "None");
     }
 }

--- a/easytier-contrib/easytier-ohrs/src/config/services/share_link_service.rs
+++ b/easytier-contrib/easytier-ohrs/src/config/services/share_link_service.rs
@@ -162,7 +162,7 @@ pub fn import_config_share_link(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config_repo::{create_config_record, init_config_store};
+    use crate::config::repository::{create_config_record, init_config_store};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn test_root() -> String {

--- a/easytier-contrib/easytier-ohrs/src/config_repo.rs
+++ b/easytier-contrib/easytier-ohrs/src/config_repo.rs
@@ -54,17 +54,14 @@ pub(crate) fn get_runtime_config_snapshot(config_id: &str) -> Option<RuntimeConf
         .and_then(|guard| guard.get(config_id).cloned())
 }
 
-pub(crate) fn get_runtime_config_route_overrides(config_id: &str) -> (Vec<String>, Vec<String>) {
+pub(crate) fn get_runtime_config_manual_routes(config_id: &str) -> Vec<String> {
     RUNTIME_CONFIG_SNAPSHOTS
         .lock()
         .ok()
         .and_then(|guard| {
-            guard.get(config_id).map(|snapshot| {
-                (
-                    snapshot.config.routes.clone(),
-                    snapshot.config.proxy_cidrs.clone(),
-                )
-            })
+            guard
+                .get(config_id)
+                .map(|snapshot| snapshot.config.routes.clone())
         })
         .unwrap_or_default()
 }

--- a/easytier-contrib/easytier-ohrs/src/kernel_bridge/routing.rs
+++ b/easytier-contrib/easytier-ohrs/src/kernel_bridge/routing.rs
@@ -1,4 +1,4 @@
-use crate::config::repository::get_runtime_config_route_overrides;
+use crate::config::repository::get_runtime_config_manual_routes;
 use crate::runtime::state::runtime_state::RuntimeInstanceState;
 use ipnet::IpNet;
 use std::collections::HashSet;
@@ -59,8 +59,7 @@ pub(crate) fn aggregate_tun_routes(instance: &RuntimeInstanceState) -> Vec<Strin
         .my_node_info
         .as_ref()
         .and_then(|info| info.virtual_ipv4_cidr.clone());
-    let (manual_routes, config_proxy_cidrs) =
-        get_runtime_config_route_overrides(&instance.config_id);
+    let manual_routes = get_runtime_config_manual_routes(&instance.config_id);
     let runtime_proxy_cidrs = instance
         .routes
         .iter()
@@ -73,7 +72,9 @@ pub(crate) fn aggregate_tun_routes(instance: &RuntimeInstanceState) -> Vec<Strin
     }
 
     raw_routes.extend(manual_routes.iter().cloned());
-    raw_routes.extend(config_proxy_cidrs.iter().cloned());
+    // Locally configured proxy CIDRs are advertisements for networks reached
+    // through this node. Installing them into this node's TUN would recapture
+    // the proxy's own destination sockets instead of using the physical LAN.
     raw_routes.extend(runtime_proxy_cidrs.iter().cloned());
     simplify_routes(raw_routes)
 }
@@ -89,4 +90,77 @@ pub(crate) fn aggregate_requested_tun_routes(instances: &[RuntimeInstanceState])
         }
     }
     aggregated_routes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::repository::{cache_runtime_config_snapshot, clear_runtime_config_snapshot};
+    use crate::runtime::state::runtime_state::{MyNodeInfo, RouteView};
+    use easytier::proto::api::manage::NetworkConfig;
+
+    fn runtime_instance(config_id: &str) -> RuntimeInstanceState {
+        RuntimeInstanceState {
+            config_id: config_id.to_string(),
+            instance_id: "test-instance".to_string(),
+            display_name: "test".to_string(),
+            running: true,
+            tun_required: true,
+            tun_attached: false,
+            magic_dns_enabled: false,
+            need_exit_node: false,
+            error_message: None,
+            my_node_info: Some(MyNodeInfo {
+                virtual_ipv4: Some("10.144.144.1".to_string()),
+                virtual_ipv4_cidr: Some("10.144.144.1/24".to_string()),
+                hostname: None,
+                version: None,
+                peer_id: Some(1),
+                listeners: Vec::new(),
+                vpn_portal_cfg: None,
+                udp_nat_type: None,
+                tcp_nat_type: None,
+            }),
+            events: Vec::new(),
+            routes: vec![RouteView {
+                peer_id: 2,
+                hostname: None,
+                ipv4: Some("10.144.144.2".to_string()),
+                ipv4_cidr: Some("10.144.144.2/24".to_string()),
+                ipv6_cidr: None,
+                proxy_cidrs: vec!["10.20.0.0/16".to_string()],
+                next_hop_peer_id: Some(2),
+                cost: Some(1),
+                path_latency: None,
+                udp_nat_type: None,
+                tcp_nat_type: None,
+                inst_id: None,
+                version: None,
+                is_public_server: None,
+            }],
+            peers: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn local_proxy_cidr_is_not_installed_in_tun_routes() {
+        let config_id = "routing-test-local-proxy";
+        cache_runtime_config_snapshot(
+            config_id.to_string(),
+            "test".to_string(),
+            NetworkConfig {
+                routes: vec!["172.16.0.0/16".to_string()],
+                proxy_cidrs: vec!["192.168.1.0/24".to_string()],
+                ..Default::default()
+            },
+        );
+
+        let routes = aggregate_tun_routes(&runtime_instance(config_id));
+        clear_runtime_config_snapshot(config_id);
+
+        assert!(routes.contains(&"10.144.144.0/24".to_string()));
+        assert!(routes.contains(&"172.16.0.0/16".to_string()));
+        assert!(routes.contains(&"10.20.0.0/16".to_string()));
+        assert!(!routes.contains(&"192.168.1.0/24".to_string()));
+    }
 }

--- a/easytier-contrib/easytier-ohrs/src/lib.rs
+++ b/easytier-contrib/easytier-ohrs/src/lib.rs
@@ -63,6 +63,7 @@ use easytier::common::{
 use easytier::instance::factory::{NativeInstanceManager, native_instance_manager_with_runtime};
 use easytier::proto::api::manage::NetworkConfig;
 use easytier::proto::api::manage::NetworkingMethod;
+use easytier::proto::common::CompressionAlgoPb;
 use easytier::web_client::{WebClient, WebClientHooks, run_web_client};
 use kernel_bridge::{
     start_local_socket_server as start_local_socket_server_inner,
@@ -669,8 +670,11 @@ fn resolve_instance_id_inner(instance_name: &str) -> Option<String> {
 }
 
 pub(crate) fn build_default_network_config_json() -> Result<String, String> {
-    let config = NetworkConfig::new_from_config(TomlConfigLoader::default())
+    let mut config = NetworkConfig::new_from_config(TomlConfigLoader::default())
         .map_err(|e| format!("default_network_config failed {}", e))?;
+    // HarmonyOS 的配置编辑页将压缩算法作为显式选项展示。新建实例默认
+    // 使用 NONE，避免在用户没有主动选择时增加压缩开销。
+    config.data_compress_algo = Some(CompressionAlgoPb::None as i32);
     serde_json::to_string(&config).map_err(|e| format!("default_network_config failed {}", e))
 }
 

--- a/easytier-core/src/gateway/dataplane/mod.rs
+++ b/easytier-core/src/gateway/dataplane/mod.rs
@@ -590,6 +590,8 @@ where
         })?;
         let overlay_destination = if local_virtual_destination {
             true
+        } else if dst_ip.is_loopback() {
+            false
         } else {
             let (peers, _) = options
                 .deadline

--- a/easytier-core/src/gateway/port_forward.rs
+++ b/easytier-core/src/gateway/port_forward.rs
@@ -256,6 +256,17 @@ where
             Arc::downgrade(&connections),
             "TCP port-forward connections",
         ));
+        if self.runtime_config.snapshot().services.proxy.force_smoltcp
+            && bind_addr.is_ipv4()
+            && bind_addr.ip().is_unspecified()
+        {
+            self.spawn_data_plane_tcp_port_forward(
+                bind_addr.port(),
+                dst_addr,
+                cancel.clone(),
+                connections.clone(),
+            );
+        }
         let host = self.host.clone();
         self.tasks.lock().unwrap().spawn(async move {
             let mut listener = Some(listener);
@@ -301,6 +312,98 @@ where
             );
         });
         Ok(())
+    }
+
+    fn spawn_data_plane_tcp_port_forward(
+        &self,
+        local_port: u16,
+        dst_addr: SocketAddr,
+        cancel: CancellationToken,
+        connections: Arc<std::sync::Mutex<JoinSet<()>>>,
+    ) {
+        let data_plane = self.data_plane.clone();
+        self.tasks.lock().unwrap().spawn(async move {
+            loop {
+                let mut listener = match select! {
+                    biased;
+                    _ = cancel.cancelled() => break,
+                    result = data_plane.data_plane_tcp_bind(local_port, Duration::from_secs(10)) => result,
+                } {
+                    Ok(listener) => listener,
+                    Err(error) => {
+                        tracing::error!(
+                            ?error,
+                            local_port,
+                            "data-plane TCP port-forward bind failed"
+                        );
+                        select! {
+                            biased;
+                            _ = cancel.cancelled() => break,
+                            _ = crate::foundation::time::sleep(TCP_PORT_FORWARD_REBIND_DELAY) => continue,
+                        }
+                    }
+                };
+                tracing::info!(
+                    ?dst_addr,
+                    local_addr = ?listener.local_addr(),
+                    "data-plane TCP port-forward listener bound"
+                );
+
+                loop {
+                    let accepted = select! {
+                        biased;
+                        _ = cancel.cancelled() => return,
+                        result = listener.accept() => result,
+                    };
+                    let (mut incoming, source_addr) = match accepted {
+                        Ok(accepted) => accepted,
+                        Err(error) => {
+                            tracing::error!(
+                                ?error,
+                                local_port,
+                                "data-plane TCP port-forward accept failed; rebinding"
+                            );
+                            break;
+                        }
+                    };
+                    let data_plane = data_plane.clone();
+                    connections.lock().unwrap().spawn(async move {
+                        let options = DataPlaneTcpConnectOptions::gateway(
+                            Duration::from_secs(10),
+                            TcpSocketPurpose::PortForward,
+                            source_addr,
+                        );
+                        let mut outgoing = match data_plane.connect_tcp(dst_addr, options).await {
+                            Ok(stream) => stream,
+                            Err(error) => {
+                                tracing::error!(?error, ?dst_addr, "port-forward connect failed");
+                                return;
+                            }
+                        };
+                        match tokio::io::copy_bidirectional(&mut incoming, &mut outgoing).await {
+                            Ok((from_client, from_server)) => tracing::info!(
+                                ?dst_addr,
+                                from_client,
+                                from_server,
+                                "port-forward connection finished"
+                            ),
+                            Err(error) => tracing::error!(
+                                ?error,
+                                ?dst_addr,
+                                "port-forward connection failed"
+                            ),
+                        }
+                    });
+                }
+
+                drop(listener);
+                select! {
+                    biased;
+                    _ = cancel.cancelled() => break,
+                    _ = crate::foundation::time::sleep(TCP_PORT_FORWARD_REBIND_DELAY) => {}
+                }
+            }
+        });
     }
 
     async fn add_udp_port_forward(&self, cfg: &PortForwardConfig) -> anyhow::Result<()> {


### PR DESCRIPTION
## 背景

HarmonyOS 使用 smoltcp 用户态网络栈时，TCP 端口转发和本机子网代理存在两类路径问题：

1. `0.0.0.0:port` 的 Host listener 无法接收发往本节点 EasyTier 虚拟 IPv4 的流量。
2. 启用出口节点后，字面量 loopback 目标 `127.0.0.0/8` 可能被默认出口路由识别为 overlay 目标，导致本应连接本机服务的流量离开本机。
3. 本机配置的 `proxy_cidrs` 被加入同一实例的 HarmonyOS VPN TUN routes 后，Core proxy 访问物理局域网目标时会被自己的 TUN 再次捕获。

此外，OHRS 配置 Schema 没有完整返回 protobuf 枚举的有效值，ArkTS 配置编辑器无法稳定生成对应选项。

## 修改内容

### 1. 用户态通配 TCP 转发

- 保留现有 Host TCP listener、accept loop 和连接处理逻辑。
- 当规则满足 `force_smoltcp + IPv4 + 0.0.0.0:port` 时，额外创建 DataPlane TCP listener，接收发往 EasyTier 虚拟 IPv4 的流量。
- 按运行能力判断，不增加 `#[cfg(target_env = "ohos")]` 或其他平台宏。
- DataPlane listener 在后台等待 DHCP/虚拟 IPv4 就绪，不阻塞实例启动。
- DataPlane generation 关闭或 accept 失败后，释放旧 listener 并重新绑定。
- 字面量 `127.0.0.0/8` 目标固定使用本机 Host 路径，不再被出口节点接管。

### 2. HarmonyOS 本机子网代理路由

- 本机配置的 `proxy_cidrs` 只作为提供给其他节点的网络宣告，不再加入本机 VPN TUN。
- 本机 TUN 继续保留：
  - 本节点虚拟 CIDR；
  - 用户手动配置的 `routes`；
  - 从远端节点学到的运行时 `proxy_cidrs`。
- 避免 Core TCP/UDP proxy 的物理局域网目标 socket 被同一个 TUN 重捕获。

### 3. OHRS 配置枚举

- 在 Schema API 中返回 protobuf 枚举的有效值。
- 更新相关配置测试的 repository 导入路径。

## 提交结构

```text
6e3460db fix(port-forward): support wildcard userspace listeners
8c64949d fix(ohos): keep local proxy subnets off tun
5a0e0cd4 fix(ohos): expose valid config enum values
```

三个提交分别对应 TCP 转发、子网代理路由和配置 Schema，互不混杂。

## 变更范围

```text
7 files changed, 210 insertions(+), 14 deletions(-)
```

其中主要文件：

```text
easytier-core/src/gateway/port_forward.rs                    +103/-0
easytier-core/src/gateway/dataplane/mod.rs                    +2/-0
easytier-contrib/easytier-ohrs/src/kernel_bridge/routing.rs  +78/-4
```

本 PR 不修改 UDP port-forward，不扩展显式虚拟 IPv4 bind。

## 验证

### 编译与测试

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p easytier-core --all-targets`
- `cargo test -p easytier-core --lib`
  - 739 passed
  - 0 failed
- `cargo check --manifest-path easytier-contrib/easytier-ohrs/Cargo.toml --target aarch64-unknown-linux-ohos --tests`
- HarmonyOS ARM64 Release 构建通过
- HarmonyOS Debug App/HAP 构建、签名和覆盖安装通过

### TCP/HDC 真机验证

启用出口节点并配置：

```text
TCP 0.0.0.0:15555 -> 127.0.0.1:36237
```

通过本节点 EasyTier 虚拟 IP 建立 HDC：

```text
hdc tconn 10.53.176.4:15555
Connect OK

hdc -t 10.53.176.4:15555 shell "echo HDC_FINAL_NO_CFG_OK"
HDC_FINAL_NO_CFG_OK
```

### 子网代理真机验证

- HarmonyOS 节点发布本地局域网 CIDR 后，对端能够收到对应路由。
- 对端能够新建到物理局域网目标的 TCP 连接。
- 本地代理 CIDR 不再进入本机 TUN。
- 停止实例后，对端对应路由正常撤销。
