### PR TITLE
fix(android): keep VPN running when pressing back

### DIFF
--- a/easytier-gui/src-tauri/gen/android/app/src/main/java/com/kkrainbow/easytier/MainActivity.kt
+++ b/easytier-gui/src-tauri/gen/android/app/src/main/java/com/kkrainbow/easytier/MainActivity.kt
@@ -3,9 +3,16 @@ package com.kkrainbow.easytier
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
+
 class MainActivity : TauriActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                moveTaskToBack(true)
+            }
+        })
         initService()
     }
 


### PR DESCRIPTION
## Summary

- intercept Android Back with the lifecycle-aware `OnBackPressedDispatcher`
- move the app task to the background instead of finishing the last Tauri activity
- keep the current in-process EasyTier runtime and VPN tunnel alive when returning to the launcher

## Motivation

Finishing the last Tauri activity exits the application process. Because the current Android VPN/TUN runtime lives in that process, pressing Back also tears down the active VPN connection. Moving the task to the background matches the behavior expected from a long-running VPN app while preserving the existing activity and runtime.

## Scope

This is a focused mitigation for pressing Back from the main activity. It does not bypass Android/OEM force-stop behavior or provide headless process recovery. A shared service-side lifecycle controller for those longer-term cases remains tracked in #2538.

## Testing

- built the production frontend and arm64 release APK
- verified APK signature, 16 KiB alignment, and bundled arm64 native library
- installed on a physical HyperOS device through ADB
- started a configured VPN and confirmed `tun0`, `TauriVpnService`, and the foreground service were active
- pressed Back and confirmed after 30 seconds that the PID was unchanged, `tun0` remained up, VPN services remained active, and no process exit or crash was logged

Refs #2538
