### PR TITLE
ci: add SignPath test signing workflow

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -1,6 +1,7 @@
 name: EasyTier Core
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "develop", "main", "releases/**" ]
   pull_request:
@@ -13,6 +14,10 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+
+permissions:
+  actions: read
+  contents: read
 
 defaults:
   run:
@@ -255,11 +260,53 @@ jobs:
           rm -rf ./artifacts/objects/
 
       - name: Archive artifact
+        id: archive-artifact
         uses: actions/upload-artifact@v5
         with:
           name: easytier-${{ matrix.ARTIFACT_NAME }}
           path: |
             ./artifacts/*
+
+      - name: Prepare SignPath test artifact
+        if: ${{ github.event_name == 'workflow_dispatch' && contains(matrix.TARGET, 'windows') }}
+        run: |
+          mkdir -p ./signpath-artifacts
+          cp \
+            ./artifacts/easytier-core.exe \
+            ./artifacts/easytier-cli.exe \
+            ./artifacts/easytier-web.exe \
+            ./artifacts/easytier-web-embed.exe \
+            ./signpath-artifacts/
+
+      - name: Upload unsigned SignPath test artifact
+        if: ${{ github.event_name == 'workflow_dispatch' && contains(matrix.TARGET, 'windows') }}
+        id: signpath-upload
+        uses: actions/upload-artifact@v5
+        with:
+          name: signpath-unsigned-${{ matrix.ARTIFACT_NAME }}
+          path: ./signpath-artifacts/*
+          if-no-files-found: error
+
+      - name: Submit SignPath test-signing request
+        if: ${{ github.event_name == 'workflow_dispatch' && contains(matrix.TARGET, 'windows') }}
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: 368cf38d-86d5-4bfe-a1fa-82a50dce7e9f
+          project-slug: EasyTier
+          signing-policy-slug: test-signing
+          artifact-configuration-slug: initial
+          github-artifact-id: ${{ steps.signpath-upload.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: ./signpath-signed-artifacts
+
+      - name: Upload signed SignPath test artifact
+        if: ${{ github.event_name == 'workflow_dispatch' && contains(matrix.TARGET, 'windows') }}
+        uses: actions/upload-artifact@v5
+        with:
+          name: signpath-signed-${{ matrix.ARTIFACT_NAME }}
+          path: ./signpath-signed-artifacts/*
+          if-no-files-found: error
 
   build_magisk:
     runs-on: ubuntu-latest

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -15,10 +15,6 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
 
-permissions:
-  actions: read
-  contents: read
-
 defaults:
   run:
     # necessary for windows
@@ -260,7 +256,6 @@ jobs:
           rm -rf ./artifacts/objects/
 
       - name: Archive artifact
-        id: archive-artifact
         uses: actions/upload-artifact@v5
         with:
           name: easytier-${{ matrix.ARTIFACT_NAME }}


### PR DESCRIPTION
## Summary

- add a manual-only SignPath test-signing path for Windows core artifacts
- upload only EasyTier-built executables for signing
- keep unsigned release artifacts unchanged during certificate validation
- grant the read-only workflow permissions required by the SignPath GitHub connector

## SignPath configuration

- organization: EasyTier [OSS]
- project: EasyTier
- artifact configuration: initial (ZIP containing four EasyTier executables)
- signing policy: test-signing

Once the SignPath Foundation production certificate is issued, the release workflow can be updated separately to consume release-signing outputs.