### PR TITLE
fix(android): avoid duplicate foreground notifications

### DIFF
--- a/easytier-gui/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/easytier-gui/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 
     <application
@@ -35,9 +34,12 @@
         </activity-alias>
         <service
             android:name=".MainForegroundService"
-            android:foregroundServiceType="dataSync"
+            android:foregroundServiceType="specialUse"
             android:enabled="true"
             android:exported="false">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Maintains EasyTier background connectivity when no VPN service is active." />
         </service>
 
         <provider

--- a/easytier-gui/src-tauri/gen/android/app/src/main/java/com/kkrainbow/easytier/MainForegroundService.kt
+++ b/easytier-gui/src-tauri/gen/android/app/src/main/java/com/kkrainbow/easytier/MainForegroundService.kt
@@ -1,5 +1,4 @@
 package com.kkrainbow.easytier
-import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.Service
@@ -24,15 +23,15 @@ class MainForegroundService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         createNotificationChannel()
         val notification = NotificationCompat.Builder(this, CHANNEL_ID)
-            .setContentTitle("easytier Running")
-            .setContentText("easytier is available on localhost")
+            .setContentTitle("EasyTier is running")
+            .setContentText("EasyTier background service is active")
             .setSmallIcon(android.R.drawable.ic_menu_manage)
             .build()
-       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             startForeground(
                 NOTIFICATION_ID,
                 notification,
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
             )
         } else {
             startForeground(NOTIFICATION_ID, notification)
@@ -52,7 +51,7 @@ class MainForegroundService : Service() {
             val channel = NotificationChannel(
                 CHANNEL_ID,
                 "easytier notice",
-                NotificationManager.IMPORTANCE_DEFAULT
+                NotificationManager.IMPORTANCE_LOW
             )
             val manager = getSystemService(NotificationManager::class.java)
             manager?.createNotificationChannel(channel)

--- a/tauri-plugin-vpnservice/android/src/main/java/TauriVpnService.kt
+++ b/tauri-plugin-vpnservice/android/src/main/java/TauriVpnService.kt
@@ -63,6 +63,7 @@ class TauriVpnService : VpnService() {
     override fun onDestroy() {
         println("vpn on destroy")
         disconnect()
+        setMainForegroundServiceEnabled(true)
         stopForeground(STOP_FOREGROUND_REMOVE)
         self = null
         EasyTierVpnTileService.requestStateUpdate(this)
@@ -72,6 +73,7 @@ class TauriVpnService : VpnService() {
     override fun onRevoke() {
         println("vpn on revoke")
         disconnect()
+        setMainForegroundServiceEnabled(true)
         stopForeground(STOP_FOREGROUND_REMOVE)
         self = null
         EasyTierVpnTileService.requestStateUpdate(this)
@@ -125,6 +127,24 @@ class TauriVpnService : VpnService() {
             )
         } else {
             startForeground(NOTIFICATION_ID, notification)
+        }
+
+        // A TUN-backed network is now protected by this foreground service, so the
+        // no-TUN keepalive service is redundant and would show a second notification.
+        setMainForegroundServiceEnabled(false)
+    }
+
+    private fun setMainForegroundServiceEnabled(enabled: Boolean) {
+        val intent = Intent().setClassName(packageName, "$packageName.MainForegroundService")
+        if (!enabled) {
+            stopService(intent)
+            return
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            startForegroundService(intent)
+        } else {
+            startService(intent)
         }
     }
 


### PR DESCRIPTION
## Problem

Starting an Android TUN network currently leaves both `MainForegroundService` and `TauriVpnService` in the foreground, so EasyTier shows two persistent notifications for one active connection. The generic service is still needed to preserve the background/no-TUN keepalive behavior introduced in #1203, so removing it outright would regress that mode.

`MainForegroundService` is also declared as `dataSync`. On Android 15+, that foreground-service type is limited to six background hours per 24 hours and does not describe a long-lived overlay-network keepalive.

## Solution

- hand foreground ownership from `MainForegroundService` to `TauriVpnService` after the VPN service has entered the foreground
- restore `MainForegroundService` before the VPN foreground notification is removed on revoke or service destruction
- retain the existing always-available background/no-TUN keepalive behavior while showing only the notification for the active foreground owner
- declare the generic keepalive as `specialUse`, with an explicit subtype, and lower its notification channel importance
- clarify the generic keepalive notification text

## Validation

- `cargo check -p tauri-plugin-vpnservice --target aarch64-linux-android`
- `pnpm --dir easytier-gui test:mobile-vpn` (18 tests passed)
- `pnpm --dir easytier-gui tauri android build --debug --apk --target aarch64`
- `./gradlew :app:compileUniversalDebugKotlin` (through the repository Android build lock; successful)
- `git diff --check`